### PR TITLE
Ignore component image commit hash in tag

### DIFF
--- a/gitops/generate_build_test.go
+++ b/gitops/generate_build_test.go
@@ -88,7 +88,7 @@ func TestNormalizeOutputImageURL(t *testing.T) {
 			args: args{
 				outputImage: "quay.io/foo/bar",
 			},
-			want: "quay.io/foo/bar:$(tt.params.git-revision)",
+			want: "quay.io/foo/bar:latest-$(tt.params.git-revision)",
 		},
 		{
 			name: "fully qualified url",
@@ -96,6 +96,13 @@ func TestNormalizeOutputImageURL(t *testing.T) {
 				outputImage: "quay.io/foo/bar:latest",
 			},
 			want: "quay.io/foo/bar:latest-$(tt.params.git-revision)",
+		},
+		{
+			name: "contains git revision suffix in tag",
+			args: args{
+				outputImage: "quay.io/foo/bar:tag-29b0823364ba05bd5a9d3a89d4e6cad57d2d3723",
+			},
+			want: "quay.io/foo/bar:tag-$(tt.params.git-revision)",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

#### What this MR does?
When generating TriggerTemplate for the component, ignore git revision hash suffix in the image tag.
Also, it aligns default to `latest` to have compatible with docker behavior.

#### Why this change is needed?
When a new version of component image is built, it is automatically put into component's spec, so the change is reflected in gitops resources and in the component's deployment in the cluster.
Before this change, image in the TriggerTemplate had the following structure: `image-$(tt.params.git-revision)`. That worked fine for the first build, but then the image became `image-sha1234` and on the next build it turns into `image-sha1234-$(tt.params.git-revision)` and so on (until max tag lengths is reached).
To fix the problem above, it's proposed to ignore git revision suffix for the TriggerTemplate, so all new builds will have `image-$(tt.params.git-revision)` pattern.

