### PR TITLE
Clean up old CDQ resources when they are requeued

### DIFF
--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -81,9 +81,10 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 
 	// If there are no conditions attached to the CDQ, the resource was just created
 	if len(componentDetectionQuery.Status.Conditions) == 0 {
+		// Start the ComponentDetectionQuery, and update its status condition accordingly
+		log.Info(fmt.Sprintf("Checking to see if a component can be detected %v", req.NamespacedName))
 		r.SetDetectingConditionAndUpdateCR(ctx, &componentDetectionQuery)
 
-		log.Info(fmt.Sprintf("Checking to see if a component can be detected %v", req.NamespacedName))
 		var gitToken string
 		if componentDetectionQuery.Spec.GitSource.Secret != "" {
 			gitSecret := corev1.Secret{}
@@ -239,7 +240,7 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 	} else {
 		// CDQ resource has been requeued after it originally ran
 		// Delete the resource as it's no longer needed and can be cleaned up
-		log.Info("Deleting finished ComponentDetectionQuery resource %v", req.NamespacedName)
+		log.Info(fmt.Sprintf("Deleting finished ComponentDetectionQuery resource %v", req.NamespacedName))
 		if err = r.Delete(ctx, &componentDetectionQuery); err != nil {
 			// Delete failed. Log the error but don't bother modifying the resource's status
 			log.Error(err, fmt.Sprintf("Unable to delete the ComponentDetectionQuery resource %v", req.NamespacedName))

--- a/controllers/componentdetectionquery_controller_conditions.go
+++ b/controllers/componentdetectionquery_controller_conditions.go
@@ -30,9 +30,10 @@ func (r *ComponentDetectionQueryReconciler) SetDetectingConditionAndUpdateCR(ctx
 	log := r.Log.WithValues("ComponentDetectionQuery", componentDetectionQuery.Name)
 
 	meta.SetStatusCondition(&componentDetectionQuery.Status.Conditions, metav1.Condition{
-		Type:    "Detecting",
+		Type:    "Processing",
 		Status:  metav1.ConditionTrue,
-		Message: "ComponentDetectionQuery is progressing.",
+		Reason:  "Success",
+		Message: "ComponentDetectionQuery is processing",
 	})
 
 	err := r.Client.Status().Update(ctx, componentDetectionQuery)

--- a/controllers/componentdetectionquery_controller_conditions.go
+++ b/controllers/componentdetectionquery_controller_conditions.go
@@ -26,6 +26,21 @@ import (
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
 )
 
+func (r *ComponentDetectionQueryReconciler) SetDetectingConditionAndUpdateCR(ctx context.Context, componentDetectionQuery *appstudiov1alpha1.ComponentDetectionQuery) {
+	log := r.Log.WithValues("ComponentDetectionQuery", componentDetectionQuery.Name)
+
+	meta.SetStatusCondition(&componentDetectionQuery.Status.Conditions, metav1.Condition{
+		Type:    "Detecting",
+		Status:  metav1.ConditionTrue,
+		Message: "ComponentDetectionQuery is progressing.",
+	})
+
+	err := r.Client.Status().Update(ctx, componentDetectionQuery)
+	if err != nil {
+		log.Error(err, "Unable to update ComponentDetectionQuery")
+	}
+}
+
 func (r *ComponentDetectionQueryReconciler) SetCompleteConditionAndUpdateCR(ctx context.Context, componentDetectionQuery *appstudiov1alpha1.ComponentDetectionQuery, completeError error) {
 	log := r.Log.WithValues("ComponentDetectionQuery", componentDetectionQuery.Name)
 

--- a/controllers/componentdetectionquery_controller_test.go
+++ b/controllers/componentdetectionquery_controller_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Component Detection Query controller", func() {
 			createdHasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompDetQueryLookupKey, createdHasCompDetectionQuery)
-				return len(createdHasCompDetectionQuery.Status.Conditions) > 0
+				return len(createdHasCompDetectionQuery.Status.Conditions) > 1
 			}, timeout, interval).Should(BeTrue())
 
 			// Make sure the a devfile is detected
@@ -121,7 +121,7 @@ var _ = Describe("Component Detection Query controller", func() {
 			createdHasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompDetQueryLookupKey, createdHasCompDetectionQuery)
-				return len(createdHasCompDetectionQuery.Status.Conditions) > 0
+				return len(createdHasCompDetectionQuery.Status.Conditions) > 1
 			}, timeout, interval).Should(BeTrue())
 
 			// Make sure the a devfile is detected
@@ -169,11 +169,11 @@ var _ = Describe("Component Detection Query controller", func() {
 			createdHasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompDetQueryLookupKey, createdHasCompDetectionQuery)
-				return len(createdHasCompDetectionQuery.Status.Conditions) > 0
+				return len(createdHasCompDetectionQuery.Status.Conditions) > 1
 			}, timeout, interval).Should(BeTrue())
 
 			// Make sure the right err is set
