### PR TITLE
Add timestamp to component's initial build subpath

### DIFF
--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"reflect"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -403,7 +404,7 @@ func (r *ComponentReconciler) runBuild(ctx context.Context, component *appstudio
 
 	log.Info(fmt.Sprintf("Eventlistener created/updated %v", eventListener.Name))
 
-	initialBuildSpec := gitops.DetermineBuildExecution(*component, gitops.GetParamsForComponentInitialBuild(*component), "initialbuildpath")
+	initialBuildSpec := gitops.DetermineBuildExecution(*component, gitops.GetParamsForComponentInitialBuild(*component), getInitialBuildWorkspaceSubpath())
 
 	initialBuild := tektonapi.PipelineRun{
 		ObjectMeta: v1.ObjectMeta{
@@ -449,6 +450,10 @@ func (r *ComponentReconciler) runBuild(ctx context.Context, component *appstudio
 	}
 
 	return err
+}
+
+func getInitialBuildWorkspaceSubpath() string {
+	return "initialbuild-" + time.Now().Format("2006-Feb-02_15-04-05")
 }
 
 // generateGitops retrieves the necessary information about a Component's gitops repository (URL, branch, context)

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -166,7 +166,7 @@ var _ = Describe("Component controller", func() {
 				}
 				if w.Name == "workspace" {
 					Expect(w.PersistentVolumeClaim.ClaimName).To(Equal("appstudio"))
-					Expect(w.SubPath).To(Equal(HASCompNameForBuild + "/initialbuildpath"))
+					Expect(w.SubPath).To(ContainSubstring("/initialbuild-"))
 				}
 			}
 


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

#### What this MR does
Adds timestamp to subpath field of tekton workspaces configuration in the pipeline run object of initial build.

#### Which issue this MR fixes
https://issues.redhat.com/browse/PLNSRVCE-53

#### How to test
1. Create an app and a components as usual.
2. Check, that created PipelineRun object has subpath with timestamp
![Screenshot from 2022-02-08 15-34-32](https://user-images.githubusercontent.com/15607393/152998604-508545f2-92c8-4aa6-88c7-bad0d6b92054.png)
