### PR TITLE
Inceasing common storage to 1GB

### DIFF
--- a/gitops/generate_build.go
+++ b/gitops/generate_build.go
@@ -334,7 +334,7 @@ func GenerateCommonStorage(component appstudiov1alpha1.Component, name string) *
 			},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					"storage": resource.MustParse("10Mi"),
+					"storage": resource.MustParse("1Gi"),
 				},
 			},
 			VolumeMode: &fsMode,


### PR DESCRIPTION
10MB is not enough to run builds. Increasing to 1GB.

Currently it works because value is overridden in https://github.com/redhat-appstudio/build-service/blob/c77a839b79d26bd1c27d0802e45fc9b558a5f1b7/controllers/component_build_controller.go#L162