### PR TITLE
Remove releaseStrategy field from component CRD

### DIFF
--- a/api/v1alpha1/component_types.go
+++ b/api/v1alpha1/component_types.go
@@ -91,9 +91,6 @@ type ComponentSpec struct {
 	// A relative path inside the git repo containing the component
 	Context string `json:"context,omitempty"`
 
-	// List of references to ReleaseStrategies to use when releasing the component
-	ReleaseStrategies []string `json:"releaseStrategies,omitempty"`
-
 	// Compute Resources required by this component
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -400,11 +400,6 @@ func (in *ComponentSourceUnion) DeepCopy() *ComponentSourceUnion {
 func (in *ComponentSpec) DeepCopyInto(out *ComponentSpec) {
 	*out = *in
 	in.Source.DeepCopyInto(&out.Source)
-	if in.ReleaseStrategies != nil {
-		in, out := &in.ReleaseStrategies, &out.ReleaseStrategies
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	in.Resources.DeepCopyInto(&out.Resources)
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env

--- a/bundle/manifests/appstudio.redhat.com_componentdetectionqueries.yaml
+++ b/bundle/manifests/appstudio.redhat.com_componentdetectionqueries.yaml
@@ -217,12 +217,6 @@ spec:
                             - name
                             type: object
                           type: array
-                        releaseStrategies:
-                          description: List of references to ReleaseStrategies to
-                            use when releasing the component
-                          items:
-                            type: string
-                          type: array
                         replicas:
                           description: The number of replicas to deploy the component
                             with

--- a/bundle/manifests/appstudio.redhat.com_components.yaml
+++ b/bundle/manifests/appstudio.redhat.com_components.yaml
@@ -176,12 +176,6 @@ spec:
                   - name
                   type: object
                 type: array
-              releaseStrategies:
-                description: List of references to ReleaseStrategies to use when releasing
-                  the component
-                items:
-                  type: string
-                type: array
               replicas:
                 description: The number of replicas to deploy the component with
                 type: integer

--- a/config/crd/bases/appstudio.redhat.com_componentdetectionqueries.yaml
+++ b/config/crd/bases/appstudio.redhat.com_componentdetectionqueries.yaml
@@ -219,12 +219,6 @@ spec:
                             - name
                             type: object
                           type: array
-                        releaseStrategies:
-                          description: List of references to ReleaseStrategies to
-                            use when releasing the component
-                          items:
-                            type: string
-                          type: array
                         replicas:
                           description: The number of replicas to deploy the component
                             with

--- a/config/crd/bases/appstudio.redhat.com_components.yaml
+++ b/config/crd/bases/appstudio.redhat.com_components.yaml
@@ -168,12 +168,6 @@ spec:
                   - name
                   type: object
                 type: array
-              releaseStrategies:
-                description: List of references to ReleaseStrategies to use when releasing
-                  the component
-                items:
-                  type: string
-                type: array
               replicas:
                 description: The number of replicas to deploy the component with
                 type: integer


### PR DESCRIPTION
Per https://issues.redhat.com/browse/HACBS-287, the `ReleaseStrategy` will be stored in the `ReleaseLink` CRD going forward

Signed-off-by: Johnny Bieren <jbieren@redhat.com>