### PR TITLE
Fix GitOps generation error message

### DIFF
--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -339,7 +339,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			if err := r.generateGitops(ctx, &component); err != nil {
 				errMsg := fmt.Sprintf("Unable to generate gitops resources for component %v", req.NamespacedName)
 				log.Error(err, errMsg)
-				r.SetCreateConditionAndUpdateCR(ctx, &component, fmt.Errorf(errMsg))
+				r.SetCreateConditionAndUpdateCR(ctx, &component, fmt.Errorf("%v: %v", errMsg, err))
 				return ctrl.Result{}, nil
 			}
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/DEVHAS-116

Surfaces the full error message in the Component status condition when gitops generation fails.