### PR TITLE
Add common labels to pipeline run generated by webhook event

### DIFF
--- a/gitops/generate_build.go
+++ b/gitops/generate_build.go
@@ -337,6 +337,7 @@ func GenerateTriggerTemplate(component appstudiov1alpha1.Component, gitopsConfig
 			GenerateName: component.Name + "-",
 			Namespace:    component.Namespace,
 			Annotations:  getBuildCommonLabelsForComponent(&component),
+			Labels:       getBuildCommonLabelsForComponent(&component),
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PipelineRun",


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

This MR adds common set of labels to the PipelineRuns that are created by an event coming from webhook, making labels consistent on initial and even based builds. Also this will allow to do PipelineRuns filtering in build-service.
