### PR TITLE
Use e2e installation script to install e2e framework and pair PR

### DIFF
--- a/.ci/oci-e2e-has.sh
+++ b/.ci/oci-e2e-has.sh
@@ -53,7 +53,10 @@ function waitBuildToBeReady() {
 function executeE2ETests() {
     # E2E instructions can be found: https://github.com/redhat-appstudio/e2e-tests
     # The e2e binary is included in Openshift CI test container from the dockerfile: https://github.com/redhat-appstudio/infra-deployments/blob/main/.ci/openshift-ci/Dockerfile
-    e2e-appstudio --ginkgo.junit-report="${ARTIFACTS_DIR}"/e2e-report.xml --ginkgo.focus="${TEST_SUITE}"
+    curl https://raw.githubusercontent.com/flacatus/e2e-tests/fixes/scripts/e2e-openshift-ci.sh | bash -s
+
+    # The bin will be installed in tmp folder after executing e2e-openshift-ci.sh script
+    ${WORKSPACE}/tmp/e2e-tests/bin/e2e-appstudio --ginkgo.junit-report="${ARTIFACTS_DIR}"/e2e-report.xml --ginkgo.focus="${TEST_SUITE}"
 }
 
 curl https://raw.githubusercontent.com/redhat-appstudio/e2e-tests/main/scripts/install-appstudio-e2e-mode.sh | bash -s install


### PR DESCRIPTION
Script to install the e2e binary and pair PR. More details about pairing PR feature can be found: https://github.com/flacatus/e2e-tests/blob/docs/docs/Installation.md#install-e2e-binary-in-openshift-ci-and-use-pairing-prs-feature