### PR TITLE
[DEVHAS-102] Add KCP-specific manifests and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,12 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
+deploy-kcp: install ## Install CRDs and deploy HAS on KCP
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	GITHUB_ORG=${GITHUB_ORG} DEVFILE_REGISTRY_URL=${DEVFILE_REGISTRY_URL} $(KUSTOMIZE) build config/kcp | kubectl apply -f -
+
+undeploy-kcp: # Undeploy HAS from KCP (including CRDs)
+	$(KUSTOMIZE) build config/kcp | kubectl delete -f -
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.

--- a/config/kcp-rbac/application_editor_role.yaml
+++ b/config/kcp-rbac/application_editor_role.yaml
@@ -1,0 +1,27 @@
+# permissions for end users to edit applications.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: application-editor-role
+  labels:
+      rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+      rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - applications
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - applications/status
+  verbs:
+  - get

--- a/config/kcp-rbac/application_viewer_role.yaml
+++ b/config/kcp-rbac/application_viewer_role.yaml
@@ -1,0 +1,22 @@
+# permissions for end users to view applications.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: application-viewer-role
+  labels:
+      rbac.authorization.k8s.io/aggregate-to-view: 'true'
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - applications
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - applications/status
+  verbs:
+  - get

--- a/config/kcp-rbac/component_editor_role.yaml
+++ b/config/kcp-rbac/component_editor_role.yaml
@@ -1,0 +1,27 @@
+# permissions for end users to edit components.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: component-editor-role
+  labels:
+      rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+      rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - components
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - components/status
+  verbs:
+  - get

--- a/config/kcp-rbac/component_viewer_role.yaml
+++ b/config/kcp-rbac/component_viewer_role.yaml
@@ -1,0 +1,22 @@
+# permissions for end users to view components.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: component-viewer-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - components
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - components/status
+  verbs:
+  - get

--- a/config/kcp-rbac/componentdetectionquery_editor_role.yaml
+++ b/config/kcp-rbac/componentdetectionquery_editor_role.yaml
@@ -1,0 +1,27 @@
+# permissions for end users to edit componentdetectionqueries.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: componentdetectionquery-editor-role
+  labels:
+      rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+      rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - componentdetectionqueries
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - componentdetectionqueries/status
+  verbs:
+  - get

--- a/config/kcp-rbac/componentdetectionquery_viewer_role.yaml
+++ b/config/kcp-rbac/componentdetectionquery_viewer_role.yaml
@@ -1,0 +1,22 @@
+# permissions for end users to view componentdetectionqueries.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: componentdetectionquery-viewer-role
+  labels:
+      rbac.authorization.k8s.io/aggregate-to-view: 'true'
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - componentdetectionqueries
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - componentdetectionqueries/status
+  verbs:
+  - get

--- a/config/kcp-rbac/kustomization.yaml
+++ b/config/kcp-rbac/kustomization.yaml
@@ -1,0 +1,25 @@
+resources:
+# All RBAC will be applied under this service account in
+# the deployment namespace. You may comment out this resource
+# if your manager will use a service account that exists at
+# runtime. Be sure to update RoleBinding and ClusterRoleBinding
+# subjects if changing service account names.
+- role.yaml
+- role_binding.yaml
+- leader_election_role.yaml
+- leader_election_role_binding.yaml
+
+# Aggegating roles which are otherwise done by OLM
+- application_editor_role.yaml
+- application_viewer_role.yaml
+- component_editor_role.yaml
+- component_viewer_role.yaml
+- componentdetectionquery_editor_role.yaml
+- componentdetectionquery_viewer_role.yaml
+
+
+## Tekton Builds
+- role_build.yaml
+
+## SPI Roles
+- role_spi.yaml

--- a/config/kcp-rbac/leader_election_role.yaml
+++ b/config/kcp-rbac/leader_election_role.yaml
@@ -1,0 +1,37 @@
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/config/kcp-rbac/leader_election_role_binding.yaml
+++ b/config/kcp-rbac/leader_election_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system

--- a/config/kcp-rbac/manager_webhook_patch.yaml
+++ b/config/kcp-rbac/manager_webhook_patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert

