### PR TITLE
Don't get the EL route if build generation failed

### DIFF
--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -26,7 +26,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -308,7 +307,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Get the Webhook from the event listener route and update it
 	// Only attempt to get it if the build generation succeeded, otherwise the route won't exist
-	if component.Status.Conditions[len(component.Status.Conditions)-1].Status == metav1.ConditionTrue {
+	if component.Status.Conditions[len(component.Status.Conditions)-1].Status == v1.ConditionTrue {
 		createdWebhook := &routev1.Route{}
 		err = r.Client.Get(ctx, types.NamespacedName{Name: "el" + component.Name, Namespace: component.Namespace}, createdWebhook)
 		if err != nil {


### PR DESCRIPTION
Slight tweak to the logic in https://github.com/redhat-appstudio/application-service/pull/46

There's no point in attempting to get the EventListener route (and requeueing if it fails) if the build generation failed, so we should only attempt to retrieve it if the build generation succeeded 
   - Since there's no specific build generation status condition at the moment, checking if the most recent status condition's status is True should be sufficient for now