### PR TITLE
[DEVHAS-26] feat: Support container image components

### DIFF
--- a/api/v1alpha1/component_types.go
+++ b/api/v1alpha1/component_types.go
@@ -36,9 +36,6 @@ type GitSource struct {
 	// If importing from git, the repository to create the component from
 	URL string `json:"url"`
 
-	// Secret containing a Person Access Token to clone a sample, if using private repository
-	Secret string `json:"secret,omitempty"`
-
 	// If specified, the devfile at the URL will be used for the component.
 	DevfileURL string `json:"devfileUrl,omitempty"`
 }
@@ -84,6 +81,11 @@ type ComponentSpec struct {
 	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// Application to add the component to
 	Application string `json:"application"`
+
+	// Secret describes the name of a Kubernetes secret containing either:
+	// 1. A Personal Access Token to access the Component's git repostiory (if using a Git-source component) or
+	// 2. An Image Pull Secret to access the Component's container image (if using an Image-source component).
+	Secret string `json:"secret,omitempty"`
 
 	// Source describes the Component source
 	Source ComponentSource `json:"source"`

--- a/api/v1alpha1/componentdetectionquery_types.go
+++ b/api/v1alpha1/componentdetectionquery_types.go
@@ -31,6 +31,9 @@ type ComponentDetectionQuerySpec struct {
 
 	// IsMultiComponent specifies if the component specified has multiple services
 	IsMultiComponent bool `json:"isMultiComponent,omitempty"`
+
+	// Secret describes the name of a Kubernetes secret containing a Personal Access Token to access the git repostiory
+	Secret string `json:"secret,omitempty"`
 }
 
 // ComponentDetectionDescription holds all the information about the component being detected

--- a/config/crd/bases/appstudio.redhat.com_componentdetectionqueries.yaml
+++ b/config/crd/bases/appstudio.redhat.com_componentdetectionqueries.yaml
@@ -48,10 +48,6 @@ spec:
                     description: If specified, the devfile at the URL will be used
                       for the component.
                     type: string
-                  secret:
-                    description: Secret containing a Person Access Token to clone
-                      a sample, if using private repository
-                    type: string
                   url:
                     description: If importing from git, the repository to create the
                       component from
@@ -63,6 +59,10 @@ spec:
                 description: IsMultiComponent specifies if the component specified
                   has multiple services
                 type: boolean
+              secret:
+                description: Secret describes the name of a Kubernetes secret containing
+                  a Personal Access Token to access the git repostiory
+                type: string
             required:
             - git
             type: object
@@ -259,6 +259,13 @@ spec:
                         route:
                           description: The route to expose the component with
                           type: string
+                        secret:
+                          description: 'Secret describes the name of a Kubernetes
+                            secret containing either: 1. A Personal Access Token to
+                            access the Component''s git repostiory (if using a Git-source
+                            component) or 2. An Image Pull Secret to access the Component''s
+                            container image (if using an Image-source component).'
+                          type: string
                         source:
                           description: Source describes the Component source
                           properties:
@@ -268,10 +275,6 @@ spec:
                                 devfileUrl:
                                   description: If specified, the devfile at the URL
                                     will be used for the component.
-                                  type: string
-                                secret:
-                                  description: Secret containing a Person Access Token
-                                    to clone a sample, if using private repository
                                   type: string
                                 url:
                                   description: If importing from git, the repository

--- a/config/crd/bases/appstudio.redhat.com_components.yaml
+++ b/config/crd/bases/appstudio.redhat.com_components.yaml
@@ -206,6 +206,13 @@ spec:
               route:
                 description: The route to expose the component with
                 type: string
+              secret:
+                description: 'Secret describes the name of a Kubernetes secret containing
+                  either: 1. A Personal Access Token to access the Component''s git
+                  repostiory (if using a Git-source component) or 2. An Image Pull
+                  Secret to access the Component''s container image (if using an Image-source
+                  component).'
+                type: string
               source:
                 description: Source describes the Component source
                 properties:
@@ -215,10 +222,6 @@ spec:
                       devfileUrl:
                         description: If specified, the devfile at the URL will be
                           used for the component.
-                        type: string
-                      secret:
-                        description: Secret containing a Person Access Token to clone
-                          a sample, if using private repository
                         type: string
                       url:
                         description: If importing from git, the repository to create

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -106,19 +106,20 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		source := component.Spec.Source
 		context := component.Spec.Context
 
+		var compDevfileData data.DevfileData
 		if source.GitSource != nil && source.GitSource.URL != "" {
 			// If a Git secret was passed in, retrieve it for use in our Git operations
 			// The secret needs to be in the same namespace as the Component
-			if source.GitSource.Secret != "" {
+			if component.Spec.Secret != "" {
 				gitSecret := corev1.Secret{}
 				namespacedName := types.NamespacedName{
-					Name:      source.GitSource.Secret,
+					Name:      component.Spec.Secret,
 					Namespace: component.Namespace,
 				}
 
 				err = r.Client.Get(ctx, namespacedName, &gitSecret)
 				if err != nil {
-					log.Error(err, fmt.Sprintf("Unable to retrieve Git secret %v, exiting reconcile loop %v", component.Spec.Source.GitSource.Secret, req.NamespacedName))
+					log.Error(err, fmt.Sprintf("Unable to retrieve Git secret %v, exiting reconcile loop %v", component.Spec.Secret, req.NamespacedName))
 					r.SetCreateConditionAndUpdateCR(ctx, &component, err)
 					return ctrl.Result{}, nil
 				}
@@ -173,105 +174,126 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			}
 
 			// Parse the Component Devfile
-			hasCompDevfileData, err := devfile.ParseDevfileModel(string(devfileBytes))
+			compDevfileData, err = devfile.ParseDevfileModel(string(devfileBytes))
 			if err != nil {
 				log.Error(err, fmt.Sprintf("Unable to parse the devfile from Component, exiting reconcile loop %v", req.NamespacedName))
 				r.SetCreateConditionAndUpdateCR(ctx, &component, err)
 				return ctrl.Result{}, nil
 			}
-
-			err = r.updateComponentDevfileModel(hasCompDevfileData, component)
+		} else if source.ImageSource != nil && source.ImageSource.ContainerImage != "" {
+			// An image component was specified
+			// Generate a stub devfile for the component
+			compDevfileData, err = devfile.ConvertImageComponentToDevfile(component)
 			if err != nil {
-				log.Error(err, fmt.Sprintf("Unable to update the Component Devfile model %v", req.NamespacedName))
+				log.Error(err, fmt.Sprintf("Unable to parse the devfile from Component, exiting reconcile loop %v", req.NamespacedName))
+				r.SetCreateConditionAndUpdateCR(ctx, &component, err)
+				return ctrl.Result{}, nil
+			}
+			log.Info(fmt.Sprintf("container image is not supported at the moment, please use github links for adding a component to an application for %s %v", component.Name, req.NamespacedName))
+			//r.SetCreateConditionAndUpdateCR(ctx, &component, nil)
+			//return ctrl.Result{}, nil
+
+			component.Status.ContainerImage = source.ImageSource.ContainerImage
+		}
+
+		err = r.updateComponentDevfileModel(compDevfileData, component)
+		if err != nil {
+			log.Error(err, fmt.Sprintf("Unable to update the Component Devfile model %v", req.NamespacedName))
+			r.SetCreateConditionAndUpdateCR(ctx, &component, err)
+			return ctrl.Result{}, nil
+		}
+
+		// Get the Application CR
+		hasApplication := appstudiov1alpha1.Application{}
+		err = r.Get(ctx, types.NamespacedName{Name: component.Spec.Application, Namespace: component.Namespace}, &hasApplication)
+		if err != nil {
+			log.Error(err, fmt.Sprintf("Unable to get the Application %s, exiting reconcile loop %v", component.Spec.Application, req.NamespacedName))
+			r.SetCreateConditionAndUpdateCR(ctx, &component, err)
+			return ctrl.Result{}, nil
+		}
+
+		if hasApplication.Status.Devfile != "" {
+			// Get the devfile of the hasApp CR
+			hasAppDevfileData, err := devfile.ParseDevfileModel(hasApplication.Status.Devfile)
+			if err != nil {
+				log.Error(err, fmt.Sprintf("Unable to parse the devfile from Application, exiting reconcile loop %v", req.NamespacedName))
 				r.SetCreateConditionAndUpdateCR(ctx, &component, err)
 				return ctrl.Result{}, nil
 			}
 
-			// Get the Application CR
-			hasApplication := appstudiov1alpha1.Application{}
-			err = r.Get(ctx, types.NamespacedName{Name: component.Spec.Application, Namespace: component.Namespace}, &hasApplication)
+			err = r.updateApplicationDevfileModel(hasAppDevfileData, component)
 			if err != nil {
-				log.Error(err, fmt.Sprintf("Unable to get the Application %s, exiting reconcile loop %v", component.Spec.Application, req.NamespacedName))
+				log.Error(err, fmt.Sprintf("Unable to update the HAS Application Devfile model %v", req.NamespacedName))
 				r.SetCreateConditionAndUpdateCR(ctx, &component, err)
 				return ctrl.Result{}, nil
 			}
 
-			if hasApplication.Status.Devfile != "" {
-				// Get the devfile of the hasApp CR
-				hasAppDevfileData, err := devfile.ParseDevfileModel(hasApplication.Status.Devfile)
-				if err != nil {
-					log.Error(err, fmt.Sprintf("Unable to parse the devfile from Application, exiting reconcile loop %v", req.NamespacedName))
-					r.SetCreateConditionAndUpdateCR(ctx, &component, err)
-					return ctrl.Result{}, nil
-				}
+			yamlHASCompData, err := yaml.Marshal(compDevfileData)
+			if err != nil {
+				log.Error(err, fmt.Sprintf("Unable to marshall the Component devfile, exiting reconcile loop %v", req.NamespacedName))
+				r.SetCreateConditionAndUpdateCR(ctx, &component, err)
+				return ctrl.Result{}, nil
+			}
 
-				err = r.updateApplicationDevfileModel(hasAppDevfileData, component)
-				if err != nil {
-					log.Error(err, fmt.Sprintf("Unable to update the HAS Application Devfile model %v", req.NamespacedName))
-					r.SetCreateConditionAndUpdateCR(ctx, &component, err)
-					return ctrl.Result{}, nil
-				}
+			component.Status.Devfile = string(yamlHASCompData)
 
-				yamlHASCompData, err := yaml.Marshal(hasCompDevfileData)
-				if err != nil {
-					log.Error(err, fmt.Sprintf("Unable to marshall the Component devfile, exiting reconcile loop %v", req.NamespacedName))
-					r.SetCreateConditionAndUpdateCR(ctx, &component, err)
-					return ctrl.Result{}, nil
-				}
+			// Update the HASApp CR with the new devfile
+			yamlHASAppData, err := yaml.Marshal(hasAppDevfileData)
+			if err != nil {
+				log.Error(err, fmt.Sprintf("Unable to marshall the Application devfile, exiting reconcile loop %v", req.NamespacedName))
+				r.SetCreateConditionAndUpdateCR(ctx, &component, err)
+				return ctrl.Result{}, nil
+			}
+			hasApplication.Status.Devfile = string(yamlHASAppData)
+			if source.ImageSource != nil {
+				fmt.Println("*****")
+				fmt.Println(hasApplication.Status.Devfile)
+			}
+			err = r.Status().Update(ctx, &hasApplication)
+			if err != nil {
+				log.Error(err, "Unable to update Application")
+				// if we're unable to update the Application CR, then  we need to err out
+				// since we need to save a reference of the Component in Application
+				r.SetCreateConditionAndUpdateCR(ctx, &component, err)
+				return ctrl.Result{}, err
+			}
 
-				component.Status.Devfile = string(yamlHASCompData)
+			if component.Spec.Build.ContainerImage != "" {
+				// Set the container image in the status
+				component.Status.ContainerImage = component.Spec.Build.ContainerImage
+			}
 
-				// Update the HASApp CR with the new devfile
-				yamlHASAppData, err := yaml.Marshal(hasAppDevfileData)
-				if err != nil {
-					log.Error(err, fmt.Sprintf("Unable to marshall the Application devfile, exiting reconcile loop %v", req.NamespacedName))
-					r.SetCreateConditionAndUpdateCR(ctx, &component, err)
-					return ctrl.Result{}, nil
-				}
-				hasApplication.Status.Devfile = string(yamlHASAppData)
-				err = r.Status().Update(ctx, &hasApplication)
-				if err != nil {
-					log.Error(err, "Unable to update Application")
-					// if we're unable to update the Application CR, then  we need to err out
-					// since we need to save a reference of the Component in Application
-					r.SetCreateConditionAndUpdateCR(ctx, &component, err)
-					return ctrl.Result{}, err
-				}
+			log.Info(fmt.Sprintf("Adding the GitOps repository information to the status for component %v", req.NamespacedName))
+			err = setGitopsStatus(&component, hasAppDevfileData)
+			if err != nil {
+				log.Error(err, fmt.Sprintf("Unable to retrieve gitops repository information for resource %v", req.NamespacedName))
+				r.SetCreateConditionAndUpdateCR(ctx, &component, err)
+				return ctrl.Result{}, err
+			}
 
-				if component.Spec.Build.ContainerImage != "" {
-					// Set the container image in the status
-					component.Status.ContainerImage = component.Spec.Build.ContainerImage
-				}
+			// Generate and push the gitops resources
+			if err := r.generateGitops(&component); err != nil {
+				errMsg := fmt.Sprintf("Unable to generate gitops resources for component %v", req.NamespacedName)
+				log.Error(err, errMsg)
+				r.SetCreateConditionAndUpdateCR(ctx, &component, fmt.Errorf(errMsg))
+				return ctrl.Result{}, nil
+			}
 
-				log.Info(fmt.Sprintf("Adding the GitOps repository information to the status for component %v", req.NamespacedName))
-				err = setGitopsStatus(&component, hasAppDevfileData)
-				if err != nil {
-					log.Error(err, fmt.Sprintf("Unable to retrieve gitops repository information for resource %v", req.NamespacedName))
-					r.SetCreateConditionAndUpdateCR(ctx, &component, err)
-					return ctrl.Result{}, err
-				}
-
-				// Generate and push the gitops resources
-				if err := r.generateGitops(&component); err != nil {
-					errMsg := fmt.Sprintf("Unable to generate gitops resources for component %v", req.NamespacedName)
-					log.Error(err, errMsg)
-					r.SetCreateConditionAndUpdateCR(ctx, &component, fmt.Errorf(errMsg))
-					return ctrl.Result{}, nil
-				}
-
+			// ToDo: Remove when removing gitops/build from HAS
+			// This if-block is just temporary until the gitops/build functionality is removed from HAS
+			// To avoid needing to do a larger refactor later.
+			if source.GitSource != nil && source.GitSource.URL != "" {
 				log.Info(fmt.Sprintf("Creating the Build objects  %v", req.NamespacedName))
 				err = r.runBuild(ctx, &component)
 				r.SetCreateConditionAndUpdateCR(ctx, &component, err)
 			} else {
-				log.Error(err, fmt.Sprintf("Application devfile model is empty. Before creating a Component, an instance of Application should be created, exiting reconcile loop %v", req.NamespacedName))
-				err := fmt.Errorf("application devfile model is empty. Before creating a Component, an instance of Application should be created")
-				r.SetCreateConditionAndUpdateCR(ctx, &component, err)
-				return ctrl.Result{}, nil
+				r.SetCreateConditionAndUpdateCR(ctx, &component, nil)
 			}
 
-		} else if source.ImageSource != nil && source.ImageSource.ContainerImage != "" {
-			log.Info(fmt.Sprintf("container image is not supported at the moment, please use github links for adding a component to an application for %s %v", component.Name, req.NamespacedName))
-			r.SetCreateConditionAndUpdateCR(ctx, &component, nil)
+		} else {
+			log.Error(err, fmt.Sprintf("Application devfile model is empty. Before creating a Component, an instance of Application should be created, exiting reconcile loop %v", req.NamespacedName))
+			err := fmt.Errorf("application devfile model is empty. Before creating a Component, an instance of Application should be created")
+			r.SetCreateConditionAndUpdateCR(ctx, &component, err)
 			return ctrl.Result{}, nil
 		}
 
@@ -314,7 +336,12 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			}
 
 			// Generate and push the gitops resources
-			component.Status.ContainerImage = component.Spec.Build.ContainerImage
+			if component.Spec.Source.ImageSource != nil && component.Spec.Source.ImageSource.ContainerImage != "" {
+				component.Status.ContainerImage = component.Spec.Source.ImageSource.ContainerImage
+			} else {
+				component.Status.ContainerImage = component.Spec.Build.ContainerImage
+			}
+
 			if err := r.generateGitops(&component); err != nil {
 				errMsg := fmt.Sprintf("Unable to generate gitops resources for component %v", req.NamespacedName)
 				log.Error(err, errMsg)
@@ -325,9 +352,14 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			component.Status.Devfile = string(yamlHASCompData)
 			r.SetUpdateConditionAndUpdateCR(ctx, &component, nil)
 
-			log.Info(fmt.Sprintf("Updating the Build objects  %v", req.NamespacedName))
-			err = r.runBuild(ctx, &component)
-			r.SetCreateConditionAndUpdateCR(ctx, &component, err)
+			// ToDo: Remove when removing gitops/build from HAS
+			// This if-block is just temporary until the gitops/build functionality is removed from HAS
+			// To avoid needing to do a larger refactor later.
+			if component.Spec.Source.GitSource != nil && component.Spec.Source.GitSource.URL != "" {
+				log.Info(fmt.Sprintf("Updating the Build objects  %v", req.NamespacedName))
+				err = r.runBuild(ctx, &component)
+				r.SetUpdateConditionAndUpdateCR(ctx, &component, err)
+			}
 
 		} else {
 			log.Info(fmt.Sprintf("The Component devfile data was not updated %v", req.NamespacedName))
@@ -382,7 +414,7 @@ func (r *ComponentReconciler) runBuild(ctx context.Context, component *appstudio
 	}
 	log.Info(fmt.Sprintf("PV is now present : %v", workspaceStorage.Name))
 
-	sourceSecretName := component.Spec.Source.GitSource.Secret
+	sourceSecretName := component.Spec.Secret
 
 	// Make the Secret ready for consumption by Tekton.
 	if sourceSecretName != "" {

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -373,7 +373,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Get the Webhook from the event listener route and update it
 	// Only attempt to get it if the build generation succeeded, otherwise the route won't exist
-	if component.Status.Conditions[len(component.Status.Conditions)-1].Status == v1.ConditionTrue {
+	if component.Status.Conditions[len(component.Status.Conditions)-1].Status == v1.ConditionTrue && component.Spec.Source.ImageSource != nil {
 		createdWebhook := &routev1.Route{}
 		err = r.Client.Get(ctx, types.NamespacedName{Name: "el" + component.Name, Namespace: component.Namespace}, createdWebhook)
 		if err != nil {

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -373,7 +373,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Get the Webhook from the event listener route and update it
 	// Only attempt to get it if the build generation succeeded, otherwise the route won't exist
-	if component.Status.Conditions[len(component.Status.Conditions)-1].Status == v1.ConditionTrue && component.Spec.Source.ImageSource != nil {
+	if component.Status.Conditions[len(component.Status.Conditions)-1].Status == v1.ConditionTrue && component.Spec.Source.ImageSource == nil {
 		createdWebhook := &routev1.Route{}
 		err = r.Client.Get(ctx, types.NamespacedName{Name: "el" + component.Name, Namespace: component.Namespace}, createdWebhook)
 		if err != nil {

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -245,10 +245,6 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				return ctrl.Result{}, nil
 			}
 			hasApplication.Status.Devfile = string(yamlHASAppData)
-			if source.ImageSource != nil {
-				fmt.Println("*****")
-				fmt.Println(hasApplication.Status.Devfile)
-			}
 			err = r.Status().Update(ctx, &hasApplication)
 			if err != nil {
 				log.Error(err, "Unable to update Application")

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -141,12 +141,10 @@ var _ = Describe("Component controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			Eventually(func() bool {
-				fmt.Println(createdHasComp.ResourceVersion)
 				labelSelectors := client.ListOptions{Raw: &metav1.ListOptions{
 					LabelSelector: "build.appstudio.openshift.io/component=" + createdHasComp.Name,
 				}}
 				k8sClient.List(context.Background(), &pipelineRuns, &labelSelectors)
-				fmt.Println(pipelineRuns.Items)
 				return len(pipelineRuns.Items) > 0
 			}, timeout, interval).Should(BeTrue())
 

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -96,11 +96,11 @@ var _ = Describe("Component controller", func() {
 				Spec: appstudiov1alpha1.ComponentSpec{
 					ComponentName: ComponentName,
 					Application:   HASAppNameForBuild,
+					Secret:        "doesmatter",
 					Source: appstudiov1alpha1.ComponentSource{
 						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
 							GitSource: &appstudiov1alpha1.GitSource{
-								URL:    SampleRepoLink,
-								Secret: "doesmatter",
+								URL: SampleRepoLink,
 							},
 						},
 					},
@@ -1415,12 +1415,12 @@ var _ = Describe("Component controller", func() {
 				Spec: appstudiov1alpha1.ComponentSpec{
 					ComponentName: ComponentName,
 					Application:   applicationName,
+					Secret:        "fake-secret",
 					Source: appstudiov1alpha1.ComponentSource{
 						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
 							GitSource: &appstudiov1alpha1.GitSource{
 								URL:        SampleRepoLink,
 								DevfileURL: "https://github.com/test/repo",
-								Secret:     "fake-secret",
 							},
 						},
 					},
@@ -1489,11 +1489,11 @@ var _ = Describe("Component controller", func() {
 				Spec: appstudiov1alpha1.ComponentSpec{
 					ComponentName: ComponentName,
 					Application:   applicationName,
+					Secret:        componentName,
 					Source: appstudiov1alpha1.ComponentSource{
 						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
 							GitSource: &appstudiov1alpha1.GitSource{
-								URL:    SampleRepoLink,
-								Secret: componentName,
+								URL: SampleRepoLink,
 							},
 						},
 					},
@@ -1561,11 +1561,11 @@ var _ = Describe("Component controller", func() {
 				Spec: appstudiov1alpha1.ComponentSpec{
 					ComponentName: ComponentName,
 					Application:   applicationName,
+					Secret:        componentName,
 					Source: appstudiov1alpha1.ComponentSource{
 						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
 							GitSource: &appstudiov1alpha1.GitSource{
-								URL:    "https://github.com/johnmcollier/test-error-response",
-								Secret: componentName,
+								URL: "https://github.com/johnmcollier/test-error-response",
 							},
 						},
 					},
@@ -1695,7 +1695,7 @@ var _ = Describe("Component controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			// Make sure the devfile model was properly set in Component
-			Expect(createdHasComp.Status.Devfile).Should(Equal(""))
+			Expect(createdHasComp.Status.Devfile).Should(Not(Equal("")))
 
 			// Make sure the component resource has been updated properly
 			Expect(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message).Should(ContainSubstring("successfully created"))
@@ -1705,11 +1705,12 @@ var _ = Describe("Component controller", func() {
 			createdHasApp := &appstudiov1alpha1.Application{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasAppLookupKey, createdHasApp)
-				return len(createdHasApp.Status.Conditions) > 0
+				return strings.Contains(createdHasApp.Status.Devfile, "containerImage/backend")
 			}, timeout, interval).Should(BeTrue())
 
 			// Make sure the devfile model was properly set in Application
 			Expect(createdHasApp.Status.Devfile).Should(Not(Equal("")))
+			Expect(createdHasApp.Status.Devfile).Should(ContainSubstring("containerImage/backend"))
 
 			// Delete the specified HASComp resource
 			deleteHASCompCR(hasCompLookupKey)

--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -86,16 +86,16 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 		r.SetDetectingConditionAndUpdateCR(ctx, &componentDetectionQuery)
 
 		var gitToken string
-		if componentDetectionQuery.Spec.GitSource.Secret != "" {
+		if componentDetectionQuery.Spec.Secret != "" {
 			gitSecret := corev1.Secret{}
 			namespacedName := types.NamespacedName{
-				Name:      componentDetectionQuery.Spec.GitSource.Secret,
+				Name:      componentDetectionQuery.Spec.Secret,
 				Namespace: componentDetectionQuery.Namespace,
 			}
 
 			err = r.Client.Get(ctx, namespacedName, &gitSecret)
 			if err != nil {
-				log.Error(err, fmt.Sprintf("Unable to retrieve Git secret %v, exiting reconcile loop %v", componentDetectionQuery.Spec.GitSource.Secret, req.NamespacedName))
+				log.Error(err, fmt.Sprintf("Unable to retrieve Git secret %v, exiting reconcile loop %v", componentDetectionQuery.Spec.Secret, req.NamespacedName))
 				r.SetCompleteConditionAndUpdateCR(ctx, &componentDetectionQuery, err)
 				return ctrl.Result{}, nil
 			}

--- a/controllers/componentdetectionquery_controller_test.go
+++ b/controllers/componentdetectionquery_controller_test.go
@@ -526,9 +526,9 @@ var _ = Describe("Component Detection Query controller", func() {
 					Namespace: HASNamespace,
 				},
 				Spec: appstudiov1alpha1.ComponentDetectionQuerySpec{
+					Secret: queryName,
 					GitSource: appstudiov1alpha1.GitSource{
-						URL:    SampleRepoLink,
-						Secret: queryName,
+						URL: SampleRepoLink,
 					},
 				},
 			}
@@ -590,9 +590,9 @@ var _ = Describe("Component Detection Query controller", func() {
 				},
 				Spec: appstudiov1alpha1.ComponentDetectionQuerySpec{
 					IsMultiComponent: true,
+					Secret:           queryName,
 					GitSource: appstudiov1alpha1.GitSource{
-						URL:    "https://github.com/maysunfaisal/multi-components",
-						Secret: queryName,
+						URL: "https://github.com/maysunfaisal/multi-components",
 					},
 				},
 			}
@@ -651,9 +651,9 @@ var _ = Describe("Component Detection Query controller", func() {
 					Namespace: HASNamespace,
 				},
 				Spec: appstudiov1alpha1.ComponentDetectionQuerySpec{
+					Secret: queryName,
 					GitSource: appstudiov1alpha1.GitSource{
-						URL:    "https://github.com/test-repo/test-error-response",
-						Secret: queryName,
+						URL: "https://github.com/test-repo/test-error-response",
 					},
 				},
 			}
@@ -694,9 +694,9 @@ var _ = Describe("Component Detection Query controller", func() {
 					Namespace: HASNamespace,
 				},
 				Spec: appstudiov1alpha1.ComponentDetectionQuerySpec{
+					Secret: queryName,
 					GitSource: appstudiov1alpha1.GitSource{
-						URL:    "https://github.com/test-repo/testrepo",
-						Secret: queryName,
+						URL: "https://github.com/test-repo/testrepo",
 					},
 				},
 			}

--- a/controllers/update.go
+++ b/controllers/update.go
@@ -240,9 +240,6 @@ func (r *ComponentReconciler) updateApplicationDevfileModel(hasAppDevfileData da
 			return err
 		}
 	} else if component.Spec.Source.ImageSource != nil {
-		fmt.Println("*****")
-		fmt.Println(component.Spec.Source.ImageSource.ContainerImage)
-
 		var err error
 
 		// Initialize the attributes

--- a/gitops/generate.go
+++ b/gitops/generate.go
@@ -73,6 +73,12 @@ func Generate(fs afero.Fs, outputFolder string, component appstudiov1alpha1.Comp
 }
 
 func generateDeployment(component appstudiov1alpha1.Component) *appsv1.Deployment {
+	var containerImage string
+	if component.Spec.Source.ImageSource != nil && component.Spec.Source.ImageSource.ContainerImage != "" {
+		containerImage = component.Spec.Source.ImageSource.ContainerImage
+	} else {
+		containerImage = component.Spec.Build.ContainerImage
+	}
 	replicas := getReplicas(component)
 	k8sLabels := generateK8sLabels(component)
 	matchLabels := getMatchLabel(component)
@@ -99,7 +105,7 @@ func generateDeployment(component appstudiov1alpha1.Component) *appsv1.Deploymen
 					Containers: []corev1.Container{
 						{
 							Name:            "container-image",
-							Image:           component.Spec.Build.ContainerImage,
+							Image:           containerImage,
 							ImagePullPolicy: corev1.PullAlways,
 							Env:             component.Spec.Env,
 							Resources:       component.Spec.Resources,

--- a/gitops/generate_test.go
+++ b/gitops/generate_test.go
@@ -198,6 +198,114 @@ func TestGenerateDeployment(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Simple image component, no optional fields set",
+			component: appstudiov1alpha1.Component{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      componentName,
+					Namespace: namespace,
+				},
+				Spec: appstudiov1alpha1.ComponentSpec{
+					ComponentName: componentName,
+					Application:   applicationName,
+					Source: appstudiov1alpha1.ComponentSource{
+						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
+							ImageSource: &appstudiov1alpha1.ImageSource{
+								ContainerImage: "quay.io/test/test:latest",
+							},
+						},
+					},
+				},
+			},
+			wantDeployment: appsv1.Deployment{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name:      componentName,
+					Namespace: namespace,
+					Labels:    k8slabels,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &replicas,
+					Selector: &v1.LabelSelector{
+						MatchLabels: matchLabels,
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{
+							Labels: matchLabels,
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:            "container-image",
+									Image:           "quay.io/test/test:latest",
+									ImagePullPolicy: corev1.PullAlways,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Simple image component with pull secret set",
+			component: appstudiov1alpha1.Component{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      componentName,
+					Namespace: namespace,
+				},
+				Spec: appstudiov1alpha1.ComponentSpec{
+					ComponentName: componentName,
+					Application:   applicationName,
+					Secret:        "my-image-pull-secret",
+					Source: appstudiov1alpha1.ComponentSource{
+						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
+							ImageSource: &appstudiov1alpha1.ImageSource{
+								ContainerImage: "quay.io/test/test:latest",
+							},
+						},
+					},
+				},
+			},
+			wantDeployment: appsv1.Deployment{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name:      componentName,
+					Namespace: namespace,
+					Labels:    k8slabels,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &replicas,
+					Selector: &v1.LabelSelector{
+						MatchLabels: matchLabels,
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: v1.ObjectMeta{
+							Labels: matchLabels,
+						},
+						Spec: corev1.PodSpec{
+							ImagePullSecrets: []corev1.LocalObjectReference{
+								{
+									Name: "my-image-pull-secret",
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Name:            "container-image",
+									Image:           "quay.io/test/test:latest",
+									ImagePullPolicy: corev1.PullAlways,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/devfile/devfile.go
+++ b/pkg/devfile/devfile.go
@@ -16,6 +16,7 @@
 package devfile
 
 import (
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/api/v2/pkg/attributes"
 	"github.com/devfile/api/v2/pkg/devfile"
 	devfilePkg "github.com/devfile/library/pkg/devfile"
@@ -86,6 +87,37 @@ func ConvertApplicationToDevfile(hasApp appstudiov1alpha1.Application, gitOpsRep
 		Description: hasApp.Spec.Description,
 		Attributes:  devfileAttributes,
 	})
+
+	return devfileData, nil
+}
+
+func ConvertImageComponentToDevfile(comp appstudiov1alpha1.Component) (data.DevfileData, error) {
+	devfileVersion := string(data.APISchemaVersion210)
+	devfileData, err := data.NewDevfileData(devfileVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	devfileData.SetSchemaVersion(devfileVersion)
+	devfileData.SetMetadata(devfile.DevfileMetadata{
+		Name: comp.Spec.ComponentName,
+	})
+
+	// Generate a stub container component for the devfile
+	components := []v1alpha2.Component{
+		{
+			Name: "container",
+			ComponentUnion: v1alpha2.ComponentUnion{
+				Container: &v1alpha2.ContainerComponent{
+					Container: v1alpha2.Container{
+						Image: comp.Spec.Source.ImageSource.ContainerImage,
+					},
+				},
+			},
+		},
+	}
+
+	devfileData.AddComponents(components)
 
 	return devfileData, nil
 }


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/DEVHAS-26

This PR implements support for (public and private) container image components in HAS. It also moves the `spec.Source.GitSecret` field to `spec.Secret` to allow both Git and Image components to reference secrets.

When a Component is created in HAS referencing a container image, like so:
```
apiVersion: appstudio.redhat.com/v1alpha1
kind: Component
metadata:
  name: component-example
  namespace: default
spec:
  application: application-example
  build:
    containerImage: ''
  componentName: sample-component-name
  resources: {}
  source:
    image:
      containerImage: docker.io/openshift/hello-openshift
```

HAS will generate gitops resources that reference that container image and push it to the gitops repository. If a private container image needs to be used, then the `spec.secret` field must be set to a valid Kubernetes `ImagePullSecret` containing credentials for the image registry containing the private container image.

**Note:** Since no build will occur, the Tekton pipeline resources will not be generated, nor will any build resources be created cluster-side.