--- a/config/kcp-rbac/role.yaml
+++ b/config/kcp-rbac/role.yaml
@@ -1,0 +1,94 @@
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: manager-role
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - applications
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - applications/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - applications/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - componentdetectionqueries
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - componentdetectionqueries/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - componentdetectionqueries/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - components
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - components/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - components/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/kcp-rbac/role_binding.yaml
+++ b/config/kcp-rbac/role_binding.yaml
@@ -1,0 +1,38 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding-build
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role-build
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding-spi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role-spi
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system

--- a/config/kcp-rbac/role_build.yaml
+++ b/config/kcp-rbac/role_build.yaml
@@ -1,0 +1,56 @@
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-role-build
+rules:
+- verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  apiGroups:
+    - tekton.dev
+  resources:
+    - pipelineruns
+- apiGroups:
+    - triggers.tekton.dev
+  resources:
+    - eventlisteners
+    - triggers
+    - triggertemplates
+  verbs:
+    - create
+    - update
+    - patch
+    - delete
+    - watch
+    - list
+- verbs:
+    - get
+    - list
+    - create
+    - watch
+    - update
+  resources:
+    - persistentvolumeclaims
+    - persistentvolumeclaims/status
+    - secrets
+    - serviceaccounts
+  apiGroups:
+    - ""
+- verbs:
+    - get
+    - list
+    - create
+    - watch
+  resources:
+    - routes
+  apiGroups:
+    - route.openshift.io
+

--- a/config/kcp-rbac/role_spi.yaml
+++ b/config/kcp-rbac/role_spi.yaml
@@ -1,0 +1,24 @@
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-role-spi
+rules:
+- verbs:
+    - '*'
+  apiGroups:
+    - appstudio.redhat.com
+  resources:
+    - spiaccesstokenbindings
+    - spiaccesstokens
+- verbs:
+    - create # allows addition of credentials only.
+    - delete
+    - list
+    - get
+    - watch
+  apiGroups:
+    - ''
+  resources:
+    - secrets

--- a/config/kcp-rbac/service_account.yaml
+++ b/config/kcp-rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-manager
+  namespace: system

--- a/config/kcp-webhooks/kustomization.yaml
+++ b/config/kcp-webhooks/kustomization.yaml
@@ -1,0 +1,40 @@
+# Adds namespace to all resources.
+namespace: application-service-system
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: application-service-
+
+resources:
+- manifests.yaml
+
+bases:
+- ../manager
+
+patchesStrategicMerge:
+- manager_webhook_patch.yaml
+
+- webhookcainjection_patch.yaml
+
+patches:
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/env/-
+      value:
+        name: ENABLE_WEBHOOKS
+        value: "true"
+  target:
+    kind: Deployment
+    name: controller-manager
+
+# HAS on KCP needs to use default service account name right now
+- patch: |-
+    - op: replace
+      path: /spec/template/spec/serviceAccountName
+      value: default
+  target:
+    kind: Deployment
+    name: controller-manager

--- a/config/kcp-webhooks/manager_webhook_patch.yaml
+++ b/config/kcp-webhooks/manager_webhook_patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert

--- a/config/kcp-webhooks/manifests.yaml
+++ b/config/kcp-webhooks/manifests.yaml
@@ -1,0 +1,88 @@
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    url: https://webhook.apps.jcolliermay19.devcluster.openshift.com/mutate-appstudio-redhat-com-v1alpha1-application
+  failurePolicy: Fail
+  name: mapplication.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - applications
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    url: https://webhook.apps.jcolliermay19.devcluster.openshift.com/mutate-appstudio-redhat-com-v1alpha1-component
+  failurePolicy: Fail
+  name: mcomponent.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - components
+  sideEffects: None
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    url: https://webhook.apps.jcolliermay19.devcluster.openshift.com/validate-appstudio-redhat-com-v1alpha1-application
+  failurePolicy: Fail
+  name: vapplication.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - applications
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    url: https://webhook.apps.jcolliermay19.devcluster.openshift.com/validate-appstudio-redhat-com-v1alpha1-component
+  failurePolicy: Fail
+  name: vcomponent.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - components
+  sideEffects: None

