### PR TITLE
If 'default' image repo is used, also set up 'default' pull secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ lint:
 	GOMAXPROCS=2 golangci-lint run --fix --verbose --timeout 300s
 
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out -v
+	BUILD_CREDENTIALS="$(shell pwd)/gitops/testdata/.dockerconfigjson" KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out -v
 
 ##@ Build
 

--- a/README.md
+++ b/README.md
@@ -53,16 +53,6 @@ The following section outlines the steps to deploy HAS on a physical Kubernetes 
 * Install `OpenShift GitOps` from the in-cluster Operator Marketplace.
 * `oc -n openshift-gitops apply -f https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/argo-cd-apps/base/build.yaml`
 
-As a user, upon creation of Component, Tekton resources would be created by the controller. 
-
-If you wish to get 'working' PipelineRuns,
-* Create an image pull secret named `redhat-appstudio-registry-pull-secret`. See [Kubernetes docs](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#registry-secret-existing-credentials) for more information on how to create
-`Secrets` containing registry credentials. 
-* Configure the default image repository to which Pipelines would push images to by defining the environment variable `IMAGE_REPOSITORY` for the operator deployment.
-Defaults to `quay.io/redhat-appstudio/user-workload`.
-
-Pipelines would use the credentials in the image pull secret `redhat-appstudio-registry-pull-secret` to push to $IMAGE_REPOSITORY.
-
 
 
 ### Creating a GitHub Secret for HAS

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,8 +24,16 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+      volumes:
+      - name: default-user-workload-pull-secret
+        secret:
+          secretName: default-user-workload-pull-secret
       containers:
-      - command:
+      - volumeMounts:
+        - name: default-user-workload-pull-secret
+          mountPath: "/etc/build"
+          readOnly: true
+        command:
         - /manager
         args:
         - --leader-elect

--- a/config/rbac/role_build.yaml
+++ b/config/rbac/role_build.yaml
@@ -47,6 +47,15 @@ rules:
     - create
     - watch
   resources:
+    - secrets
+  apiGroups:
+    - ""
+- verbs:
+    - get
+    - list
+    - create
+    - watch
+  resources:
     - routes
   apiGroups:
     - route.openshift.io

--- a/gitops/generate_build.go
+++ b/gitops/generate_build.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	routev1 "github.com/openshift/api/route/v1"
-	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
+	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/ "
 	"github.com/redhat-appstudio/application-service/gitops/resources"
 	yaml "github.com/redhat-appstudio/application-service/gitops/yaml"
 	"github.com/spf13/afero"

--- a/gitops/generate_build.go
+++ b/gitops/generate_build.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	routev1 "github.com/openshift/api/route/v1"
-	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/ "
+	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
 	"github.com/redhat-appstudio/application-service/gitops/resources"
 	yaml "github.com/redhat-appstudio/application-service/gitops/yaml"
 	"github.com/spf13/afero"

--- a/gitops/generate_build.go
+++ b/gitops/generate_build.go
@@ -30,7 +30,7 @@ import (
 	"github.com/spf13/afero"
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	triggersapi "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -79,7 +79,7 @@ func DefaultUserWorkloadPullSecret(component appstudiov1alpha1.Component, path s
 	if err != nil {
 		log.Fatal(err)
 	}
-	secret := v1.Secret{
+	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      component.Name,
 			Namespace: component.Namespace,

--- a/gitops/generate_build.go
+++ b/gitops/generate_build.go
@@ -30,7 +30,6 @@ import (
 	"github.com/spf13/afero"
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	triggersapi "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -75,7 +74,7 @@ func GenerateBuild(fs afero.Fs, outputFolder string, component appstudiov1alpha1
 	return nil
 }
 
-func DefaultUserWorkloadPullSecret(component appstudiov1alpha1.Component, path string) v1.Secret {
+func DefaultUserWorkloadPullSecret(component appstudiov1alpha1.Component, path string) corev1.Secret {
 	content, err := os.ReadFile(path) //"/etc/build/.dockerconfigjson")
 	if err != nil {
 		log.Fatal(err)

--- a/gitops/generate_build_test.go
+++ b/gitops/generate_build_test.go
@@ -19,7 +19,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/redhat-appstudio/application-service/api/v1alpha1"
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -281,7 +280,7 @@ func Test_defaultUserWorkloadPullSecret(t *testing.T) {
 			name: "from test data - empty file",
 			args: args{
 				path: "testdata/.emptydockerconfigjson",
-				component: v1alpha1.Component{
+				component: appstudiov1alpha1.Component{
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "foo",
 						Namespace: "bar",
@@ -303,7 +302,7 @@ func Test_defaultUserWorkloadPullSecret(t *testing.T) {
 			name: "from test data",
 			args: args{
 				path: "testdata/.dockerconfigjson",
-				component: v1alpha1.Component{
+				component: appstudiov1alpha1.Component{
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "foo",
 						Namespace: "bar",

--- a/gitops/testdata/.dockerconfigjson
+++ b/gitops/testdata/.dockerconfigjson
@@ -1,0 +1,1 @@
+{"auths":{"https://index.docker.io/v1/":{"username":"sbose78","password":"foo","auth":"c2Jvc2U3ODpmb28=","email":""}}}


### PR DESCRIPTION
## Problem statement

It is painful to try out the App Studio experience from the UI because the user needs to 'somehow' create the `redhat-appstudio-registry-pull-secret`. This PR removes the need for the same by having the controller *conditionally* create the same upon creation of a Component. 

Note, the controller already sets the the output image to `quay.io/redhat-appstudio/user-workload:unique-tag`, this PR also sets the pull secret for the same. 


## Why

Provide a low-code way of setting up the system-wide 'default' pull secret named `default-user-workload-pull-secret` required for pushing images built out of components when the output image is not specified ( ie, in the UI flows )


## How

### Application Service controller setup

The secret is mounted into the file system of the Application Service controller deployment as  "/etc/build/.dockerconfigjson" . (Needs to be done in the `application-service` namespace). The `/etc/build` Path can be overriden to `/current/working/directory` by setting the `BUILD_CREDENTIALS` env var such that `gitops/testdata` is usable in tests.


### User namespaces

* Upon component creation, conditionally, a pull secret named `component-foo` gets created ( by the controller ) with the contents of the "/etc/build/.dockerconfigjson" .
* This secret is then associated with the build resources for the component.
* This removes the need for the user to set the `redhat-appstudio-registry-pull-secret` out of band.

## Deployment

Before deployment of this change on any environment,
* Create `default-user-workload-pull-secret` in `application-service` associated with `quay.io/redhat-appstudio/user-workload`. 

