### PR TITLE
[DEVHAS-64] Don't watch for changes to Component's status

### DIFF
--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -28,7 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/yaml"
 
 	"github.com/devfile/api/v2/pkg/attributes"
@@ -395,6 +397,6 @@ func setGitopsAnnotations(component *appstudiov1alpha1.Component, devfileData da
 // SetupWithManager sets up the controller with the Manager.
 func (r *ComponentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&appstudiov1alpha1.Component{}).
+		For(&appstudiov1alpha1.Component{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -777,10 +777,12 @@ var _ = Describe("Component controller", func() {
 				return len(createdHasComp.Status.Conditions) > 0 && createdHasComp.GetLabels()["appstudio.has/component"] != ""
 			}, timeout, interval).Should(BeTrue())
 
-			// Remove the component's devfile
+			// Remove the component's devfile and update a field in the spec to trigger a reconcile
 			createdHasComp.Status.Devfile = "a"
-
 			Expect(k8sClient.Status().Update(ctx, createdHasComp)).Should(Succeed())
+
+			createdHasComp.Spec.Build.ContainerImage = "test"
+			Expect(k8sClient.Update(ctx, createdHasComp)).Should(Succeed())
 
 			updatedHasComp := &appstudiov1alpha1.Component{}
 			Eventually(func() bool {

--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -24,7 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/go-logr/logr"
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
@@ -159,6 +161,6 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 // SetupWithManager sets up the controller with the Manager.
 func (r *ComponentDetectionQueryReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&appstudiov1alpha1.ComponentDetectionQuery{}).
+		For(&appstudiov1alpha1.ComponentDetectionQuery{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/DEVHAS-64

Just adding this for the Component and ComponentDetectionQuery CRs for now.

Leaving it out for the Application CR for now, cause there may be scenarios in the future where we want to trigger a reconcile loop upon modifying the App Model's status (specifically the app model devfile).