### PR TITLE
Treat URLs with .git as valid

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -51,8 +51,15 @@ func IsExist(path string) (bool, error) {
 }
 
 // ConvertGitHubURL converts a git url to its raw format
-// taken from Jingfu's odo code
+// adapted from https://github.com/redhat-developer/odo/blob/e63773cc156ade6174a533535cbaa0c79506ffdb/pkg/catalog/catalog.go#L72
 func ConvertGitHubURL(URL string) (string, error) {
+	// If the URL ends with .git, remove it
+	if len(URL) > len(".git") {
+		if URL[len(URL)-len(".git"):] == ".git" {
+			URL = URL[:len(URL)-4]
+		}
+	}
+
 	url, err := url.Parse(URL)
 	if err != nil {
 		return "", err

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/go-git/go-git/v5"
@@ -54,11 +55,12 @@ func IsExist(path string) (bool, error) {
 // adapted from https://github.com/redhat-developer/odo/blob/e63773cc156ade6174a533535cbaa0c79506ffdb/pkg/catalog/catalog.go#L72
 func ConvertGitHubURL(URL string) (string, error) {
 	// If the URL ends with .git, remove it
-	if len(URL) > len(".git") {
-		if URL[len(URL)-len(".git"):] == ".git" {
-			URL = URL[:len(URL)-4]
-		}
+	// The regex will match if '.git' is at the end of the given string
+	reg, err := regexp.Compile(".git$")
+	if err != nil {
+		return "", err
 	}
+	URL = reg.ReplaceAllString(URL, "")
 
 	url, err := url.Parse(URL)
 	if err != nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -55,7 +55,7 @@ func IsExist(path string) (bool, error) {
 // adapted from https://github.com/redhat-developer/odo/blob/e63773cc156ade6174a533535cbaa0c79506ffdb/pkg/catalog/catalog.go#L72
 func ConvertGitHubURL(URL string) (string, error) {
 	// If the URL ends with .git, remove it
-	// The regex will match if '.git' is at the end of the given string
+	// The regex will only instances of '.git' if it is at the end of the given string
 	reg, err := regexp.Compile(".git$")
 	if err != nil {
 		return "", err

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -228,6 +228,11 @@ func TestConvertGitHubURL(t *testing.T) {
 			wantUrl: "https://raw.githubusercontent.com/devfile-samples/devfile-sample-java-springboot-basic/main",
 		},
 		{
+			name:    "Successfully convert a github url with .git to raw url",
+			url:     "https://github.com/devfile-samples/devfile-sample-java-springboot-basic.git",
+			wantUrl: "https://raw.githubusercontent.com/devfile-samples/devfile-sample-java-springboot-basic/main",
+		},
+		{
 			name:    "A non github url",
 			url:     "https://some.url",
 			wantUrl: "https://some.url",


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/DEVHAS-63

Updates the `util.ConvertGitHubURL` function to treat GitHub URLs with `.git` at the end as valid.