### PR TITLE
[DEVHAS-134] Sanitize Git error messages

### DIFF
--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -475,8 +475,9 @@ func (r *ComponentReconciler) generateGitops(ctx context.Context, component *app
 
 	err = gitops.GenerateAndPush(tempDir, remoteURL, *component, r.Executor, r.AppFS, gitOpsBranch, gitOpsContext, gitopsConfig)
 	if err != nil {
-		log.Error(err, "unable to generate gitops resources due to error")
-		return err
+		gitOpsErr := util.SanitizeErrorMessage(err)
+		log.Error(gitOpsErr, "unable to generate gitops resources due to error")
+		return gitOpsErr
 	}
 
 	// Remove the temp folder that was created

--- a/controllers/component_controller_finalizer.go
+++ b/controllers/component_controller_finalizer.go
@@ -24,6 +24,7 @@ import (
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
 	"github.com/redhat-appstudio/application-service/gitops"
 	devfile "github.com/redhat-appstudio/application-service/pkg/devfile"
+	"github.com/redhat-appstudio/application-service/pkg/util"
 	"github.com/redhat-appstudio/application-service/pkg/util/ioutils"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/yaml"
@@ -105,7 +106,8 @@ func (r *ComponentReconciler) Finalize(ctx context.Context, component *appstudio
 
 	err = gitops.RemoveAndPush(tempDir, remoteURL, *component, r.Executor, r.AppFS, gitOpsBranch, gitOpsContext)
 	if err != nil {
-		return err
+		gitOpsErr := util.SanitizeErrorMessage(err)
+		return gitOpsErr
 	}
 
 	err = r.AppFS.RemoveAll(tempDir)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -131,6 +131,13 @@ func CloneRepo(clonePath, repoURL string, token string) error {
 	return nil
 }
 
+// SanitizeErrorMessage takes in a given error message and returns a new, santized error with things like tokens, removed
+func SanitizeErrorMessage(err error) error {
+	reg := regexp.MustCompile(`ghp_[a-z0-9]*`)
+	newErrMsg := reg.ReplaceAllString(err.Error(), "<TOKEN>")
+	return fmt.Errorf(newErrMsg)
+}
+
 // CheckWithRegex checks if a name matches the pattern.
 // If a pattern fails to compile, it returns false
 func CheckWithRegex(pattern, name string) bool {


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/DEVHAS-134

Adds a new util function (+ tests) for sanitizing error messages. Can expand in the future as needed. Updates the Component controller to call this function before reporting errors from the gitops library.