### PR TITLE
Only upload to code coverage reports on pushes to main

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -9,7 +9,10 @@
 #   Red Hat, Inc. - initial API and implementation
 
 name: Code Coverage Report
-on: [push]
+on:
+  push:
+    branches:
+      - main
 jobs:
   build-and-deploy:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Fixes the issue where code coverage reports were getting uploaded on PRs, messing with our reported code coverage percentage.