### PR TITLE
fix: ArgoCD requires relative path

### DIFF
--- a/pkg/devfile/devfile.go
+++ b/pkg/devfile/devfile.go
@@ -86,7 +86,7 @@ func ConvertApplicationToDevfile(hasApp appstudiov1alpha1.Application, gitOpsRep
 	if hasApp.Spec.GitOpsRepository.Context != "" {
 		devfileAttributes.PutString("gitOpsRepository.context", hasApp.Spec.GitOpsRepository.Context)
 	} else {
-		devfileAttributes.PutString("gitOpsRepository.context", "/")
+		devfileAttributes.PutString("gitOpsRepository.context", "./")
 	}
 
 	devfileData.SetMetadata(devfile.DevfileMetadata{

--- a/pkg/devfile/devfile_test.go
+++ b/pkg/devfile/devfile_test.go
@@ -99,7 +99,7 @@ func TestConvertApplicationToDevfile(t *testing.T) {
 						SchemaVersion: string(data.APISchemaVersion210),
 						Metadata: devfile.DevfileMetadata{
 							Name:       "Petclinic",
-							Attributes: attributes.Attributes{}.PutString("gitOpsRepository.url", "https://github.com/testorg/petclinic-gitops").PutString("appModelRepository.url", "https://github.com/testorg/petclinic-app").PutString("gitOpsRepository.context", "/").PutString("appModelRepository.context", "/"),
+							Attributes: attributes.Attributes{}.PutString("gitOpsRepository.url", "https://github.com/testorg/petclinic-gitops").PutString("appModelRepository.url", "https://github.com/testorg/petclinic-app").PutString("gitOpsRepository.context", "./").PutString("appModelRepository.context", "/"),
 						},
 					},
 				},


### PR DESCRIPTION
ArgoCD app created is falining on:
'rpc error: code = Unknown desc = Manifest generation error (cached): /: app path is absolute'