### PR TITLE
Add action for pushing to quay.io

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,12 +28,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Login to quay.io
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-          registry: quay.io
       - name: Docker Build & Push
         uses: docker/build-push-action@v2.7.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
   build-imgs:
     runs-on: ubuntu-20.04
     steps:
-      - name: Checkout devworkspace-operator source code
+      - name: Checkout application-service source code
         uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Container build
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+
+  build-imgs:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout devworkspace-operator source code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Login to quay.io
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+          registry: quay.io
+      - name: Docker Build & Push
+        uses: docker/build-push-action@v2.7.0
+        with:
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+          registry: quay.io
+          repository: redhat-appstudio/application-service
+          dockerfile: ./Dockerfile
+          tag_with_sha: true


### PR DESCRIPTION
Adds an action to push the application-service operator's image to quay.io/redhat-appstudio/application-service:<sha> (and latest)