### PR TITLE
Put common-storage-pvc at application-level in gitops repository

### DIFF
--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -416,7 +416,7 @@ func (r *ComponentReconciler) runBuild(ctx context.Context, component *appstudio
 	err := r.Get(ctx, types.NamespacedName{Name: workspaceStorage.Name, Namespace: workspaceStorage.Namespace}, pvc)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			err = r.Client.Create(ctx, &workspaceStorage)
+			err = r.Client.Create(ctx, workspaceStorage)
 			if err != nil {
 				log.Error(err, fmt.Sprintf("Unable to create common storage %v", workspaceStorage))
 				return err

--- a/gitops/generate_build.go
+++ b/gitops/generate_build.go
@@ -46,7 +46,7 @@ const (
 )
 
 func GenerateBuild(fs afero.Fs, outputFolder string, component appstudiov1alpha1.Component) error {
-	commonStoragePVC := GenerateCommonStorage(component, "appstudio")
+	//commonStoragePVC := GenerateCommonStorage(component, "appstudio")
 	triggerTemplate, err := GenerateTriggerTemplate(component)
 	if err != nil {
 		return err
@@ -55,10 +55,10 @@ func GenerateBuild(fs afero.Fs, outputFolder string, component appstudiov1alpha1
 	webhookRoute := GenerateBuildWebhookRoute(component)
 
 	buildResources := map[string]interface{}{
-		buildCommonStoragePVCFileName: commonStoragePVC,
-		buildTriggerTemplateFileName:  triggerTemplate,
-		buildEventListenerFileName:    eventListener,
-		buildWebhookRouteFileName:     webhookRoute,
+		//buildCommonStoragePVCFileName: commonStoragePVC,
+		buildTriggerTemplateFileName: triggerTemplate,
+		buildEventListenerFileName:   eventListener,
+		buildWebhookRouteFileName:    webhookRoute,
 	}
 
 	kustomize := resources.Kustomization{}
@@ -275,7 +275,7 @@ func getBuildCommonLabelsForComponent(component *appstudiov1alpha1.Component) ma
 
 // GenerateCommonStorage returns the PVC that would be created per namespace for
 // user-triggered and webhook-triggered Tekton workspaces.
-func GenerateCommonStorage(component appstudiov1alpha1.Component, name string) corev1.PersistentVolumeClaim {
+func GenerateCommonStorage(component appstudiov1alpha1.Component, name string) *corev1.PersistentVolumeClaim {
 	fsMode := corev1.PersistentVolumeFilesystem
 
 	workspaceStorage := &corev1.PersistentVolumeClaim{
@@ -300,7 +300,7 @@ func GenerateCommonStorage(component appstudiov1alpha1.Component, name string) c
 			VolumeMode: &fsMode,
 		},
 	}
-	return *workspaceStorage
+	return workspaceStorage
 }
 
 // GenerateBuildWebhookRoute returns the Route resource that would enable


### PR DESCRIPTION
Moves the common storage pvc file to application level in the gitops repository

For example: https://github.com/redhat-appstudio-appdata/my-app-default-mix-climb