### PR TITLE
Use the Component revision

### DIFF
--- a/gitops/generate_build.go
+++ b/gitops/generate_build.go
@@ -234,7 +234,7 @@ func normalizeOutputImageURL(outputImage string) string {
 // is that the git revision appended to the output image tag in case of webhook build.
 func getParamsForComponentBuild(component appstudiov1alpha1.Component, isInitialBuild bool) ([]tektonapi.Param, error) {
 	sourceCode := component.Spec.Source.GitSource.URL
-	revision := component.Spec.Source.GitSource.Revision 
+	revision := component.Spec.Source.GitSource.Revision
 	outputImage := component.Spec.ContainerImage
 	var err error
 
@@ -265,14 +265,14 @@ func getParamsForComponentBuild(component appstudiov1alpha1.Component, isInitial
 	}
 	// if revision is specified in the component
 	// use it in the parms to the Pipeline Run
-	if revision != "" { 
+	if revision != "" {
 		params = append(params, tektonapi.Param{
 			Name: "revision",
 			Value: tektonapi.ArrayOrString{
 				Type:      tektonapi.ParamTypeString,
 				StringVal: revision,
 			},
-		}) 
+		})
 	}
 	// Analyze component model for additional parameters
 	if componentDevfileData, err := devfile.ParseDevfileModel(component.Status.Devfile); err == nil {

--- a/gitops/generate_build.go
+++ b/gitops/generate_build.go
@@ -234,6 +234,7 @@ func normalizeOutputImageURL(outputImage string) string {
 // is that the git revision appended to the output image tag in case of webhook build.
 func getParamsForComponentBuild(component appstudiov1alpha1.Component, isInitialBuild bool) ([]tektonapi.Param, error) {
 	sourceCode := component.Spec.Source.GitSource.URL
+	revision := component.Spec.Source.GitSource.Revision 
 	outputImage := component.Spec.ContainerImage
 	var err error
 
@@ -262,7 +263,17 @@ func getParamsForComponentBuild(component appstudiov1alpha1.Component, isInitial
 			},
 		},
 	}
-
+	// if revision is specified in the component
+	// use it in the parms to the Pipeline Run
+	if revision != "" { 
+		params = append(params, tektonapi.Param{
+			Name: "revision",
+			Value: tektonapi.ArrayOrString{
+				Type:      tektonapi.ParamTypeString,
+				StringVal: revision,
+			},
+		}) 
+	}
 	// Analyze component model for additional parameters
 	if componentDevfileData, err := devfile.ParseDevfileModel(component.Status.Devfile); err == nil {
 

--- a/gitops/generate_build_test.go
+++ b/gitops/generate_build_test.go
@@ -703,6 +703,51 @@ func TestGetParamsForComponentBuild(t *testing.T) {
 		},
 
 		{
+			name:           "Use Image as is, ensure revision is set",
+			IsInitialBuild: true,
+			component: appstudiov1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testcomponent",
+					Namespace: "kcpworkspacename",
+				},
+				Spec: appstudiov1alpha1.ComponentSpec{
+					ContainerImage: "whatever-is-set",
+					Source: appstudiov1alpha1.ComponentSource{
+						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
+							GitSource: &appstudiov1alpha1.GitSource{
+								URL:      "https://a/b/c",
+								Revision: "master",
+							},
+						},
+					},
+				},
+			},
+			want: []tektonapi.Param{
+				{
+					Name: "git-url",
+					Value: tektonapi.ArrayOrString{
+						Type:      tektonapi.ParamTypeString,
+						StringVal: "https://a/b/c",
+					},
+				},
+				{
+					Name: "output-image",
+					Value: tektonapi.ArrayOrString{
+						Type:      tektonapi.ParamTypeString,
+						StringVal: "whatever-is-set",
+					},
+				},
+				{
+					Name: "revision",
+					Value: tektonapi.ArrayOrString{
+						Type:      tektonapi.ParamTypeString,
+						StringVal: "master",
+					},
+				},
+			},
+		},
+
+		{
 			name:    "default repo mismatched user error on non initial build",
 			wantErr: true,
 			want:    []tektonapi.Param{},


### PR DESCRIPTION
This PR contains a fix for Components where the default branch is other than `main` and is specified in the the Component Spec as part of the source git reference

The repository https://github.com/Apicurio/apicurio-registry uses `master` instead of main but the reference in the component is ignored when a build is created and the build fails. This PR adds a check to setthe revision into the pipeline run if it is set in the component. 

Example (note the `revision: master`) 
```
apiVersion: appstudio.redhat.com/v1alpha1
kind: Component
metadata:
  name: service-registry
spec:
  componentName: service-registry
  application: service-registry
  containerImage: quay.io/jduimovich0/service-registry
  source:
    git:
      url: https://github.com/Apicurio/apicurio-registry
      revision: master
      devfileUrl: https://raw.githubusercontent.com/jduimovich/appstudio-e2e-demos/main/demos/service-registry/devfiles/devfile.yaml
  build:
    containerImage: quay.io/jduimovich0/service-registry:1
```
 
 The application definition for the above component.  It will fail to build as the default will checkout `main`, instead of `master`. 
```
apiVersion: appstudio.redhat.com/v1alpha1
kind: Application
metadata:
  name: service-registry 
spec:
  description: "service-registry built in App Studio"
  displayName: service-registry
```

To test, rebuild both application-service and build-service as the code is shared in both and create a Component using the above as an example build. 
