### PR TITLE
[DEVHAS-61] Allow the GitOps org to be configured easily

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,22 +57,25 @@ In addition to this, the GitHub token must be associated with an account that ha
 For example, on OpenShift:
 <img width="862" alt="Screen Shot 2021-12-14 at 1 08 43 AM" src="https://user-images.githubusercontent.com/6880023/145942734-63422532-6fad-4017-9d26-79436fe241b8.png">
 
+### Specifying Alternate GitHub org
+
+By default, HAS will use the `redhat-appstudio-appdata` GitHub org for the creation of GitOps repositories. If you wish to use a different org, you can create a ConfigMap, `github-config`, in the same namespace as HAS before deploying, that references the org you wish to create GitOps repositories in. There should be a single key-value pair in the ConfigMap, where the key is `GITHUB_ORG`, and the value is the name of the GitHub organization you wish to use.
+
+For example:
+
+`kubectl create configmap github-config --from-literal=GITHUB_ORG=test-org` would create a ConfigMap that tells HAS to use the `test-org`.
+
+**Note:** If you specify a custom GitHub organization for HAS, you must ensure that the GitHub token created for HAS has the proper permissions to access the org.
+
+**Note:** You must specify a GitHub organization, if overriding the default value. GitHub accounts are not supported in lieu of organizations at this time.
+
 ### Deploying HAS
 
-Once a secret has been created, simply run the following commands to deploy HAS:
+Once the GitHub secret has been created, simply run the following commands to deploy HAS:
 ```
 make install
 make deploy
 ```
-
-### Specifying Alternate GitHub org
-
-By default, HAS will use the `redhat-appstudio-appdata` org for the creation of GitOps repositories. If you wish to use your own account, or a different GitHub org, setting `GITHUB_ORG=<org>` before deploying will ensure that an alternate location is used.
-
-For example:
-
-`GITHUB_ORG=fake-organization make deploy` would deploy HAS configured to use github.com/fake-organization.
-
 
 Useful links:
 * [HAS Project information page](https://docs.google.com/document/d/1axzNOhRBSkly3M2Y32Pxr1MBpBif2ljb-ufj0_aEt74/edit?usp=sharing)

--- a/README.md
+++ b/README.md
@@ -44,19 +44,6 @@ IMG=quay.io/user/hasoperator:next make docker-push
 
 The following section outlines the steps to deploy HAS on a physical Kubernetes cluster. If you are looking to deploy HAS on KCP, please see [this document](./docs/kcp.md).
 
-### Creating a GitHub Secret for HAS
-
-Before deploying the operator, you must ensure that a secret, `has-github-token`, exists in the namespace where HAS will be deployed. This secret must contain a key-value pair, where the key is `token` and where the value points to a valid GitHub Personal Access Token.
-
-The token that is used here must have the following permissions set:
-- `repo`
-- `delete_repo`
-
-In addition to this, the GitHub token must be associated with an account that has write access to the GitHub organization you plan on using with HAS (see next section).
-
-For example, on OpenShift:
-<img width="862" alt="Screen Shot 2021-12-14 at 1 08 43 AM" src="https://user-images.githubusercontent.com/6880023/145942734-63422532-6fad-4017-9d26-79436fe241b8.png">
-
 ### Specifying Alternate GitHub org
 
 By default, HAS will use the `redhat-appstudio-appdata` GitHub org for the creation of GitOps repositories. If you wish to use a different org, you can create a ConfigMap, `github-config`, in the same namespace as HAS before deploying, that references the org you wish to create GitOps repositories in. There should be a single key-value pair in the ConfigMap, where the key is `GITHUB_ORG`, and the value is the name of the GitHub organization you wish to use.
@@ -65,9 +52,20 @@ For example:
 
 `kubectl create configmap github-config --from-literal=GITHUB_ORG=test-org` would create a ConfigMap that tells HAS to use the `test-org`.
 
-**Note:** If you specify a custom GitHub organization for HAS, you must ensure that the GitHub token created for HAS has the proper permissions to access the org.
+**Note:** You must specify a GitHub organization if overriding the default value. GitHub accounts are not supported in lieu of organizations at this time.
 
-**Note:** You must specify a GitHub organization, if overriding the default value. GitHub accounts are not supported in lieu of organizations at this time.
+### Creating a GitHub Secret for HAS
+
+Before deploying the operator, you must ensure that a secret, `has-github-token`, exists in the namespace where HAS will be deployed. This secret must contain a key-value pair, where the key is `token` and where the value points to a valid GitHub Personal Access Token.
+
+The token that is used here must have the following permissions set:
+- `repo`
+- `delete_repo`
+
+In addition to this, the GitHub token must be associated with an account that has write access to the GitHub organization you plan on using with HAS (see above).
+
+For example, on OpenShift:
+<img width="862" alt="Screen Shot 2021-12-14 at 1 08 43 AM" src="https://user-images.githubusercontent.com/6880023/145942734-63422532-6fad-4017-9d26-79436fe241b8.png">
 
 ### Deploying HAS
 

--- a/config/manager/github.properties
+++ b/config/manager/github.properties
@@ -1,1 +1,0 @@
-GITHUB_ORG

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,9 +8,6 @@ configMapGenerator:
 - files:
   - controller_manager_config.yaml
   name: manager-config
-- envs:
-  - github.properties
-  name: github-config
   
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/DEVHAS-61

This PR allows HAS to be easily configured to point to an alternate GitHub org by allowing a ConfigMap to be created before deployment.

In all:
- Removes the github.properties file from the deployment manifests for HAS
  - It's not needed and actually makes it harder to configure the GitHub org that HAS uses
- No longer generates a ConfigMap from this github.properties file
  - But the optional ConfigMap mount is still kept in the operator's deployment
- Updates the readme to reflect these changes