-			Expect(createdHasCompDetectionQuery.Status.Conditions[0].Message).Should(ContainSubstring("cannot set IsMultiComponent"))
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Message).Should(ContainSubstring("cannot set IsMultiComponent"))
 
 			// Delete the specified Detection Query resource
 			deleteCompDetQueryCR(hasCompDetQueryLookupKey)
@@ -211,7 +211,7 @@ var _ = Describe("Component Detection Query controller", func() {
 			createdHasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompDetQueryLookupKey, createdHasCompDetectionQuery)
-				return len(createdHasCompDetectionQuery.Status.Conditions) > 0
+				return len(createdHasCompDetectionQuery.Status.Conditions) > 1
 			}, timeout, interval).Should(BeTrue())
 
 			// Make sure the a devfile is detected
@@ -258,11 +258,11 @@ var _ = Describe("Component Detection Query controller", func() {
 			createdHasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompDetQueryLookupKey, createdHasCompDetectionQuery)
-				return len(createdHasCompDetectionQuery.Status.Conditions) > 0
+				return len(createdHasCompDetectionQuery.Status.Conditions) > 1
 			}, timeout, interval).Should(BeTrue())
 
 			// Make sure the right err is set
-			Expect(createdHasCompDetectionQuery.Status.Conditions[0].Message).Should(ContainSubstring("ComponentDetectionQuery has successfully finished"))
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Message).Should(ContainSubstring("ComponentDetectionQuery has successfully finished"))
 
 			// Delete the specified Detection Query resource
 			deleteCompDetQueryCR(hasCompDetQueryLookupKey)
@@ -300,11 +300,11 @@ var _ = Describe("Component Detection Query controller", func() {
 			createdHasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompDetQueryLookupKey, createdHasCompDetectionQuery)
-				return len(createdHasCompDetectionQuery.Status.Conditions) > 0
+				return len(createdHasCompDetectionQuery.Status.Conditions) > 1
 			}, timeout, interval).Should(BeTrue())
 
 			// Make sure the right err is set
-			Expect(createdHasCompDetectionQuery.Status.Conditions[0].Message).Should(ContainSubstring("ComponentDetectionQuery has successfully finished"))
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Message).Should(ContainSubstring("ComponentDetectionQuery has successfully finished"))
 
 			// Make sure the a devfile is detected
 			Expect(len(createdHasCompDetectionQuery.Status.ComponentDetected)).Should(Equal(2))
@@ -349,11 +349,11 @@ var _ = Describe("Component Detection Query controller", func() {
 			createdHasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompDetQueryLookupKey, createdHasCompDetectionQuery)
-				return len(createdHasCompDetectionQuery.Status.Conditions) > 0
+				return len(createdHasCompDetectionQuery.Status.Conditions) > 1
 			}, timeout, interval).Should(BeTrue())
 
 			// Make sure the right err is set
-			Expect(createdHasCompDetectionQuery.Status.Conditions[0].Message).Should(ContainSubstring("ComponentDetectionQuery has successfully finished"))
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Message).Should(ContainSubstring("ComponentDetectionQuery has successfully finished"))
 
 			// Make sure the a devfile is detected
 			Expect(len(createdHasCompDetectionQuery.Status.ComponentDetected)).Should(Equal(1))
@@ -399,11 +399,11 @@ var _ = Describe("Component Detection Query controller", func() {
 			createdHasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompDetQueryLookupKey, createdHasCompDetectionQuery)
-				return len(createdHasCompDetectionQuery.Status.Conditions) > 0
+				return len(createdHasCompDetectionQuery.Status.Conditions) > 1
 			}, timeout, interval).Should(BeTrue())
 
 			// Make sure the right err is set
