### PR TITLE
Use proper APIVersion for Route

### DIFF
--- a/gitops/generate.go
+++ b/gitops/generate.go
@@ -170,8 +170,8 @@ func generateRoute(component appstudiov1alpha1.Component) *routev1.Route {
 	weight := int32(100)
 	route := routev1.Route{
 		TypeMeta: v1.TypeMeta{
-			APIVersion: "v1",
 			Kind:       "Route",
+			APIVersion: "route.openshift.io/v1",
 		},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      component.Name,

--- a/gitops/generate_test.go
+++ b/gitops/generate_test.go
@@ -311,8 +311,8 @@ func TestGenerateRoute(t *testing.T) {
 			},
 			wantRoute: routev1.Route{
 				TypeMeta: v1.TypeMeta{
-					APIVersion: "v1",
 					Kind:       "Route",
+					APIVersion: "route.openshift.io/v1",
 				},
 				ObjectMeta: v1.ObjectMeta{
 					Name:      componentName,
@@ -351,8 +351,8 @@ func TestGenerateRoute(t *testing.T) {
 			},
 			wantRoute: routev1.Route{
 				TypeMeta: v1.TypeMeta{
-					APIVersion: "v1",
 					Kind:       "Route",
+					APIVersion: "route.openshift.io/v1",
 				},
 				ObjectMeta: v1.ObjectMeta{
 					Name:      componentName,


### PR DESCRIPTION
Fixes the warning message seen when deploying GitOps resources generated by HAS