### PR TITLE
[DEVHAS-69] Don't return an error upon every reconcile error in HAS

### DIFF
--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -130,7 +130,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			if err != nil {
 				log.Error(err, fmt.Sprintf("Unable to create repository %v", repoUrl))
 				r.SetCreateConditionAndUpdateCR(ctx, &application, err)
-				return reconcile.Result{}, err
+				return reconcile.Result{}, nil
 			}
 
 			gitOpsRepo = repoUrl
@@ -145,13 +145,13 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		if err != nil {
 			log.Error(err, fmt.Sprintf("Unable to convert Application CR to devfile, exiting reconcile loop %v", req.NamespacedName))
 			r.SetCreateConditionAndUpdateCR(ctx, &application, err)
-			return reconcile.Result{}, err
+			return reconcile.Result{}, nil
 		}
 		yamlData, err := yaml.Marshal(devfileData)
 		if err != nil {
 			log.Error(err, fmt.Sprintf("Unable to marshall Application devfile, exiting reconcile loop %v", req.NamespacedName))
 			r.SetCreateConditionAndUpdateCR(ctx, &application, err)
-			return reconcile.Result{}, err
+			return reconcile.Result{}, nil
 		}
 
 		application.Status.Devfile = string(yamlData)
@@ -165,7 +165,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		devfileData, err := devfile.ParseDevfileModel(application.Status.Devfile)
 		if err != nil {
 			log.Error(err, fmt.Sprintf("Unable to parse devfile model, exiting reconcile loop %v", req.NamespacedName))
-			return ctrl.Result{}, err
+			return ctrl.Result{}, nil
 		}
 
 		// Update any specific fields that changed
@@ -189,7 +189,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			if err != nil {
 				log.Error(err, fmt.Sprintf("Unable to marshall Application devfile, exiting reconcile loop %v", req.NamespacedName))
 				r.SetUpdateConditionAndUpdateCR(ctx, &application, err)
-				return reconcile.Result{}, err
+				return reconcile.Result{}, nil
 			}
 
 			application.Status.Devfile = string(yamlData)
@@ -198,7 +198,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	log.Info(fmt.Sprintf("Finished reconcile loop for %v", req.NamespacedName))
-	return ctrl.Result{}, err
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -164,6 +164,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		// Get the devfile of the hasApp CR
 		devfileData, err := devfile.ParseDevfileModel(application.Status.Devfile)
 		if err != nil {
+			r.SetUpdateConditionAndUpdateCR(ctx, &application, err)
 			log.Error(err, fmt.Sprintf("Unable to parse devfile model, exiting reconcile loop %v", req.NamespacedName))
 			return ctrl.Result{}, nil
 		}

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -111,7 +111,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				if err != nil {
 					log.Error(err, fmt.Sprintf("Unable to convert Github URL to raw format, exiting reconcile loop %v", req.NamespacedName))
 					r.SetCreateConditionAndUpdateCR(ctx, &component, err)
-					return ctrl.Result{}, err
+					return ctrl.Result{}, nil
 				}
 
 				// append context to the path if present
@@ -127,7 +127,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				if err != nil {
 					log.Error(err, fmt.Sprintf("Unable to read the devfile from dir %s %v", devfileDir, req.NamespacedName))
 					r.SetCreateConditionAndUpdateCR(ctx, &component, err)
-					return ctrl.Result{}, err
+					return ctrl.Result{}, nil
 				}
 			} else {
 				devfileBytes, err = util.CurlEndpoint(source.GitSource.DevfileURL)
@@ -135,7 +135,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 					log.Error(err, fmt.Sprintf("Unable to GET %s, exiting reconcile loop %v", source.GitSource.DevfileURL, req.NamespacedName))
 					err := fmt.Errorf("unable to GET from %s", source.GitSource.DevfileURL)
 					r.SetCreateConditionAndUpdateCR(ctx, &component, err)
-					return ctrl.Result{}, err
+					return ctrl.Result{}, nil
 				}
 			}
 
@@ -144,7 +144,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			if err != nil {
 				log.Error(err, fmt.Sprintf("Unable to parse the devfile from Component, exiting reconcile loop %v", req.NamespacedName))
 				r.SetCreateConditionAndUpdateCR(ctx, &component, err)
-				return ctrl.Result{}, err
+				return ctrl.Result{}, nil
 			}
 
 			err = r.updateComponentDevfileModel(hasCompDevfileData, component)
