### PR TITLE
[DEVHAS-94] Requeue the Component when its Application can't be found

### DIFF
--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -193,7 +193,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			if err != nil {
 				log.Error(err, fmt.Sprintf("Unable to get the Application %s, exiting reconcile loop %v", component.Spec.Application, req.NamespacedName))
 				r.SetCreateConditionAndUpdateCR(ctx, &component, err)
-				return ctrl.Result{}, nil
+				return ctrl.Result{}, err
 			}
 
 			if hasApplication.Status.Devfile != "" {
@@ -266,7 +266,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				log.Error(err, fmt.Sprintf("Application devfile model is empty. Before creating a Component, an instance of Application should be created, exiting reconcile loop %v", req.NamespacedName))
 				err := fmt.Errorf("application devfile model is empty. Before creating a Component, an instance of Application should be created")
 				r.SetCreateConditionAndUpdateCR(ctx, &component, err)
-				return ctrl.Result{}, nil
+				return ctrl.Result{}, err
 			}
 
 		} else if source.ImageSource != nil && source.ImageSource.ContainerImage != "" {

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -22,15 +22,18 @@ import (
 	"net/url"
 	"path"
 	"reflect"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/yaml"
@@ -191,7 +194,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			hasApplication := appstudiov1alpha1.Application{}
 			err = r.Get(ctx, types.NamespacedName{Name: component.Spec.Application, Namespace: component.Namespace}, &hasApplication)
 			if err != nil {
-				log.Error(err, fmt.Sprintf("Unable to get the Application %s, exiting reconcile loop %v", component.Spec.Application, req.NamespacedName))
+				log.Error(err, fmt.Sprintf("Unable to get the Application %s, requeueing %v", component.Spec.Application, req.NamespacedName))
 				r.SetCreateConditionAndUpdateCR(ctx, &component, err)
 				return ctrl.Result{}, err
 			}
@@ -263,8 +266,8 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				err = r.runBuild(ctx, &component)
 				r.SetCreateConditionAndUpdateCR(ctx, &component, err)
 			} else {
-				log.Error(err, fmt.Sprintf("Application devfile model is empty. Before creating a Component, an instance of Application should be created, exiting reconcile loop %v", req.NamespacedName))
-				err := fmt.Errorf("application devfile model is empty. Before creating a Component, an instance of Application should be created")
+				log.Error(err, fmt.Sprintf("Application devfile model is empty. Requeueing %v", req.NamespacedName))
+				err := fmt.Errorf("application devfile model is empty")
 				r.SetCreateConditionAndUpdateCR(ctx, &component, err)
 				return ctrl.Result{}, err
 			}
@@ -643,5 +646,8 @@ func setGitopsStatus(component *appstudiov1alpha1.Component, devfileData data.De
 func (r *ComponentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appstudiov1alpha1.Component{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		WithOptions(controller.Options{
+			RateLimiter: workqueue.NewItemExponentialFailureRateLimiter(time.Duration(500*time.Millisecond), time.Duration(60*time.Second)),
+		}).
 		Complete(r)
 }

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -604,7 +604,7 @@ var _ = Describe("Component controller", func() {
 	})
 
 	Context("Create a Component before an Application", func() {
-		It("Should error out because an Application is missing", func() {
+		It("Should reconcile once the application is created", func() {
 			ctx := context.Background()
 
 			applicationName := HASAppName + "4"
@@ -647,7 +647,17 @@ var _ = Describe("Component controller", func() {
 			Expect(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Reason).Should(Equal("Error"))
 			Expect(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message).Should(ContainSubstring(fmt.Sprintf("%q not found", hasComp.Spec.Application)))
 
+			// Now create the application resource that it references
+			createAndFetchSimpleApp(applicationName, HASAppNamespace, DisplayName, Description)
+
+			// Now fetch the Component resource and validate that eventually its status condition changes to succcess
+			Eventually(func() bool {
+				k8sClient.Get(context.Background(), hasCompLookupKey, createdHasComp)
+				return len(createdHasComp.Status.Conditions) > 0 && createdHasComp.Status.Conditions[0].Reason == "OK"
+			}, timeout, interval).Should(BeTrue())
+
 			// Delete the specified HASComp resource
+			deleteHASAppCR(types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace})
 			deleteHASCompCR(hasCompLookupKey)
 
 		})


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/DEVHAS-94

Updates the Component controller logic to requeue if a Component's Application cannot be found, or is not finished reconciling.