### PR TITLE
Make pr github workflow reusable for others

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,7 @@ name: Validate PRs
 on:
   pull_request:
     branches: [ main ]
+  workflow_call:
 
 jobs:
   go:


### PR DESCRIPTION
In the release workstream, we'd like to use the same github actions to verify our operator. We can't call this workflow by filename unless the `workflow_call` trigger is added to the workflow. It shouldn't affect anything in this workflow besides allowing others to call it