-			Expect(createdHasCompDetectionQuery.Status.Conditions[0].Message).Should(ContainSubstring("unable to GET from https://registry.devfile.io/devfiles/fake"))
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Message).Should(ContainSubstring("unable to GET from https://registry.devfile.io/devfiles/fake"))
 
 			// Delete the specified Detection Query resource
 			deleteCompDetQueryCR(hasCompDetQueryLookupKey)
@@ -440,11 +440,11 @@ var _ = Describe("Component Detection Query controller", func() {
 			createdHasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompDetQueryLookupKey, createdHasCompDetectionQuery)
-				return len(createdHasCompDetectionQuery.Status.Conditions) > 0
+				return len(createdHasCompDetectionQuery.Status.Conditions) > 1
 			}, timeout, interval).Should(BeTrue())
 
 			// Make sure the right err is set
-			Expect(createdHasCompDetectionQuery.Status.Conditions[0].Message).Should(ContainSubstring("parse \"https://github.com/redhat-appstudio-appdata/!@#$%U%I$F    DFDN##\": invalid URL escape \"%U%\""))
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Message).Should(ContainSubstring("parse \"https://github.com/redhat-appstudio-appdata/!@#$%U%I$F    DFDN##\": invalid URL escape \"%U%\""))
 
 			// Delete the specified Detection Query resource
 			deleteCompDetQueryCR(hasCompDetQueryLookupKey)
@@ -482,11 +482,11 @@ var _ = Describe("Component Detection Query controller", func() {
 			createdHasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompDetQueryLookupKey, createdHasCompDetectionQuery)
-				return len(createdHasCompDetectionQuery.Status.Conditions) > 0
+				return len(createdHasCompDetectionQuery.Status.Conditions) > 1
 			}, timeout, interval).Should(BeTrue())
 
 			// Make sure the right err is set
-			Expect(createdHasCompDetectionQuery.Status.Conditions[0].Message).Should(ContainSubstring("authentication required"))
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Message).Should(ContainSubstring("authentication required"))
 
 			// Delete the specified Detection Query resource
 			deleteCompDetQueryCR(hasCompDetQueryLookupKey)
@@ -541,7 +541,7 @@ var _ = Describe("Component Detection Query controller", func() {
 			createdHasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompDetQueryLookupKey, createdHasCompDetectionQuery)
-				return len(createdHasCompDetectionQuery.Status.Conditions) > 0
+				return len(createdHasCompDetectionQuery.Status.Conditions) > 1
 			}, timeout, interval).Should(BeTrue())
 
 			// Make sure the a devfile is detected
@@ -605,12 +605,12 @@ var _ = Describe("Component Detection Query controller", func() {
 			createdHasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompDetQueryLookupKey, createdHasCompDetectionQuery)
-				return len(createdHasCompDetectionQuery.Status.Conditions) > 0
+				return len(createdHasCompDetectionQuery.Status.Conditions) > 1
 			}, timeout, interval).Should(BeTrue())
 
 			// Make sure the a devfile is detected
-			Expect(createdHasCompDetectionQuery.Status.Conditions[0].Status).Should(Equal(metav1.ConditionFalse))
-			Expect(createdHasCompDetectionQuery.Status.Conditions[0].Message).Should(ContainSubstring("ComponentDetectionQuery failed: authentication required"))
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Status).Should(Equal(metav1.ConditionFalse))
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Message).Should(ContainSubstring("ComponentDetectionQuery failed: authentication required"))
 
 			// Delete the specified Detection Query resource
 			deleteCompDetQueryCR(hasCompDetQueryLookupKey)
@@ -666,12 +666,12 @@ var _ = Describe("Component Detection Query controller", func() {
 			createdHasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompDetQueryLookupKey, createdHasCompDetectionQuery)
-				return len(createdHasCompDetectionQuery.Status.Conditions) > 0
+				return len(createdHasCompDetectionQuery.Status.Conditions) > 1
 			}, timeout, interval).Should(BeTrue())
 
 			// Make sure the a devfile is detected
