### PR TITLE
Add context attribute to Application devfiles by deafult

### DIFF
--- a/pkg/devfile/devfile.go
+++ b/pkg/devfile/devfile.go
@@ -77,12 +77,16 @@ func ConvertApplicationToDevfile(hasApp appstudiov1alpha1.Application, gitOpsRep
 	}
 	if hasApp.Spec.AppModelRepository.Context != "" {
 		devfileAttributes.PutString("appModelRepository.context", hasApp.Spec.AppModelRepository.Context)
+	} else {
+		devfileAttributes.PutString("appModelRepository.context", "/")
 	}
 	if hasApp.Spec.GitOpsRepository.Branch != "" {
 		devfileAttributes.PutString("gitOpsRepository.branch", hasApp.Spec.GitOpsRepository.Branch)
 	}
 	if hasApp.Spec.GitOpsRepository.Context != "" {
 		devfileAttributes.PutString("gitOpsRepository.context", hasApp.Spec.GitOpsRepository.Context)
+	} else {
+		devfileAttributes.PutString("gitOpsRepository.context", "/")
 	}
 
 	devfileData.SetMetadata(devfile.DevfileMetadata{

--- a/pkg/devfile/devfile_test.go
+++ b/pkg/devfile/devfile_test.go
@@ -98,7 +98,7 @@ func TestConvertApplicationToDevfile(t *testing.T) {
 						SchemaVersion: string(data.APISchemaVersion210),
 						Metadata: devfile.DevfileMetadata{
 							Name:       "Petclinic",
-							Attributes: attributes.Attributes{}.PutString("gitOpsRepository.url", "https://github.com/testorg/petclinic-gitops").PutString("appModelRepository.url", "https://github.com/testorg/petclinic-app"),
+							Attributes: attributes.Attributes{}.PutString("gitOpsRepository.url", "https://github.com/testorg/petclinic-gitops").PutString("appModelRepository.url", "https://github.com/testorg/petclinic-app").PutString("gitOpsRepository.context", "/").PutString("appModelRepository.context", "/"),
 						},
 					},
 				},


### PR DESCRIPTION
Adds the context attribute (`appModelRepository.context`) and (`gitOpsRepository.context`) by default to the Application devfile generated by HAS. 

If no context is specified, it will default to `/`, otherwise the context value will be used.