@@ -160,7 +160,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			if err != nil {
 				log.Error(err, fmt.Sprintf("Unable to get the Application %s, exiting reconcile loop %v", component.Spec.Application, req.NamespacedName))
 				r.SetCreateConditionAndUpdateCR(ctx, &component, err)
-				return ctrl.Result{}, nil
+				return ctrl.Result{}, err
 			}
 
 			if hasApplication.Status.Devfile != "" {
@@ -169,7 +169,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				if err != nil {
 					log.Error(err, fmt.Sprintf("Unable to parse the devfile from Application, exiting reconcile loop %v", req.NamespacedName))
 					r.SetCreateConditionAndUpdateCR(ctx, &component, err)
-					return ctrl.Result{}, err
+					return ctrl.Result{}, nil
 				}
 
 				err = r.updateApplicationDevfileModel(hasAppDevfileData, component)
@@ -183,7 +183,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				if err != nil {
 					log.Error(err, fmt.Sprintf("Unable to marshall the Component devfile, exiting reconcile loop %v", req.NamespacedName))
 					r.SetCreateConditionAndUpdateCR(ctx, &component, err)
-					return ctrl.Result{}, err
+					return ctrl.Result{}, nil
 				}
 
 				component.Status.Devfile = string(yamlHASCompData)
@@ -193,7 +193,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				if err != nil {
 					log.Error(err, fmt.Sprintf("Unable to marshall the Application devfile, exiting reconcile loop %v", req.NamespacedName))
 					r.SetCreateConditionAndUpdateCR(ctx, &component, err)
-					return ctrl.Result{}, err
+					return ctrl.Result{}, nil
 				}
 				hasApplication.Status.Devfile = string(yamlHASAppData)
 				err = r.Status().Update(ctx, &hasApplication)
@@ -250,7 +250,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				log.Error(err, fmt.Sprintf("Application devfile model is empty. Before creating a Component, an instance of Application should be created, exiting reconcile loop %v", req.NamespacedName))
 				err := fmt.Errorf("application devfile model is empty. Before creating a Component, an instance of Application should be created")
 				r.SetCreateConditionAndUpdateCR(ctx, &component, err)
-				return ctrl.Result{}, err
+				return ctrl.Result{}, nil
 			}
 
 		} else if source.ImageSource != nil && source.ImageSource.ContainerImage != "" {
@@ -267,14 +267,14 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if err != nil {
 			log.Error(err, fmt.Sprintf("Unable to parse the devfile from Component, exiting reconcile loop %v", req.NamespacedName))
 			r.SetUpdateConditionAndUpdateCR(ctx, &component, err)
-			return ctrl.Result{}, err
+			return ctrl.Result{}, nil
 		}
 
 		err = r.updateComponentDevfileModel(hasCompDevfileData, component)
 		if err != nil {
 			log.Error(err, fmt.Sprintf("Unable to update the Component Devfile model %v", req.NamespacedName))
 			r.SetUpdateConditionAndUpdateCR(ctx, &component, err)
-			return ctrl.Result{}, err
+			return ctrl.Result{}, nil
 		}
 
 		// Read the devfile again to compare it with any updates
@@ -282,7 +282,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if err != nil {
 			log.Error(err, fmt.Sprintf("Unable to parse the devfile from Component, exiting reconcile loop %v", req.NamespacedName))
 			r.SetUpdateConditionAndUpdateCR(ctx, &component, err)
-			return ctrl.Result{}, err
+			return ctrl.Result{}, nil
 		}
 
 		isUpdated := !reflect.DeepEqual(oldCompDevfileData, hasCompDevfileData) || component.Spec.Build.ContainerImage != component.Status.ContainerImage
@@ -292,7 +292,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			if err != nil {
 				log.Error(err, fmt.Sprintf("Unable to marshall the Component devfile, exiting reconcile loop %v", req.NamespacedName))
 				r.SetUpdateConditionAndUpdateCR(ctx, &component, err)
-				return ctrl.Result{}, err
+				return ctrl.Result{}, nil
 			}
 
 			// Generate and push the gitops resources if spec.containerImage is set
@@ -326,7 +326,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	log.Info(fmt.Sprintf("Finished reconcile loop for %v", req.NamespacedName))
-	return ctrl.Result{}, err
+	return ctrl.Result{}, nil
 }
 
 func (r *ComponentReconciler) generateBuild(ctx context.Context, component *appstudiov1alpha1.Component) (string, error) {

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -235,7 +235,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 						errMsg := fmt.Sprintf("Unable to generate gitops resources for component %v", req.NamespacedName)
 						log.Error(err, errMsg)
 						r.SetCreateConditionAndUpdateCR(ctx, &component, fmt.Errorf(errMsg))
-						return ctrl.Result{}, err
+						return ctrl.Result{}, nil
 					}
 				}
 
@@ -303,7 +303,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 					errMsg := fmt.Sprintf("Unable to generate gitops resources for component %v", req.NamespacedName)
 					log.Error(err, errMsg)
 					r.SetUpdateConditionAndUpdateCR(ctx, &component, fmt.Errorf("%v: %v", errMsg, err))
