### PR TITLE
Add releaseStrategies field to component CRD

### DIFF
--- a/api/v1alpha1/component_types.go
+++ b/api/v1alpha1/component_types.go
@@ -91,6 +91,9 @@ type ComponentSpec struct {
 	// A relative path inside the git repo containing the component
 	Context string `json:"context,omitempty"`
 
+	// List of references to ReleaseStrategies to use when releasing the component
+	ReleaseStrategies []string `json:"releaseStrategies,omitempty"`
+
 	// Compute Resources required by this component
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -400,6 +400,11 @@ func (in *ComponentSourceUnion) DeepCopy() *ComponentSourceUnion {
 func (in *ComponentSpec) DeepCopyInto(out *ComponentSpec) {
 	*out = *in
 	in.Source.DeepCopyInto(&out.Source)
+	if in.ReleaseStrategies != nil {
+		in, out := &in.ReleaseStrategies, &out.ReleaseStrategies
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	in.Resources.DeepCopyInto(&out.Resources)
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env

--- a/config/crd/bases/appstudio.redhat.com_componentdetectionqueries.yaml
+++ b/config/crd/bases/appstudio.redhat.com_componentdetectionqueries.yaml
@@ -217,6 +217,12 @@ spec:
                             - name
                             type: object
                           type: array
+                        releaseStrategies:
+                          description: List of references to ReleaseStrategies to
+                            use when releasing the component
+                          items:
+                            type: string
+                          type: array
                         replicas:
                           description: The number of replicas to deploy the component
                             with

--- a/config/crd/bases/appstudio.redhat.com_components.yaml
+++ b/config/crd/bases/appstudio.redhat.com_components.yaml
@@ -166,6 +166,12 @@ spec:
                   - name
                   type: object
                 type: array
+              releaseStrategies:
+                description: List of references to ReleaseStrategies to use when releasing
+                  the component
+                items:
+                  type: string
+                type: array
               replicas:
                 description: The number of replicas to deploy the component with
                 type: integer


### PR DESCRIPTION
Add a new field to the component CRD. This field will be used by the Release service to trigger releases for a given component.