--- a/config/kcp-webhooks/manifests.yaml
+++ b/config/kcp-webhooks/manifests.yaml
@@ -10,7 +10,7 @@ webhooks:
   - v1
   - v1beta1
   clientConfig:
-    url: https://webhook.apps.jcolliermay19.devcluster.openshift.com/mutate-appstudio-redhat-com-v1alpha1-application
+    url: <REPLACE_HOST>
   failurePolicy: Fail
   name: mapplication.kb.io
   rules:
@@ -28,7 +28,7 @@ webhooks:
   - v1
   - v1beta1
   clientConfig:
-    url: https://webhook.apps.jcolliermay19.devcluster.openshift.com/mutate-appstudio-redhat-com-v1alpha1-component
+    url: <REPLACE_HOST>
   failurePolicy: Fail
   name: mcomponent.kb.io
   rules:
@@ -54,7 +54,7 @@ webhooks:
   - v1
   - v1beta1
   clientConfig:
-    url: https://webhook.apps.jcolliermay19.devcluster.openshift.com/validate-appstudio-redhat-com-v1alpha1-application
+    url: <REPLACE_HOST>
   failurePolicy: Fail
   name: vapplication.kb.io
   rules:
@@ -72,7 +72,7 @@ webhooks:
   - v1
   - v1beta1
   clientConfig:
-    url: https://webhook.apps.jcolliermay19.devcluster.openshift.com/validate-appstudio-redhat-com-v1alpha1-component
+    url: <REPLACE_HOST>
   failurePolicy: Fail
   name: vcomponent.kb.io
   rules:

--- a/config/kcp-webhooks/manifests.yaml
+++ b/config/kcp-webhooks/manifests.yaml
@@ -10,7 +10,7 @@ webhooks:
   - v1
   - v1beta1
   clientConfig:
-    url: <REPLACE_HOST>
+    url: <REPLACE_HOST>/mutate-appstudio-redhat-com-v1alpha1-application
   failurePolicy: Fail
   name: mapplication.kb.io
   rules:
@@ -28,7 +28,7 @@ webhooks:
   - v1
   - v1beta1
   clientConfig:
-    url: <REPLACE_HOST>
+    url: <REPLACE_HOST>/mutate-appstudio-redhat-com-v1alpha1-component
   failurePolicy: Fail
   name: mcomponent.kb.io
   rules:
@@ -54,7 +54,7 @@ webhooks:
   - v1
   - v1beta1
   clientConfig:
-    url: <REPLACE_HOST>
+    url: <REPLACE_HOST>/validate-appstudio-redhat-com-v1alpha1-application
   failurePolicy: Fail
   name: vapplication.kb.io
   rules:
@@ -72,7 +72,7 @@ webhooks:
   - v1
   - v1beta1
   clientConfig:
-    url: <REPLACE_HOST>
+    url: <REPLACE_HOST>/validate-appstudio-redhat-com-v1alpha1-component
   failurePolicy: Fail
   name: vcomponent.kb.io
   rules:

--- a/config/kcp-webhooks/webhookcainjection_patch.yaml
+++ b/config/kcp-webhooks/webhookcainjection_patch.yaml
@@ -1,0 +1,15 @@
+# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"

--- a/config/kcp/kustomization.yaml
+++ b/config/kcp/kustomization.yaml
@@ -1,0 +1,40 @@
+# Adds namespace to all resources.
+namespace: application-service-system
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: application-service-
+
+# Labels to add to all resources and selectors.
+#commonLabels:
+#  someName: someValue
+
+bases:
+- ../crd
+- ../manager
+- ../rbac
+
+patches:
+# Disable webhooks by default on KCP
+# Webhooks can be optionally enabled after deploy
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/env/-
+      value:
+        name: ENABLE_WEBHOOKS
+        value: "false"
+  target:
+    kind: Deployment
+    name: controller-manager
+
+# HAS on KCP needs to use default service account name right now
+- patch: |-
+    - op: replace
+      path: /spec/template/spec/serviceAccountName
+      value: default
+  target:
+    kind: Deployment
+    name: controller-manager