-			Expect(createdHasCompDetectionQuery.Status.Conditions[0].Status).Should(Equal(metav1.ConditionFalse))
-			Expect(createdHasCompDetectionQuery.Status.Conditions[0].Message).Should(ContainSubstring("ComponentDetectionQuery failed: unable to find any devfiles in repo https://github.com/test-repo/test-error-response"))
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Status).Should(Equal(metav1.ConditionFalse))
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Message).Should(ContainSubstring("ComponentDetectionQuery failed: unable to find any devfiles in repo https://github.com/test-repo/test-error-response"))
 
 			// Delete the specified Detection Query resource
 			deleteCompDetQueryCR(hasCompDetQueryLookupKey)
@@ -709,12 +709,12 @@ var _ = Describe("Component Detection Query controller", func() {
 			createdHasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompDetQueryLookupKey, createdHasCompDetectionQuery)
-				return len(createdHasCompDetectionQuery.Status.Conditions) > 0
+				return len(createdHasCompDetectionQuery.Status.Conditions) > 1
 			}, timeout, interval).Should(BeTrue())
 
 			// Make sure the a devfile is detected
-			Expect(createdHasCompDetectionQuery.Status.Conditions[0].Status).Should(Equal(metav1.ConditionFalse))
-			Expect(createdHasCompDetectionQuery.Status.Conditions[0].Message).Should(ContainSubstring(fmt.Sprintf("ComponentDetectionQuery failed: Secret %q not found", queryName)))
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Status).Should(Equal(metav1.ConditionFalse))
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Message).Should(ContainSubstring(fmt.Sprintf("ComponentDetectionQuery failed: Secret %q not found", queryName)))
 
 			// Delete the specified Detection Query resource
 			deleteCompDetQueryCR(hasCompDetQueryLookupKey)
@@ -751,12 +751,12 @@ var _ = Describe("Component Detection Query controller", func() {
 			createdHasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompDetQueryLookupKey, createdHasCompDetectionQuery)
-				return len(createdHasCompDetectionQuery.Status.Conditions) > 0
+				return len(createdHasCompDetectionQuery.Status.Conditions) > 1
 			}, timeout, interval).Should(BeTrue())
 
 			// Make sure that the proper error condition is set
-			Expect(createdHasCompDetectionQuery.Status.Conditions[0].Status).Should(Equal(metav1.ConditionFalse))
-			Expect(createdHasCompDetectionQuery.Status.Conditions[0].Message).Should(ContainSubstring("ComponentDetectionQuery failed: failed to decode devfile json: json: cannot unmarshal string into Go value of type map[string]"))
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Status).Should(Equal(metav1.ConditionFalse))
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Message).Should(ContainSubstring("ComponentDetectionQuery failed: failed to decode devfile json: json: cannot unmarshal string into Go value of type map[string]"))
 			// Delete the specified Detection Query resource
 			deleteCompDetQueryCR(hasCompDetQueryLookupKey)
 		})
@@ -792,11 +792,11 @@ var _ = Describe("Component Detection Query controller", func() {
 			createdHasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompDetQueryLookupKey, createdHasCompDetectionQuery)
-				return len(createdHasCompDetectionQuery.Status.Conditions) > 0
+				return len(createdHasCompDetectionQuery.Status.Conditions) > 1
 			}, timeout, interval).Should(BeTrue())
 
 			// Make sure the right err is set
-			Expect(createdHasCompDetectionQuery.Status.Conditions[0].Message).Should(ContainSubstring("ComponentDetectionQuery failed: dummy Analyze err"))
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Message).Should(ContainSubstring("ComponentDetectionQuery failed: dummy Analyze err"))
 
 			// Make sure the a devfile is detected
 			Expect(len(createdHasCompDetectionQuery.Status.ComponentDetected)).Should(Equal(0))
@@ -837,11 +837,11 @@ var _ = Describe("Component Detection Query controller", func() {
 			createdHasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompDetQueryLookupKey, createdHasCompDetectionQuery)
-				return len(createdHasCompDetectionQuery.Status.Conditions) > 0
+				return len(createdHasCompDetectionQuery.Status.Conditions) > 1
 			}, timeout, interval).Should(BeTrue())
 
 			// Make sure the right err is set
-			Expect(createdHasCompDetectionQuery.Status.Conditions[0].Message).Should(ContainSubstring("ComponentDetectionQuery failed: dummy Analyze err"))
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Message).Should(ContainSubstring("ComponentDetectionQuery failed: dummy Analyze err"))
 
 			// Make sure the a devfile is detected
 			Expect(len(createdHasCompDetectionQuery.Status.ComponentDetected)).Should(Equal(0))
