### PR TITLE
Watch secret with Github token

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,9 @@
             "mode": "auto",
             "program": "${workspaceFolder}/main.go",
             "cwd": "${workspaceFolder}",
+            "env": {
+                "DEBUG": "true"
+            }
         }
     ]
 }

--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -135,7 +135,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	if len(r.Context.GithubConf.GithubToken) == 0 {
-		return ctrl.Result{}, fmt.Errorf("Use secret '%s' to provide Github token.", githubTokenSecret)
+		return ctrl.Result{}, fmt.Errorf("use secret '%s' to provide Github token", githubTokenSecret)
 	}
 
 	log.Info(fmt.Sprintf("Starting reconcile loop for %v", req.NamespacedName))

--- a/controllers/application_controller_finalizer.go
+++ b/controllers/application_controller_finalizer.go
@@ -57,12 +57,12 @@ func (r *ApplicationReconciler) Finalize(application *appstudiov1alpha1.Applicat
 	gitOpsURL := devfileGitOps.(string)
 
 	// Only delete the GitOps repo if we created it.
-	if strings.Contains(gitOpsURL, r.GitHubOrg) {
-		repoName, err := github.GetRepoNameFromURL(gitOpsURL, r.GitHubOrg)
+	if strings.Contains(gitOpsURL, r.Context.GithubConf.GithubOrg) {
+		repoName, err := github.GetRepoNameFromURL(gitOpsURL, r.Context.GithubConf.GithubOrg)
 		if err != nil {
 			return err
 		}
-		return github.DeleteRepository(r.GitHubClient, context.Background(), r.GitHubOrg, repoName)
+		return github.DeleteRepository(r.Context.GithubConf.GithubClient, context.Background(), r.Context.GithubConf.GithubOrg, repoName)
 	}
 	return nil
 }

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -83,7 +83,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	if len(r.Context.GithubConf.GithubToken) == 0 {
-		return ctrl.Result{}, fmt.Errorf("Use secret '%s' to provide Github token.", githubTokenSecret)
+		return ctrl.Result{}, fmt.Errorf("use secret '%s' to provide Github token", githubTokenSecret)
 	}
 
 	// If the devfile hasn't been populated, the CR was just created

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -44,12 +44,11 @@ import (
 // ComponentReconciler reconciles a Component object
 type ComponentReconciler struct {
 	client.Client
-	Scheme    *runtime.Scheme
-	Log       logr.Logger
-	GitToken  string
-	GitHubOrg string
-	Executor  gitops.Executor
-	AppFS     afero.Afero
+	Scheme   *runtime.Scheme
+	Log      logr.Logger
+	Context  *ControllerContext
+	Executor gitops.Executor
+	AppFS    afero.Afero
 }
 
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components,verbs=get;list;watch;create;update;patch;delete
@@ -330,7 +329,7 @@ func (r *ComponentReconciler) generateGitops(component *appstudiov1alpha1.Compon
 		log.Error(err, "unable to parse gitops URL due to error")
 		return err
 	}
-	parsedURL.User = url.User(r.GitToken)
+	parsedURL.User = url.User(r.Context.GithubConf.GithubToken)
 	remoteURL := parsedURL.String()
 
 	// Create a temp folder to create the gitops resources in

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -82,6 +82,10 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
+	if len(r.Context.GithubConf.GithubToken) == 0 {
+		return ctrl.Result{}, fmt.Errorf("Use secret '%s' to provide Github token.", githubTokenSecret)
+	}
+
 	// If the devfile hasn't been populated, the CR was just created
 	if component.Status.Devfile == "" {
 		source := component.Spec.Source

--- a/controllers/component_controller_unit_test.go
+++ b/controllers/component_controller_unit_test.go
@@ -28,7 +28,6 @@ import (
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
 	"github.com/redhat-appstudio/application-service/gitops/ioutils"
 	"github.com/redhat-appstudio/application-service/gitops/testutils"
-	"github.com/redhat-appstudio/application-service/pkg/github"
 	"github.com/spf13/afero"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -151,21 +150,23 @@ func TestGenerateGitops(t *testing.T) {
 	appFS := ioutils.NewMemoryFilesystem()
 	readOnlyFs := ioutils.NewReadOnlyFs()
 
+	contrContext := &ControllerContext{GithubConf: &GithubConfiguration{
+		GithubToken: "fake-token",
+	}}
+
 	r := &ComponentReconciler{
-		Log:       ctrl.Log.WithName("controllers").WithName("Component"),
-		GitHubOrg: github.AppStudioAppDataOrg,
-		GitToken:  "fake-token",
-		Executor:  executor,
+		Log:      ctrl.Log.WithName("controllers").WithName("Component"),
+		Context:  contrContext,
+		Executor: executor,
 	}
 
 	// Create a second reconciler for testing error scenarios
 	errExec := testutils.NewMockExecutor()
 	errExec.Errors.Push(errors.New("Fatal error"))
 	errReconciler := &ComponentReconciler{
-		Log:       ctrl.Log.WithName("controllers").WithName("Component"),
-		GitHubOrg: github.AppStudioAppDataOrg,
-		GitToken:  "fake-token",
-		Executor:  errExec,
+		Log:      ctrl.Log.WithName("controllers").WithName("Component"),
+		Context:  contrContext,
+		Executor: errExec,
 	}
 
 	tests := []struct {

--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -40,3 +40,12 @@ const (
 	// componentKey is the key to reference an application-service CR component
 	componentKey = "appstudio.has/component"
 )
+
+// Github related constants.
+const (
+	GithubOrgConfMapKey = "GITHUB_ORG"
+
+	githubTokenSecret = "has-github-token"
+
+	githubTokenSecretKey = "token"
+)

--- a/controllers/controller_context.go
+++ b/controllers/controller_context.go
@@ -1,10 +1,29 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controllers
 
 import gh "github.com/google/go-github/v41/github"
 
 // Common context for application service reconsilers.
 type ControllerContext struct {
+	// Github specific configuration
 	GithubConf *GithubConfiguration
+	// Namespace where is deployed operator. Notice: That's not the same with "WatchNamespace".
+	Namespace string
 }
 
 // Github properties required to execute application pipeline

--- a/controllers/controller_context.go
+++ b/controllers/controller_context.go
@@ -1,0 +1,15 @@
+package controllers
+
+import gh "github.com/google/go-github/v41/github"
+
+// Common context for application service reconsilers.
+type ControllerContext struct {
+	GithubConf *GithubConfiguration
+}
+
+// Github properties required to execute application pipeline
+type GithubConfiguration struct {
+	GithubClient *gh.Client
+	GithubOrg    string
+	GithubToken  string
+}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -35,7 +35,7 @@ import (
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
 	"github.com/redhat-appstudio/application-service/gitops/ioutils"
 	"github.com/redhat-appstudio/application-service/gitops/testutils"
-	// github "github.com/redhat-appstudio/application-service/pkg/github"
+	github "github.com/redhat-appstudio/application-service/pkg/github"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -95,13 +95,18 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
+	context := &ControllerContext{GithubConf: &GithubConfiguration{
+		GithubToken:  "fake-token",
+		GithubClient: github.GetMockedClient(),
+		GithubOrg:    github.AppStudioAppDataOrg,
+	}}
+
 	// To Do: Set up reconcilers for the other controllers
 	err = (&ApplicationReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-		Log:    ctrl.Log.WithName("controllers").WithName("Application"),
-		// GitHubClient: github.GetMockedClient(),
-		// GitHubOrg:    github.AppStudioAppDataOrg,
+		Client:  k8sManager.GetClient(),
+		Scheme:  k8sManager.GetScheme(),
+		Log:     ctrl.Log.WithName("controllers").WithName("Application"),
+		Context: context,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -111,6 +116,7 @@ var _ = BeforeSuite(func() {
 		Log:      ctrl.Log.WithName("controllers").WithName("Component"),
 		Executor: testutils.NewMockExecutor(),
 		AppFS:    ioutils.NewMemoryFilesystem(),
+		Context:  context,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -35,7 +35,7 @@ import (
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
 	"github.com/redhat-appstudio/application-service/gitops/ioutils"
 	"github.com/redhat-appstudio/application-service/gitops/testutils"
-	github "github.com/redhat-appstudio/application-service/pkg/github"
+	// github "github.com/redhat-appstudio/application-service/pkg/github"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -97,11 +97,11 @@ var _ = BeforeSuite(func() {
 
 	// To Do: Set up reconcilers for the other controllers
 	err = (&ApplicationReconciler{
-		Client:       k8sManager.GetClient(),
-		Scheme:       k8sManager.GetScheme(),
-		Log:          ctrl.Log.WithName("controllers").WithName("Application"),
-		GitHubClient: github.GetMockedClient(),
-		GitHubOrg:    github.AppStudioAppDataOrg,
+		Client: k8sManager.GetClient(),
+		Scheme: k8sManager.GetScheme(),
+		Log:    ctrl.Log.WithName("controllers").WithName("Application"),
+		// GitHubClient: github.GetMockedClient(),
+		// GitHubOrg:    github.AppStudioAppDataOrg,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"log"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -36,6 +37,7 @@ import (
 	"github.com/redhat-appstudio/application-service/gitops"
 	"github.com/redhat-appstudio/application-service/gitops/ioutils"
 	"github.com/redhat-appstudio/application-service/pkg/github"
+	"github.com/redhat-appstudio/application-service/pkg/util"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -92,11 +94,16 @@ func main() {
 
 	// Retrieve the GitHub Auth Token to use, error out if not found
 	ghToken := os.Getenv("GITHUB_AUTH_TOKEN")
-
 	if len(ghToken) > 0 {
 		cntsContext.GithubConf.GithubToken = ghToken
 		cntsContext.GithubConf.GithubClient = github.NewGithubClient(ghToken)
 	}
+
+	operatorNamespace, err := util.GetNamespace()
+	if err != nil {
+		log.Fatal(err)
+	}
+	cntsContext.Namespace = operatorNamespace
 
 	if err = (&controllers.ApplicationReconciler{
 		Client:  mgr.GetClient(),

--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ func main() {
 		GithubOrg: ghOrg,
 	}}
 
-	// Retrieve the GitHub Auth Token to use, error out if not found
+	// Retrieve the GitHub Auth Token to use
 	ghToken := os.Getenv("GITHUB_AUTH_TOKEN")
 	if len(ghToken) > 0 {
 		cntsContext.GithubConf.GithubToken = ghToken

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -23,9 +23,17 @@ import (
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/go-github/v41/github"
 	"github.com/redhat-appstudio/application-service/pkg/util"
+	"golang.org/x/oauth2"
 )
 
 const AppStudioAppDataOrg = "redhat-appstudio-appdata"
+
+func NewGithubClient(token string) *github.Client {
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	tc := oauth2.NewClient(ctx, ts)
+	return github.NewClient(tc)
+}
 
 func GenerateNewRepositoryName(displayName string, namespace string) string {
 	sanitizedName := util.SanitizeName(displayName)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -29,6 +29,14 @@ import (
 	"github.com/redhat-appstudio/application-service/pkg/devfile"
 )
 
+var (
+	namespace string
+)
+
+const (
+	namespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+)
+
 func SanitizeName(name string) string {
 	sanitizedName := strings.ToLower(strings.Replace(strings.Replace(name, " ", "-", -1), "'", "", -1))
 	if len(sanitizedName) > 50 {
@@ -206,4 +214,22 @@ func searchDevfiles(localpath string, currentLevel, depth int) (map[string][]byt
 	}
 
 	return devfileMapFromRepo, err
+}
+
+// GetNamespace returns namespace where is located operator deployment.
+func GetNamespace() (string, error) {
+	debug := os.Getenv("DEBUG")
+	if debug == "true" {
+		return "application-service", nil
+	}
+
+	if len(namespace) == 0 {
+		namespaceBytes, err := ioutil.ReadFile(namespaceFile)
+		if err != nil {
+			return "", err
+		}
+		namespace = string(namespaceBytes)
+	}
+
+	return namespace, nil
 }


### PR DESCRIPTION
Motivation: gh token can be revoked or expired. It would be nice to allow update this token via secret without operator deployment rescale.