### PR TITLE
[DEVHAS-60] Return after adding the finalizer to reset reconcile loop

### DIFF
--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -81,7 +81,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// If so: Remove the GitOps repo (if generated) and remove the finalizer.
 	if application.ObjectMeta.DeletionTimestamp.IsZero() {
 		if !containsString(application.GetFinalizers(), appFinalizerName) {
-			// Attached the finalizer and return to reset the reconciler loop
+			// Attach the finalizer and return to reset the reconciler loop
 			err := r.AddFinalizer(ctx, &application)
 			return ctrl.Result{}, err
 		}

--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -81,9 +81,9 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// If so: Remove the GitOps repo (if generated) and remove the finalizer.
 	if application.ObjectMeta.DeletionTimestamp.IsZero() {
 		if !containsString(application.GetFinalizers(), appFinalizerName) {
-			if err := r.AddFinalizer(ctx, &application); err != nil {
-				return ctrl.Result{}, err
-			}
+			// Attached the finalizer and return to reset the reconciler loop
+			err := r.AddFinalizer(ctx, &application)
+			return ctrl.Result{}, err
 		}
 	} else {
 		if containsString(application.GetFinalizers(), appFinalizerName) {


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/DEVHAS-60

The way we're currently attaching the Application finalizer to Application resources in HAS is problematic, and there's a chance (about 1/3 from my observations) that the reconcile loop will be triggered twice, resulting in the following error:

```
2022-01-12T17:43:49.613-0500	ERROR	controllers.Application	Unable to update Application	{"Application": "application-sample", "error": "Operation cannot be fulfilled on applications.appstudio.redhat.com \"application-sample\": the object has been modified; please apply your changes to the latest version and try again"}
github.com/redhat-appstudio/application-service/controllers.(*ApplicationReconciler).Reconcile
	/Users/johncollier/appstudio/application-service/controllers/application_controller.go:165
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/Users/johncollier/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.5/pkg/internal/controller/controller.go:298
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/Users/johncollier/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.5/pkg/internal/controller/controller.go:253
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/Users/johncollier/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.5/pkg/internal/controller/controller.go:214
```

This results in a duplicate GitOps repo being created, which will be left in a weird state of limbo.

Forcing the controller to return after adding the finalizer to the resource avoids this issue.