@@ -881,17 +881,70 @@ var _ = Describe("Component Detection Query controller", func() {
 			createdHasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompDetQueryLookupKey, createdHasCompDetectionQuery)
-				return len(createdHasCompDetectionQuery.Status.Conditions) > 0
+				return len(createdHasCompDetectionQuery.Status.Conditions) > 1
 			}, timeout, interval).Should(BeTrue())
 
 			// Make sure the a devfile is detected
 			Expect(len(createdHasCompDetectionQuery.Status.ComponentDetected)).Should(Equal(0))
 
 			// Make sure the right err is set
-			Expect(createdHasCompDetectionQuery.Status.Conditions[0].Message).Should(ContainSubstring("ComponentDetectionQuery failed: authentication required"))
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Message).Should(ContainSubstring("ComponentDetectionQuery failed: authentication required"))
 
 			// Delete the specified Detection Query resource
 			deleteCompDetQueryCR(hasCompDetQueryLookupKey)
+		})
+	})
+
+	Context("A Requeued ComponentDetectionQuery", func() {
+		It("Should delete itself", func() {
+			ctx := context.Background()
+
+			queryName := HASCompDetQuery + "19"
+
+			hasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "ComponentDetectionQuery",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      queryName,
+					Namespace: HASNamespace,
+				},
+				Spec: appstudiov1alpha1.ComponentDetectionQuerySpec{
+					GitSource: appstudiov1alpha1.GitSource{
+						URL: "https://github.com/devfile-samples/fake-sample",
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, hasCompDetectionQuery)).Should(Succeed())
+
+			// Look up the has app resource that was created.
+			// num(conditions) may still be < 1 on the first try, so retry until at least _some_ condition is set
+			hasCompDetQueryLookupKey := types.NamespacedName{Name: queryName, Namespace: HASNamespace}
+			createdHasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{}
+			Eventually(func() bool {
+				k8sClient.Get(context.Background(), hasCompDetQueryLookupKey, createdHasCompDetectionQuery)
+				return len(createdHasCompDetectionQuery.Status.Conditions) > 1
+			}, timeout, interval).Should(BeTrue())
+
+			// Make sure no component was detected
+			Expect(len(createdHasCompDetectionQuery.Status.ComponentDetected)).Should(Equal(0))
+
+			// Make sure the right err is set
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Message).Should(ContainSubstring("ComponentDetectionQuery failed: authentication required"))
+
+			// Trigger a requeue by updating the resource
+			createdHasCompDetectionQuery.Spec.GitSource.URL = SampleRepoLink
+			Expect(k8sClient.Update(ctx, createdHasCompDetectionQuery)).Should(Succeed())
+
+			// Validate that the resource has been deleted
+			hasCompDetQueryLookupKey = types.NamespacedName{Name: queryName, Namespace: HASNamespace}
+			deletedCompDetQuery := &appstudiov1alpha1.ComponentDetectionQuery{}
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), hasCompDetQueryLookupKey, deletedCompDetQuery)
+				return err != nil
+			}, timeout, interval).Should(BeTrue())
 		})
 	})
 

--- a/pkg/devfile/detect_test.go
+++ b/pkg/devfile/detect_test.go
@@ -47,7 +47,7 @@ func TestAnalyzeAndDetectDevfile(t *testing.T) {
 		},
 		{
 			name:        "Cannot detect a devfile for a Scala repository",
-			clonePath:   "/tmp/testclone",
+			clonePath:   "/tmp/testscala",
 			repo:        "https://github.com/johnmcollier/scalatemplate",
 			registryURL: DevfileStageRegistryEndpoint,
 			wantErr:     true,

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -146,7 +146,7 @@ func TestCloneRepo(t *testing.T) {
 	}{
 		{
 			name:      "Clone Successfully",
-			clonePath: "/tmp/testclone",
+			clonePath: "/tmp/testspringboot",
 			repo:      "https://github.com/devfile-samples/devfile-sample-java-springboot-basic",
 		},
 		{


### PR DESCRIPTION
- Cleans up old CDQ resources when they get deleted
- Also adds new `Detecting` status condition to the CDQs, as discussed earlier
   - Name to be decided, so it's just a placeholder til we finalize on a proper name for the status.
- Test case for the CDQ deletion logic.