-					return ctrl.Result{}, err
+					return ctrl.Result{}, nil
 				}
 			}
 

--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -95,7 +95,7 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 				if err != nil {
 					log.Error(err, fmt.Sprintf("Unable to clone repo %s and read devfile(s) in path %s, exiting reconcile loop %v", source.URL, clonePath, req.NamespacedName))
 					r.SetCompleteConditionAndUpdateCR(ctx, &componentDetectionQuery, err)
-					return ctrl.Result{}, err
+					return ctrl.Result{}, nil
 				}
 				log.Info(fmt.Sprintf("cloned from %s to path %s... %v", source.URL, clonePath, req.NamespacedName))
 
@@ -103,7 +103,7 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 				if err != nil {
 					log.Error(err, fmt.Sprintf("Unable to find devfile(s) in repo %s, exiting reconcile loop %v", source.URL, req.NamespacedName))
 					r.SetCompleteConditionAndUpdateCR(ctx, &componentDetectionQuery, err)
-					return ctrl.Result{}, err
+					return ctrl.Result{}, nil
 				}
 			} else {
 				log.Info(fmt.Sprintf("Since this is not a multi-component, attempt will be made to read devfile at the root dir... %v", req.NamespacedName))
@@ -111,14 +111,14 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 				if err != nil {
 					log.Error(err, fmt.Sprintf("Unable to convert Github URL to raw format, exiting reconcile loop %v", req.NamespacedName))
 					r.SetCompleteConditionAndUpdateCR(ctx, &componentDetectionQuery, err)
-					return ctrl.Result{}, err
+					return ctrl.Result{}, nil
 				}
 
 				devfileBytes, err = util.DownloadDevfile(rawURL)
 				if err != nil {
 					log.Error(err, fmt.Sprintf("Unable to curl for any known devfile locations from %s %v", source.URL, req.NamespacedName))
 					r.SetCompleteConditionAndUpdateCR(ctx, &componentDetectionQuery, err)
-					return ctrl.Result{}, err
+					return ctrl.Result{}, nil
 				}
 
 				devfilesMap["./"] = devfileBytes
@@ -129,7 +129,7 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 				log.Error(err, errMsg)
 				err := fmt.Errorf(errMsg)
 				r.SetCompleteConditionAndUpdateCR(ctx, &componentDetectionQuery, err)
-				return ctrl.Result{}, err
+				return ctrl.Result{}, nil
 			}
 
 			log.Info(fmt.Sprintf("devfile was explicitly specified at %s %v", source.DevfileURL, req.NamespacedName))
@@ -138,7 +138,7 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 				log.Error(err, fmt.Sprintf("Unable to GET %s, exiting reconcile loop %v", source.DevfileURL, req.NamespacedName))
 				err := fmt.Errorf("unable to GET from %s", source.DevfileURL)
 				r.SetCompleteConditionAndUpdateCR(ctx, &componentDetectionQuery, err)
-				return ctrl.Result{}, err
+				return ctrl.Result{}, nil
 			}
 			devfilesMap["./"] = devfileBytes
 		}
@@ -147,7 +147,7 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 		if err != nil {
 			log.Error(err, fmt.Sprintf("Unable to update the component stub %v", req.NamespacedName))
 			r.SetCompleteConditionAndUpdateCR(ctx, &componentDetectionQuery, err)
-			return ctrl.Result{}, err
+			return ctrl.Result{}, nil
 		}
 
 		r.SetCompleteConditionAndUpdateCR(ctx, &componentDetectionQuery, nil)


### PR DESCRIPTION
Don't reconcile upon every error

Fixes https://issues.redhat.com/browse/DEVHAS-69

This PR updates HAS so that we don't return error from the Reconcile() function after every error that is encountered. For the following errors, we now return `ctrl.Result{}, nil` instead of `ctrl.Result{}:

**Application**
- Failure to convert Application CR to devfile
- Unable to marshall Application devfile to yaml

**Component**
- Unable to convert Github URL to raw format 
- Unable to read the devfile from github repository
- Unable to GET the devfile from URL
- Unable to parse the Component devfile
- Unable to update the Component Devfile model
- Unable to parse the Application devfile
- Unable to update the Application Devfile model
- Unable to marshall the Component devfile
- Unable to marshall the Application devfile
- Application devfile model is empty

**ComponentDetectionQuery**
- Unable to clone repo
- Unable to find devfile(s) in repo
- Unable to convert Github URL to raw format
- Unable to curl for any known devfile locations
- cannot set IsMultiComponent and DevfileURL
- Unable to GET devfile
- Unable to update the component stub


`Application` and `Component` errors that might resolve upon retrying (such as Kubernetes client operations), I've left alone, and still return an error value, to allow the resource to be requeued and retried further times.