### PR TITLE
Only run CDQ if no conditions are attached

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,33 +35,3 @@ jobs:
         dockerfile: Dockerfile
         tags: next
         tag_with_sha: true
-
-  build-bundle-images:
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Checkout application-service source code
-      uses: actions/checkout@v2
-    - name: Install CLI tools from GitHub
-      uses: redhat-actions/openshift-tools-installer@v1
-      with:
-        source: "github"
-        github_pat: ${{ github.token }}
-        operator-sdk: "1.13.1"
-    - name: Get the 7-digit commit sha
-      id: get_sha
-      run: echo ::set-output name=git_sha::sha-$(git rev-parse --short=7 HEAD)
-    - name: Login to quay.io
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_PASSWORD }}
-        registry: quay.io
-    - name: Docker Build & Push - application-service Operator Bundle Image - next tag
-      run: make bundle bundle-build bundle-push
-    - name: Docker Build & Push - application-service Operator Catalog Image - next tag
-      run: make catalog-build catalog-push
-    - name: Docker Build & Push - application-service Operator Bundle Image - SHA tag
-      run: TAG_NAME=${{ steps.get_sha.outputs.git_sha }} make bundle bundle-build bundle-push
-    - name: Docker Build & Push - application-service Operator Catalog Image - SHA tag
-      run: TAG_NAME=${{ steps.get_sha.outputs.git_sha }} make catalog-build catalog-push
-

--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -64,7 +64,6 @@ const (
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.9.2/pkg/reconcile
 func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("ComponentDetectionQuery", req.NamespacedName)
-	log.Info(fmt.Sprintf("Starting reconcile loop for %v", req.NamespacedName))
 
 	// Fetch the ComponentDetectionQuery instance
 	var componentDetectionQuery appstudiov1alpha1.ComponentDetectionQuery
@@ -80,8 +79,8 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 		return ctrl.Result{}, err
 	}
 
-	// If there is no component list in the map, the CR was just created
-	if len(componentDetectionQuery.Status.ComponentDetected) == 0 {
+	// If there are no conditions attached to the CDQ, the resource was just created
+	if len(componentDetectionQuery.Status.Conditions) == 0 {
 		log.Info(fmt.Sprintf("Checking to see if a component can be detected %v", req.NamespacedName))
 		var gitToken string
 		if componentDetectionQuery.Spec.GitSource.Secret != "" {
@@ -216,8 +215,6 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 		}
 
 		r.SetCompleteConditionAndUpdateCR(ctx, &componentDetectionQuery, nil)
-	} else {
-		log.Info(fmt.Sprintf("No update scenario yet... %v", req.NamespacedName))
 	}
 
 	return ctrl.Result{}, nil

--- a/docs/private-git-repos.md
+++ b/docs/private-git-repos.md
@@ -8,9 +8,9 @@ In order to use HAS resources (e.g. `Applications`, `Components`, `ComponentDete
 
    a) Install RBAC for App Studio: `kustomize build openshift-gitops/cluster-rbac | oc apply -f -`
 
-   b) Install Build component`oc apply -n openshift-gitops argo-cd-apps/base/build.yaml`
+   b) Install Build component`oc apply -n openshift-gitops -f argo-cd-apps/base/build.yaml`
 
-   c) Install SPI component`oc apply -n openshift-gitops argo-cd-apps/base/spi.yaml`
+   c) Install SPI component`oc apply -n openshift-gitops -f argo-cd-apps/base/spi.yaml`
 
 2) Set up SPI
 


### PR DESCRIPTION
Prevents errored out CDQs from re-running at once upon HAS restart.

Also some miscellaneous changes included:
- Remove operator bundle build github action -> no longer needed and the build was failing
   - I left the bundle files themself in, incase we need to revisit bundles in the future
- Fix typo on private repo doc