### PR TITLE
update ci docker image to go 1.17

### DIFF
--- a/.ci/openshift-ci/Dockerfile
+++ b/.ci/openshift-ci/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/redhat-appstudio/e2e-tests:latest as e2e
-FROM registry.ci.openshift.org/openshift/release:golang-1.16
+FROM registry.ci.openshift.org/openshift/release:golang-1.17
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

update ci docker image to go 1.17