### PR TITLE
Update controller test case intermittent bug

### DIFF
--- a/controllers/application_controller_test.go
+++ b/controllers/application_controller_test.go
@@ -49,13 +49,15 @@ var _ = Describe("Application controller", func() {
 		It("Should create successfully with generated repositories", func() {
 			ctx := context.Background()
 
+			applicationName := HASAppName + "1"
+
 			hasApp := &appstudiov1alpha1.Application{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "appstudio.redhat.com/v1alpha1",
 					Kind:       "Application",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      HASAppName,
+					Name:      applicationName,
 					Namespace: HASAppNamespace,
 				},
 				Spec: appstudiov1alpha1.ApplicationSpec{
@@ -68,7 +70,7 @@ var _ = Describe("Application controller", func() {
 
 			// Look up the has app resource that was created.
 			// num(conditions) may still be < 1 on the first try, so retry until at least _some_ condition is set
-			hasAppLookupKey := types.NamespacedName{Name: HASAppName, Namespace: HASAppNamespace}
+			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
 			createdHasApp := &appstudiov1alpha1.Application{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasAppLookupKey, createdHasApp)
@@ -94,13 +96,15 @@ var _ = Describe("Application controller", func() {
 		It("Should create successfully with appmodel repository set to gitops repository", func() {
 			ctx := context.Background()
 
+			applicationName := HASAppName + "2"
+
 			hasApp := &appstudiov1alpha1.Application{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "appstudio.redhat.com/v1alpha1",
 					Kind:       "Application",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      HASAppName,
+					Name:      applicationName,
 					Namespace: HASAppNamespace,
 				},
 				Spec: appstudiov1alpha1.ApplicationSpec{
@@ -116,7 +120,7 @@ var _ = Describe("Application controller", func() {
 
 			// Look up the has app resource that was created.
 			// num(conditions) may still be < 1 on the first try, so retry until at least _some_ condition is set
-			hasAppLookupKey := types.NamespacedName{Name: HASAppName, Namespace: HASAppNamespace}
+			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
 			createdHasApp := &appstudiov1alpha1.Application{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasAppLookupKey, createdHasApp)
@@ -143,13 +147,15 @@ var _ = Describe("Application controller", func() {
 		It("Should create successfully with generated gitops repository", func() {
 			ctx := context.Background()
 
+			applicationName := HASAppName + "3"
+
 			hasApp := &appstudiov1alpha1.Application{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "appstudio.redhat.com/v1alpha1",
 					Kind:       "Application",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      HASAppName,
+					Name:      applicationName,
 					Namespace: HASAppNamespace,
 				},
 				Spec: appstudiov1alpha1.ApplicationSpec{
@@ -165,7 +171,7 @@ var _ = Describe("Application controller", func() {
 
 			// Look up the has app resource that was created.
 			// num(conditions) may still be < 1 on the first try, so retry until at least _some_ condition is set
-			hasAppLookupKey := types.NamespacedName{Name: HASAppName, Namespace: HASAppNamespace}
+			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
 			createdHasApp := &appstudiov1alpha1.Application{}
 
 			Eventually(func() bool {
@@ -193,13 +199,15 @@ var _ = Describe("Application controller", func() {
 		It("Should update successfully with updated description", func() {
 			ctx := context.Background()
 
+			applicationName := HASAppName + "4"
+
 			hasApp := &appstudiov1alpha1.Application{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "appstudio.redhat.com/v1alpha1",
 					Kind:       "Application",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      HASAppName,
+					Name:      applicationName,
 					Namespace: HASAppNamespace,
 				},
 				Spec: appstudiov1alpha1.ApplicationSpec{
@@ -215,7 +223,7 @@ var _ = Describe("Application controller", func() {
 
 			// Look up the has app resource that was created.
 			// num(conditions) may still be < 1 on the first try, so retry until at least _some_ condition is set
-			hasAppLookupKey := types.NamespacedName{Name: HASAppName, Namespace: HASAppNamespace}
+			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
 			fetchedHasApp := &appstudiov1alpha1.Application{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasAppLookupKey, fetchedHasApp)

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -41,8 +41,8 @@ var _ = Describe("Component controller", func() {
 
 	// Define utility constants for object names and testing timeouts/durations and intervals.
 	const (
-		HASAppName      = "test-application-123"
-		HASCompName     = "test-component-123"
+		HASAppName      = "test-application"
+		HASCompName     = "test-component"
 		HASAppNamespace = "default"
 		DisplayName     = "petclinic"
 		Description     = "Simple petclinic app"
@@ -54,13 +54,16 @@ var _ = Describe("Component controller", func() {
 		It("Should create successfully and update the Application", func() {
 			ctx := context.Background()
 
+			applicationName := HASAppName + "1"
+			componentName := HASCompName + "1"
+
 			hasApp := &appstudiov1alpha1.Application{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "appstudio.redhat.com/v1alpha1",
 					Kind:       "Application",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      HASAppName,
+					Name:      applicationName,
 					Namespace: HASAppNamespace,
 				},
 				Spec: appstudiov1alpha1.ApplicationSpec{
@@ -77,12 +80,12 @@ var _ = Describe("Component controller", func() {
 					Kind:       "Component",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      HASCompName,
+					Name:      componentName,
 					Namespace: HASAppNamespace,
 				},
 				Spec: appstudiov1alpha1.ComponentSpec{
 					ComponentName: ComponentName,
-					Application:   HASAppName,
+					Application:   applicationName,
 					Source: appstudiov1alpha1.ComponentSource{
 						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
 							GitSource: &appstudiov1alpha1.GitSource{
@@ -96,7 +99,7 @@ var _ = Describe("Component controller", func() {
 
 			// Look up the has app resource that was created.
 			// num(conditions) may still be < 1 on the first try, so retry until at least _some_ condition is set
-			hasCompLookupKey := types.NamespacedName{Name: HASCompName, Namespace: HASAppNamespace}
+			hasCompLookupKey := types.NamespacedName{Name: componentName, Namespace: HASAppNamespace}
 			createdHasComp := &appstudiov1alpha1.Component{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompLookupKey, createdHasComp)
@@ -106,7 +109,7 @@ var _ = Describe("Component controller", func() {
 			// Make sure the devfile model was properly set in Component
 			Expect(createdHasComp.Status.Devfile).Should(Not(Equal("")))
 
-			hasAppLookupKey := types.NamespacedName{Name: HASAppName, Namespace: HASAppNamespace}
+			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
 			createdHasApp := &appstudiov1alpha1.Application{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasAppLookupKey, createdHasApp)
@@ -157,13 +160,16 @@ var _ = Describe("Component controller", func() {
 		It("Should create successfully on a valid url", func() {
 			ctx := context.Background()
 
+			applicationName := HASAppName + "2"
+			componentName := HASCompName + "2"
+
 			hasApp := &appstudiov1alpha1.Application{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "appstudio.redhat.com/v1alpha1",
 					Kind:       "Application",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      HASAppName,
+					Name:      applicationName,
 					Namespace: HASAppNamespace,
 				},
 				Spec: appstudiov1alpha1.ApplicationSpec{
@@ -180,12 +186,12 @@ var _ = Describe("Component controller", func() {
 					Kind:       "Component",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      HASCompName,
+					Name:      componentName,
 					Namespace: HASAppNamespace,
 				},
 				Spec: appstudiov1alpha1.ComponentSpec{
 					ComponentName: ComponentName,
-					Application:   HASAppName,
+					Application:   applicationName,
 					Source: appstudiov1alpha1.ComponentSource{
 						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
 							GitSource: &appstudiov1alpha1.GitSource{
@@ -200,7 +206,7 @@ var _ = Describe("Component controller", func() {
 
 			// Look up the has app resource that was created.
 			// num(conditions) may still be < 1 on the first try, so retry until at least _some_ condition is set
-			hasCompLookupKey := types.NamespacedName{Name: HASCompName, Namespace: HASAppNamespace}
+			hasCompLookupKey := types.NamespacedName{Name: componentName, Namespace: HASAppNamespace}
 			createdHasComp := &appstudiov1alpha1.Component{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompLookupKey, createdHasComp)
@@ -210,7 +216,7 @@ var _ = Describe("Component controller", func() {
 			// Make sure the devfile model was properly set in Component
 			Expect(createdHasComp.Status.Devfile).Should(Not(Equal("")))
 
-			hasAppLookupKey := types.NamespacedName{Name: HASAppName, Namespace: HASAppNamespace}
+			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
 			createdHasApp := &appstudiov1alpha1.Application{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasAppLookupKey, createdHasApp)
@@ -264,13 +270,16 @@ var _ = Describe("Component controller", func() {
 		It("Should error out on a bad url", func() {
 			ctx := context.Background()
 
+			applicationName := HASAppName + "3"
+			componentName := HASCompName + "3"
+
 			hasApp := &appstudiov1alpha1.Application{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "appstudio.redhat.com/v1alpha1",
 					Kind:       "Application",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      HASAppName,
+					Name:      applicationName,
 					Namespace: HASAppNamespace,
 				},
 				Spec: appstudiov1alpha1.ApplicationSpec{
@@ -287,12 +296,12 @@ var _ = Describe("Component controller", func() {
 					Kind:       "Component",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      HASCompName,
+					Name:      componentName,
 					Namespace: HASAppNamespace,
 				},
 				Spec: appstudiov1alpha1.ComponentSpec{
 					ComponentName: ComponentName,
-					Application:   HASAppName,
+					Application:   applicationName,
 					Source: appstudiov1alpha1.ComponentSource{
 						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
 							GitSource: &appstudiov1alpha1.GitSource{
@@ -307,7 +316,7 @@ var _ = Describe("Component controller", func() {
 
 			// Look up the has app resource that was created.
 			// num(conditions) may still be < 1 on the first try, so retry until at least _some_ condition is set
-			hasCompLookupKey := types.NamespacedName{Name: HASCompName, Namespace: HASAppNamespace}
+			hasCompLookupKey := types.NamespacedName{Name: componentName, Namespace: HASAppNamespace}
 			createdHasComp := &appstudiov1alpha1.Component{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompLookupKey, createdHasComp)
@@ -319,7 +328,7 @@ var _ = Describe("Component controller", func() {
 			Expect(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Reason).Should(Equal("Error"))
 			Expect(strings.ToLower(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message)).Should(ContainSubstring("unable to get"))
 
-			hasAppLookupKey := types.NamespacedName{Name: HASAppName, Namespace: HASAppNamespace}
+			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
 
 			// Delete the specified HASComp resource
 			deleteHASCompCR(hasCompLookupKey)
@@ -333,18 +342,21 @@ var _ = Describe("Component controller", func() {
 		It("Should error out because an Application is missing", func() {
 			ctx := context.Background()
 
+			applicationName := HASAppName + "4"
+			componentName := HASCompName + "4"
+
 			hasComp := &appstudiov1alpha1.Component{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "appstudio.redhat.com/v1alpha1",
 					Kind:       "Component",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      HASCompName,
+					Name:      componentName,
 					Namespace: HASAppNamespace,
 				},
 				Spec: appstudiov1alpha1.ComponentSpec{
 					ComponentName: ComponentName,
-					Application:   HASAppName,
+					Application:   applicationName,
 					Source: appstudiov1alpha1.ComponentSource{
 						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
 							GitSource: &appstudiov1alpha1.GitSource{
@@ -358,7 +370,7 @@ var _ = Describe("Component controller", func() {
 
 			// Look up the has app resource that was created.
 			// num(conditions) may still be < 1 on the first try, so retry until at least _some_ condition is set
-			hasCompLookupKey := types.NamespacedName{Name: HASCompName, Namespace: HASAppNamespace}
+			hasCompLookupKey := types.NamespacedName{Name: componentName, Namespace: HASAppNamespace}
 			createdHasComp := &appstudiov1alpha1.Component{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompLookupKey, createdHasComp)
@@ -380,13 +392,16 @@ var _ = Describe("Component controller", func() {
 		It("Should create successfully and update the Application", func() {
 			ctx := context.Background()
 
+			applicationName := HASAppName + "5"
+			componentName := HASCompName + "5"
+
 			hasApp := &appstudiov1alpha1.Application{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "appstudio.redhat.com/v1alpha1",
 					Kind:       "Application",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      HASAppName,
+					Name:      applicationName,
 					Namespace: HASAppNamespace,
 				},
 				Spec: appstudiov1alpha1.ApplicationSpec{
@@ -476,12 +491,12 @@ var _ = Describe("Component controller", func() {
 					Kind:       "Component",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      HASCompName,
+					Name:      componentName,
 					Namespace: HASAppNamespace,
 				},
 				Spec: appstudiov1alpha1.ComponentSpec{
 					ComponentName: ComponentName,
-					Application:   HASAppName,
+					Application:   applicationName,
 					Source: appstudiov1alpha1.ComponentSource{
 						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
 							GitSource: &appstudiov1alpha1.GitSource{
@@ -499,7 +514,7 @@ var _ = Describe("Component controller", func() {
 			Expect(k8sClient.Create(ctx, hasComp)).Should(Succeed())
 
 			// Look up the has app resource that was created.
-			hasCompLookupKey := types.NamespacedName{Name: HASCompName, Namespace: HASAppNamespace}
+			hasCompLookupKey := types.NamespacedName{Name: componentName, Namespace: HASAppNamespace}
 			createdHasComp := &appstudiov1alpha1.Component{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompLookupKey, createdHasComp)
@@ -509,7 +524,7 @@ var _ = Describe("Component controller", func() {
 			// Make sure the devfile model was properly set in Component
 			Expect(createdHasComp.Status.Devfile).Should(Not(Equal("")))
 
-			hasAppLookupKey := types.NamespacedName{Name: HASAppName, Namespace: HASAppNamespace}
+			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
 			createdHasApp := &appstudiov1alpha1.Application{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasAppLookupKey, createdHasApp)


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

Updates the controller test case names.
It seems like the kubeClient used for the test sometimes runs into issues when using the same name for Kube resources. Even after a delete op is performed, it complains about a resource being present.