### PR TITLE
Allow the overriding of the default build bundle by using a configmap

### DIFF
--- a/api/v1alpha1/component_types.go
+++ b/api/v1alpha1/component_types.go
@@ -132,6 +132,9 @@ type ComponentStatus struct {
 
 	// GitOps specific status for the Component CR
 	GitOps GitOpsStatus `json:"gitops,omitempty"`
+
+	// Tekton bundle for the Component CR
+	BuildBundle string `json:"buildBundle,omitempty"`
 }
 
 // GitOpsStatus contains GitOps repository-specific status for the component

--- a/config/crd/bases/appstudio.redhat.com_components.yaml
+++ b/config/crd/bases/appstudio.redhat.com_components.yaml
@@ -249,6 +249,9 @@ spec:
           status:
             description: ComponentStatus defines the observed state of Component
             properties:
+              buildBundle:
+                description: Tekton bundle for the Component CR
+                type: string
               conditions:
                 description: Condition about the Component CR
                 items:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -84,3 +84,11 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch

--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -36,4 +36,16 @@ const (
 
 	// maxDevfileDiscoveryDepth is the depth of the directory to detect devfiles
 	maxDevfileDiscoveryDepth = 1
+
+	// namespace where the bundle configuration will be searched in case it is not found in the component's namespace
+	buildBundleDefaultNamepace = "build-templates"
+
+	// name for a configMap that holds the URL to a build bundle
+	buildBundleConfigMapName = "build-pipelines-defaults"
+
+	// data key within a configMap that holds the URL to a build bundle
+	buildBundleConfigMapKey = "default_build_bundle"
+
+	// fallback bundle that will be used in case the bundle resolution fails
+	fallbackBuildBundle = "quay.io/redhat-appstudio/build-templates-bundle:8201a567956ba6d2095d615ea2c0f6ab35f9ba5f"
 )

--- a/gitops/generate_build.go
+++ b/gitops/generate_build.go
@@ -101,7 +101,7 @@ func DetermineBuildExecution(component appstudiov1alpha1.Component, params []tek
 		Params: params,
 		PipelineRef: &tektonapi.PipelineRef{
 			Name:   determineBuildPipeline(component),
-			Bundle: determineBuildCatalog(component.Namespace),
+			Bundle: component.Status.BuildBundle,
 		},
 
 		Workspaces: []tektonapi.WorkspaceBinding{
@@ -168,12 +168,6 @@ func determineBuildPipeline(component appstudiov1alpha1.Component) string {
 	// Failed to detect build pipeline
 	// Do nothing as we do not know how to build given component
 	return "noop"
-}
-
-func determineBuildCatalog(namespace string) string {
-	// TODO: If there's a namespace/workspace specific catalog, we got
-	// to respect that.
-	return "quay.io/redhat-appstudio/build-templates-bundle:8201a567956ba6d2095d615ea2c0f6ab35f9ba5f"
 }
 
 func normalizeOutputImageURL(outputImage string) string {

--- a/gitops/generate_build_test.go
+++ b/gitops/generate_build_test.go
@@ -112,6 +112,9 @@ func TestGenerateInitialBuildPipelineRun(t *testing.T) {
 			Name:      "testcomponent",
 			Namespace: "kcpworkspacename",
 		},
+		Status: appstudiov1alpha1.ComponentStatus{
+			BuildBundle: "quay.io/redhat-appstudio/build-templates-bundle:latest",
+		},
 		Spec: appstudiov1alpha1.ComponentSpec{
 			Source: appstudiov1alpha1.ComponentSource{
 				ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
@@ -144,7 +147,7 @@ func TestGenerateInitialBuildPipelineRun(t *testing.T) {
 				},
 				Spec: tektonapi.PipelineRunSpec{
 					PipelineRef: &tektonapi.PipelineRef{
-						Bundle: "quay.io/redhat-appstudio/build-templates-bundle:8201a567956ba6d2095d615ea2c0f6ab35f9ba5f",
+						Bundle: "quay.io/redhat-appstudio/build-templates-bundle:latest",
 						Name:   "noop",
 					},
 					Params: []tektonapi.Param{
@@ -210,13 +213,16 @@ func TestDetermineBuildExecution(t *testing.T) {
 						Name:      "testcomponent",
 						Namespace: "kcpworkspacename",
 					},
+					Status: appstudiov1alpha1.ComponentStatus{
+						BuildBundle: "quay.io/redhat-appstudio/build-templates-bundle:latest",
+					},
 				},
 				workspaceSubPath: "initialbuild",
 				params:           []tektonapi.Param{},
 			},
 			want: tektonapi.PipelineRunSpec{
 				PipelineRef: &tektonapi.PipelineRef{
-					Bundle: "quay.io/redhat-appstudio/build-templates-bundle:8201a567956ba6d2095d615ea2c0f6ab35f9ba5f",
+					Bundle: "quay.io/redhat-appstudio/build-templates-bundle:latest",
 					Name:   "noop",
 				},
 				Params: []tektonapi.Param{},
@@ -245,13 +251,16 @@ func TestDetermineBuildExecution(t *testing.T) {
 						Name:      "testcomponent",
 						Namespace: "kcpworkspacename",
 					},
+					Status: appstudiov1alpha1.ComponentStatus{
+						BuildBundle: "quay.io/redhat-appstudio/build-templates-bundle:latest",
+					},
 				},
 				workspaceSubPath: "a-long-git-reference",
 				params:           []tektonapi.Param{},
 			},
 			want: tektonapi.PipelineRunSpec{
 				PipelineRef: &tektonapi.PipelineRef{
-					Bundle: "quay.io/redhat-appstudio/build-templates-bundle:8201a567956ba6d2095d615ea2c0f6ab35f9ba5f",
+					Bundle: "quay.io/redhat-appstudio/build-templates-bundle:latest",
 					Name:   "noop",
 				},
 				Params: []tektonapi.Param{},


### PR DESCRIPTION
We need to [implement the concept of organizations](https://issues.redhat.com/browse/PLNSRVCE-56) and allow the sharing of assets in a non-KCP world. 

This PR is a first step in that direction, providing a simple mechanism to define a configmap that'll allow HAS to use a specific Tekton bundle instead of the default one.

Here's a sample configmap, which should be placed in the same namespace where the HAS application/component objects will be created.
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: build-pipelines-defaults
data:
  default_build_bundle: "quay.io/user/custombundle:version" 
```
In case this configmap is not available, HAS will try to search for one with the same name at the `build-templates` namespace, which is currently defined as default by the infra-deployments [configuration](https://github.com/redhat-appstudio/infra-deployments/blob/1c6328ee54c4ccde2d2bc58bd845d3eb024ae0f3/components/build/kustomization.yaml#L11). 

If no configmap is found, it will resort to the one that's currently [hardcoded](https://github.com/brunoapimentel/application-service/blob/96308c90f86acc7b6993a4deb7cf5da17835a3e1/gitops/generate_build.go#L42).