--- a/config/kcp/webhookcainjection_patch.yaml
+++ b/config/kcp/webhookcainjection_patch.yaml
@@ -1,0 +1,15 @@
+# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"

--- a/docs/kcp-webhooks.md
+++ b/docs/kcp-webhooks.md
@@ -1,0 +1,81 @@
+# Webhooks on KCP
+
+By default, the KCP-specific kustomize manifests under `config/kcp` do **not** deploy HAS with webhooks. 
+
+At this point in time, Webhooks on KCP need to be exposed over a Route / Ingress URL. The following instructions outline how to do that.
+
+  - At least, on an OpenShift workload cluster. If you're running HAS on a non-OpenShift workload cluster, these steps will differ.
+
+## Prereqs:
+
+- [OpenShift Acme installed](https://developer.ibm.com/tutorials/secure-red-hat-openshift-routes-with-lets-encrypt) on the workload cluster
+  - cert-manager w/ let's encrypt should also work if you're using non-OpenShift clusters
+
+## Steps:
+
+On the KCP side-of-things:
+
+1) Follow the [HAS on KCP](./kcp.md) doc to install HAS on KCP.
+
+Next, switch to the workload cluster:
+
+2) Find the namespace on the workload cluster where KCP synced HAS to. It should look something like `kcp1b06ba2d907942fa826c1c66e7eb185b2708dd4b69770069eaa470b8`
+
+   - Validate that this is the namespace where HAS got synced to, by seeing if there are running pods in the namespace
+   - For convenience with the following commands run `export KCP_NAMESPACE=<your-kcp-namespace>`
+
+2) `oc apply -f hack/kcp/webhook-service.yaml -n $KCP_NAMESPACE` to create the Service exposing the webhook service
+
+3) A secret, `webhook-server-cert` should have been created in the same namespace. Run `oc extract secret/webhook-server-cert -n $KCP_NAMESPACE` to retrieve the TLS certificates for the webhook service.
+
+4) Copy the contents of the `tls.crt` file.
+
+5) Open `hack/kcp/webhook-route.yaml` in an editor and make the following changes: 
+  - Replace the `<REPLACE_CERT>` with the TLS Certificate retrieved from the previous step. 
+  - Replace the `<REPLACE_HOST>` with a valid Route hostname (e.g. webhook.apps.myopenshiftcluster.com). We are not using generated hostnames because the generated hostname is too long (> 63 characters) because of the kcp namespace length.
+  
+    It should look something like this:
+   
+    ```
+    kind: Route
+    apiVersion: route.openshift.io/v1
+    metadata:
+      name: webhook-route
+      annotations:
+        kubernetes.io/tls-acme: 'true'
+    spec:
+      host: $REPLACE_HOST
+      to:
+        kind: Service
+        name: webhook-service
+        weight: 100
+      port:
+        targetPort: 9443
+      tls:
+        termination: reencrypt
+        destinationCACertificate: |
+          -----BEGIN CERTIFICATE-----
+          FAKECERTIFICATE1
+          -----END CERTIFICATE-----
+          -----BEGIN CERTIFICATE-----
+          FAKECERTIFICATE2
+          -----END CERTIFICATE-----
+        insecureEdgeTerminationPolicy: None
+      wildcardPolicy: None
+      ```
+    
+5) `oc apply -f hack/kcp/webhook-route.yaml -n $KCP_NAMESPACE` to create the route
+  
+    - *NOTE:* You must make sure the generated url for the Route is less than 63 characters, or else OpenShift Acme's cert generation *will* fail. 
+  
+    - If the generated route url is over 63 characters, modify it to be shorter.
+
+6) Access the Route URL in your browser and verify that publicly signed certificates are being used.
+
+Next, switch back to KCP and do the following
+
+7) Open `config/kcp-webhook/manifests.yaml` in an editor and change all occurrences of `<REPLACE_ME>` to the exposed Route URL from the previous step
+
+    - There should be 4 occurrences that need to be changed.
+
+8) Run `kustomize build config/kcp-webhook | kubectl apply -f -` to deploy the webhooks

