### PR TITLE
Allow the overriding of the default Tekton bundle

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -84,3 +84,11 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch

--- a/gitops/generate.go
+++ b/gitops/generate.go
@@ -20,6 +20,7 @@ import (
 
 	routev1 "github.com/openshift/api/route/v1"
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
+	"github.com/redhat-appstudio/application-service/gitops/prepare"
 	"github.com/redhat-appstudio/application-service/gitops/resources"
 	"github.com/spf13/afero"
 	appsv1 "k8s.io/api/apps/v1"
@@ -39,7 +40,7 @@ const (
 
 // Generate takes in a given Component CR and
 // spits out a deployment, service, and route file to disk
-func Generate(fs afero.Afero, gitOpsFolder string, outputFolder string, component appstudiov1alpha1.Component) error {
+func Generate(fs afero.Afero, gitOpsFolder string, outputFolder string, component appstudiov1alpha1.Component, gitopsConfig prepare.GitopsConfig) error {
 	deployment := generateDeployment(component)
 
 	k := resources.Kustomization{}
@@ -62,7 +63,7 @@ func Generate(fs afero.Afero, gitOpsFolder string, outputFolder string, componen
 		tektonResourcesDirName := ".tekton"
 		k.AddResources(tektonResourcesDirName + "/")
 
-		if err := GenerateBuild(fs, filepath.Join(outputFolder, tektonResourcesDirName), component); err != nil {
+		if err := GenerateBuild(fs, filepath.Join(outputFolder, tektonResourcesDirName), component, gitopsConfig); err != nil {
 			return err
 		}
 

--- a/gitops/generate_build.go
+++ b/gitops/generate_build.go
@@ -25,6 +25,7 @@ import (
 	devfilecommon "github.com/devfile/library/pkg/devfile/parser/data/v2/common"
 	routev1 "github.com/openshift/api/route/v1"
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
+	"github.com/redhat-appstudio/application-service/gitops/prepare"
 	"github.com/redhat-appstudio/application-service/gitops/resources"
 	yaml "github.com/redhat-appstudio/application-service/gitops/yaml"
 	"github.com/redhat-appstudio/application-service/pkg/devfile"
@@ -45,9 +46,9 @@ const (
 	buildWebhookRouteFileName     = "build-webhook-route.yaml"
 )
 
-func GenerateBuild(fs afero.Fs, outputFolder string, component appstudiov1alpha1.Component) error {
+func GenerateBuild(fs afero.Fs, outputFolder string, component appstudiov1alpha1.Component, gitopsConfig prepare.GitopsConfig) error {
 	//commonStoragePVC := GenerateCommonStorage(component, "appstudio")
-	triggerTemplate, err := GenerateTriggerTemplate(component)
+	triggerTemplate, err := GenerateTriggerTemplate(component, gitopsConfig)
 	if err != nil {
 		return err
 	}
@@ -76,8 +77,8 @@ func GenerateBuild(fs afero.Fs, outputFolder string, component appstudiov1alpha1
 }
 
 // GenerateInitialBuildPipelineRun generates pipeline run for initial build of the component.
-func GenerateInitialBuildPipelineRun(component appstudiov1alpha1.Component) tektonapi.PipelineRun {
-	initialBuildSpec := DetermineBuildExecution(component, getParamsForComponentBuild(component, true), getInitialBuildWorkspaceSubpath())
+func GenerateInitialBuildPipelineRun(component appstudiov1alpha1.Component, gitopsConfig prepare.GitopsConfig) tektonapi.PipelineRun {
+	initialBuildSpec := DetermineBuildExecution(component, getParamsForComponentBuild(component, true), getInitialBuildWorkspaceSubpath(), gitopsConfig)
 
 	return tektonapi.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
@@ -95,13 +96,13 @@ func getInitialBuildWorkspaceSubpath() string {
 
 // DetermineBuildExecution returns the pipelineRun spec that would be used
 // in webhooks-triggered pipelineRuns as well as user-triggered PipelineRuns
-func DetermineBuildExecution(component appstudiov1alpha1.Component, params []tektonapi.Param, workspaceSubPath string) tektonapi.PipelineRunSpec {
+func DetermineBuildExecution(component appstudiov1alpha1.Component, params []tektonapi.Param, workspaceSubPath string, gitopsConfig prepare.GitopsConfig) tektonapi.PipelineRunSpec {
 
 	pipelineRunSpec := tektonapi.PipelineRunSpec{
 		Params: params,
 		PipelineRef: &tektonapi.PipelineRef{
 			Name:   determineBuildPipeline(component),
-			Bundle: determineBuildCatalog(component.Namespace),
+			Bundle: gitopsConfig.BuildBundle,
 		},
 
 		Workspaces: []tektonapi.WorkspaceBinding{
@@ -168,12 +169,6 @@ func determineBuildPipeline(component appstudiov1alpha1.Component) string {
 	// Failed to detect build pipeline
 	// Do nothing as we do not know how to build given component
 	return "noop"
-}
-
-func determineBuildCatalog(namespace string) string {
-	// TODO: If there's a namespace/workspace specific catalog, we got
-	// to respect that.
-	return "quay.io/redhat-appstudio/build-templates-bundle:8201a567956ba6d2095d615ea2c0f6ab35f9ba5f"
 }
 
 func normalizeOutputImageURL(outputImage string) string {
@@ -335,8 +330,8 @@ func GenerateBuildWebhookRoute(component appstudiov1alpha1.Component) routev1.Ro
 // GenerateTriggerTemplate generates the TriggerTemplate resources
 // which defines how a webhook-based trigger event would be handled -
 // In this case, a PipelineRun to build an image would be created.
-func GenerateTriggerTemplate(component appstudiov1alpha1.Component) (*triggersapi.TriggerTemplate, error) {
-	webhookBasedBuildTemplate := DetermineBuildExecution(component, getParamsForComponentBuild(component, false), "$(tt.params.git-revision)")
+func GenerateTriggerTemplate(component appstudiov1alpha1.Component, gitopsConfig prepare.GitopsConfig) (*triggersapi.TriggerTemplate, error) {
+	webhookBasedBuildTemplate := DetermineBuildExecution(component, getParamsForComponentBuild(component, false), "$(tt.params.git-revision)", gitopsConfig)
 	resoureTemplatePipelineRun := tektonapi.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: component.Name + "-",

--- a/gitops/generate_build_test.go
+++ b/gitops/generate_build_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/devfile/api/v2/pkg/devfile"
 	data "github.com/devfile/library/pkg/devfile/parser/data"
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
+	"github.com/redhat-appstudio/application-service/gitops/prepare"
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -123,6 +124,8 @@ func TestGenerateInitialBuildPipelineRun(t *testing.T) {
 		},
 	}
 
+	gitopsConfig := prepare.GitopsConfig{BuildBundle: "quay.io/redhat-appstudio/build-templates-bundle:0.0.1"}
+
 	type args struct {
 		component appstudiov1alpha1.Component
 	}
@@ -144,7 +147,7 @@ func TestGenerateInitialBuildPipelineRun(t *testing.T) {
 				},
 				Spec: tektonapi.PipelineRunSpec{
 					PipelineRef: &tektonapi.PipelineRef{
-						Bundle: "quay.io/redhat-appstudio/build-templates-bundle:8201a567956ba6d2095d615ea2c0f6ab35f9ba5f",
+						Bundle: gitopsConfig.BuildBundle,
 						Name:   "noop",
 					},
 					Params: []tektonapi.Param{
@@ -184,7 +187,7 @@ func TestGenerateInitialBuildPipelineRun(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GenerateInitialBuildPipelineRun(tt.args.component); !reflect.DeepEqual(got, tt.want) {
+			if got := GenerateInitialBuildPipelineRun(tt.args.component, gitopsConfig); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GenerateInitialBuildPipelineRun() = %v, want %v", got, tt.want)
 			}
 		})
@@ -197,6 +200,9 @@ func TestDetermineBuildExecution(t *testing.T) {
 		params           []tektonapi.Param
 		workspaceSubPath string
 	}
+
+	gitopsConfig := prepare.GitopsConfig{BuildBundle: "quay.io/redhat-appstudio/build-templates-bundle:0.0.1"}
+
 	tests := []struct {
 		name string
 		args args
@@ -216,7 +222,7 @@ func TestDetermineBuildExecution(t *testing.T) {
 			},
 			want: tektonapi.PipelineRunSpec{
 				PipelineRef: &tektonapi.PipelineRef{
-					Bundle: "quay.io/redhat-appstudio/build-templates-bundle:8201a567956ba6d2095d615ea2c0f6ab35f9ba5f",
+					Bundle: gitopsConfig.BuildBundle,
 					Name:   "noop",
 				},
 				Params: []tektonapi.Param{},
@@ -251,7 +257,7 @@ func TestDetermineBuildExecution(t *testing.T) {
 			},
 			want: tektonapi.PipelineRunSpec{
 				PipelineRef: &tektonapi.PipelineRef{
-					Bundle: "quay.io/redhat-appstudio/build-templates-bundle:8201a567956ba6d2095d615ea2c0f6ab35f9ba5f",
+					Bundle: gitopsConfig.BuildBundle,
 					Name:   "noop",
 				},
 				Params: []tektonapi.Param{},
@@ -275,7 +281,7 @@ func TestDetermineBuildExecution(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := DetermineBuildExecution(tt.args.component, tt.args.params, tt.args.workspaceSubPath); !reflect.DeepEqual(got, tt.want) {
+			if got := DetermineBuildExecution(tt.args.component, tt.args.params, tt.args.workspaceSubPath, gitopsConfig); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("DetermineBuildExecution() = %v, want %v", got, tt.want)
 			}
 		})

--- a/gitops/gitops.go
+++ b/gitops/gitops.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
+	"github.com/redhat-appstudio/application-service/gitops/prepare"
 	"github.com/spf13/afero"
 )
 
@@ -37,7 +38,7 @@ type Executor interface {
 // 6. The branch to push to
 // 7. The path within the repository to generate the resources in
 // Adapted from https://github.com/redhat-developer/kam/blob/master/pkg/pipelines/utils.go#L79
-func GenerateAndPush(outputPath string, remote string, component appstudiov1alpha1.Component, e Executor, appFs afero.Afero, branch string, context string) error {
+func GenerateAndPush(outputPath string, remote string, component appstudiov1alpha1.Component, e Executor, appFs afero.Afero, branch string, context string, gitopsConfig prepare.GitopsConfig) error {
 	componentName := component.Name
 	if out, err := e.Execute(outputPath, "git", "clone", remote, componentName); err != nil {
 		return fmt.Errorf("failed to clone git repository in %q %q: %s", outputPath, string(out), err)
@@ -59,7 +60,7 @@ func GenerateAndPush(outputPath string, remote string, component appstudiov1alph
 	// Generate the gitops resources and update the parent kustomize yaml file
 	gitopsFolder := filepath.Join(repoPath, context)
 	componentPath := filepath.Join(gitopsFolder, "components", componentName, "base")
-	if err := Generate(appFs, gitopsFolder, componentPath, component); err != nil {
+	if err := Generate(appFs, gitopsFolder, componentPath, component, gitopsConfig); err != nil {
 		return fmt.Errorf("failed to generate the gitops resources in %q for component %q: %s", componentPath, componentName, err)
 	}
 

--- a/gitops/gitops_test.go
+++ b/gitops/gitops_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
+	"github.com/redhat-appstudio/application-service/gitops/prepare"
 	"github.com/redhat-appstudio/application-service/gitops/testutils"
 	"github.com/redhat-appstudio/application-service/pkg/util/ioutils"
 	"github.com/spf13/afero"
@@ -565,7 +566,7 @@ func TestGenerateAndPush(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := testutils.NewMockExecutor(tt.outputs...)
 			e.Errors = tt.errors
-			err := GenerateAndPush(outputPath, repo, tt.component, e, tt.fs, "main", "/")
+			err := GenerateAndPush(outputPath, repo, tt.component, e, tt.fs, "main", "/", prepare.GitopsConfig{})
 
 			if tt.wantErrString != "" {
 				testutils.AssertErrorMatch(t, tt.wantErrString, err)

--- a/gitops/prepare/prepare.go
+++ b/gitops/prepare/prepare.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package prepare
+
+import (
+	"context"
+
+	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// namespace where the bundle configuration will be searched in case it is not found in the component's namespace
+	BuildBundleDefaultNamepace = "build-templates"
+	// name for a configMap that holds the URL to a build bundle
+	BuildBundleConfigMapName = "build-pipelines-defaults"
+	// data key within a configMap that holds the URL to a build bundle
+	BuildBundleConfigMapKey = "default_build_bundle"
+	// fallback bundle that will be used in case the bundle resolution fails
+	FallbackBuildBundle = "quay.io/redhat-appstudio/build-templates-bundle:8201a567956ba6d2095d615ea2c0f6ab35f9ba5f"
+)
+
+// Holds data that needs to be queried from the cluster in order for the gitops generation function to work
+// This struct is left here so more data can be added as needed
+type GitopsConfig struct {
+	BuildBundle string
+}
+
+func PrepareGitopsConfig(ctx context.Context, cli client.Client, component appstudiov1alpha1.Component) GitopsConfig {
+	data := GitopsConfig{}
+
+	data.BuildBundle = resolveBuildBundle(ctx, cli, component)
+
+	return data
+}
+
+// Tries to load a custom build bundle path from a configmap.
+// The following priority is used: component's namespace -> default namespace -> fallback value.
+func resolveBuildBundle(ctx context.Context, cli client.Client, component appstudiov1alpha1.Component) string {
+	namespaces := [2]string{component.Namespace, BuildBundleDefaultNamepace}
+
+	for _, namespace := range namespaces {
+		var configMap = corev1.ConfigMap{}
+
+		// All errors during the loading of the configmaps should be treated as non-fatal
+		// TODO: Add logging to help the debugging of eventual issues
+		_ = cli.Get(ctx, types.NamespacedName{Name: BuildBundleConfigMapName, Namespace: namespace}, &configMap)
+
+		if value, isPresent := configMap.Data[BuildBundleConfigMapKey]; isPresent && value != "" {
+			return value
+		}
+	}
+
+	return FallbackBuildBundle
+}

--- a/gitops/prepare/prepare_test.go
+++ b/gitops/prepare/prepare_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package prepare
+
+import (
+	"context"
+	"testing"
+
+	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestPrepareGitopsConfig(t *testing.T) {
+	client := fake.NewClientBuilder().Build()
+
+	component := appstudiov1alpha1.Component{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "appstudio.redhat.com/v1alpha1",
+			Kind:       "Component",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myName",
+			Namespace: "myNamespace",
+		},
+	}
+
+	want := GitopsConfig{
+		BuildBundle: FallbackBuildBundle,
+	}
+
+	t.Run("", func(t *testing.T) {
+		if got := PrepareGitopsConfig(context.TODO(), client, component); got != want {
+			t.Errorf("ResolveBuildBundle() = %v, want %v", got, want)
+		}
+	})
+
+}
+
+func TestResolveBuildBundle(t *testing.T) {
+	ctx := context.TODO()
+
+	component := appstudiov1alpha1.Component{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "appstudio.redhat.com/v1alpha1",
+			Kind:       "Component",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myName",
+			Namespace: "myNamespace",
+		},
+	}
+
+	tests := []struct {
+		name string
+		data corev1.ConfigMap
+		want string
+	}{
+		{
+			name: "should resolve the build bundle in case a configmap exists in the component's namespace",
+			data: corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+				},
+				Data: map[string]string{
+					BuildBundleConfigMapKey: "quay.io/foo/bar:1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      BuildBundleConfigMapName,
+					Namespace: component.Namespace,
+				},
+			},
+			want: "quay.io/foo/bar:1",
+		},
+		{
+			name: "should resolve the build bundle in case a configmap exists in the default namespace",
+			data: corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+				},
+				Data: map[string]string{
+					BuildBundleConfigMapKey: "quay.io/foo/bar:2",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      BuildBundleConfigMapName,
+					Namespace: BuildBundleDefaultNamepace,
+				},
+			},
+			want: "quay.io/foo/bar:2",
+		},
+		{
+			name: "should fall back to the hard-coded bundle in case the resolution fails",
+			data: corev1.ConfigMap{},
+			want: FallbackBuildBundle,
+		},
+		{
+			name: "should ignore malformed configmaps",
+			data: corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+				},
+				Data: map[string]string{
+					"invalidKey": "quay.io/foo/bar:3",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      BuildBundleConfigMapName,
+					Namespace: BuildBundleDefaultNamepace,
+				},
+			},
+			want: FallbackBuildBundle,
+		},
+		{
+			name: "should ignore configmaps with empty keys",
+			data: corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+				},
+				Data: map[string]string{
+					BuildBundleConfigMapKey: "",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      BuildBundleConfigMapName,
+					Namespace: BuildBundleDefaultNamepace,
+				},
+			},
+			want: FallbackBuildBundle,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewClientBuilder().WithRuntimeObjects(&tt.data).Build()
+
+			if got := resolveBuildBundle(ctx, client, component); got != tt.want {
+				t.Errorf("ResolveBuildBundle() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
[PLNSRVCE-141](https://issues.redhat.com//browse/PLNSRVCE-141)

This is a reimplementation of #74 considering the splitting of the code into the build-service operator.

----

This PR provides a simple mechanism to allow the overriding of the Tekton bundle that will be inserted into the generated TriggerTemplate when a Component CR is created.

To do that, a configmap needs to be created in the same namespace as the Component CR:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: build-pipelines-defaults
data:
  default_build_bundle: "quay.io/user/custombundle:version" 
```

In case this configmap is not available, HAS will try to search for one with the same name at the `build-templates` namespace. If no configmap is found, it will resort to the one that's currently [hardcoded](https://github.com/brunoapimentel/application-service/blob/96308c90f86acc7b6993a4deb7cf5da17835a3e1/gitops/generate_build.go#L42).