### PR TITLE
Add new annotation

### DIFF
--- a/gitops/generate_build.go
+++ b/gitops/generate_build.go
@@ -188,6 +188,7 @@ func getParamsForComponentWebhookBuilds(component appstudiov1alpha1.Component) [
 
 func GetBuildCommonLabelsForComponent(component *appstudiov1alpha1.Component) map[string]string {
 	labels := map[string]string{
+		"pipelines.appstudio.openshift.io/type":    "build",
 		"build.appstudio.openshift.io/build":       "true",
 		"build.appstudio.openshift.io/type":        "build",
 		"build.appstudio.openshift.io/version":     "0.1",


### PR DESCRIPTION
This PR adds a new annotation ("pipelines.appstudio.openshift.io/type") which aims to unify annotations for PipelineRuns across AppStudio.

This annotation would replace, at least, "build.appstudio.openshift.io/type". Tentatively, it would also replace "build.appstudio.openshift.io/build". Both of these annotation have been replaced so this is not a breaking change.