--- a/docs/kcp-webhooks.md
+++ b/docs/kcp-webhooks.md
@@ -74,7 +74,7 @@ Next, switch to the workload cluster:
 
 Next, switch back to KCP and do the following
 
-7) Open `config/kcp-webhook/manifests.yaml` in an editor and change all occurrences of `<REPLACE_ME>` to the exposed Route URL from the previous step
+7) Open `config/kcp-webhook/manifests.yaml` in an editor and change all occurrences of `<REPLACE_HOST>` to the exposed Route URL from the previous step
 
     - There should be 4 occurrences that need to be changed.
 

--- a/docs/kcp.md
+++ b/docs/kcp.md
@@ -22,7 +22,7 @@ where `$TOKEN` is the GitHub token to be used with HAS, as described [here](http
 To deploy HAS on KCP, just run:
 
 ```bash
-kustomize build config/kcp | kubectl apply -f -
+make deploy-kcp
 ```
 
 Next, run `kubectl get deploy -n application-service-system` to validate that HAS was successfully deployed and synced to the workload cluster.

--- a/hack/kcp/webhook-route.yaml
+++ b/hack/kcp/webhook-route.yaml
@@ -1,0 +1,21 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: webhook-route
+  annotations:
+    kubernetes.io/tls-acme: 'true'
+spec:
+  to:
+    kind: Service
+    name: webhook-service
+    weight: 100
+  port:
+    targetPort: 9443
+  tls:
+    termination: reencrypt
+    destinationCACertificate: |
+      -----BEGIN CERTIFICATE-----
+      FAKECERTIFICATE
+      -----END CERTIFICATE-----
+    insecureEdgeTerminationPolicy: None
+  wildcardPolicy: None

--- a/hack/kcp/webhook-route.yaml
+++ b/hack/kcp/webhook-route.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: 'true'
 spec:
+  host: <REPLACE_HOST>
   to:
     kind: Service
     name: webhook-service
@@ -14,8 +15,6 @@ spec:
   tls:
     termination: reencrypt
     destinationCACertificate: |
-      -----BEGIN CERTIFICATE-----
-      FAKECERTIFICATE
-      -----END CERTIFICATE-----
+      <REPLACE_CERT>
     insecureEdgeTerminationPolicy: None
   wildcardPolicy: None

--- a/hack/kcp/webhook-service.yaml
+++ b/hack/kcp/webhook-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    control-plane: controller-manager


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/DEVHAS-102

This PR adds the following manifests for running HAS on KCP:

- `config/kcp` 
  - Deploys HAS on KCP without webhooks.
- `config/kcp-webhooks`
  - Enables webhooks for HAS on KCP
  - **Note:** Enabling webhooks is still a bit of a manual process even with this Kustomize manifest, and the `kcp-webhooks.md` doc that I am adding **must** be followed when enabling webhooks
- `config/kcp-rbac`
  - A copy of `config/rbac` with certain manifests removed that were not needed for KCP
  

The following docs have been modified or added
- `docs/kcp.md`
    - Covers how to run KCP on a managed instance of KCP (e.g. kcp-stable or kcp-unstable)
- `docs/kcp-webhooks.md`
     - Covers how to enable webhooks for HAS, _after_ installing HAS on KCP
- `docs/kcp-old.md` (formerly `kcp.md`) 
    - The now former kcp doc. Instead of removing it, I opted to keep it, as it contains useful information on running HAS on a **local** instance of KCP

**How to Test?**
1) Get yourself access to a managed KCP instance (as of right now, `kcp-unstable` must be used)
2) Checkout my changes
3) Follow the instructions in `./docs/kcp.md` to install HAS on KCP
   - After deploy on kcp-unstable, HAS may be stuck crashlooping. If so, do the following:
       - `kubectl edit deploy <deploy> -n $KCP_NAMESPACE`
       - Remove the following from the deployment:
          ```
          - configMap:
              items:
              - key: ca.crt
                path: ca.crt
              name: kcp-root-ca.crt
          ```