### PR TITLE
Do not attempt to get tekton event listener route if pipelines as code is used

### DIFF
--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -404,7 +404,8 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Get the Webhook from the event listener route and update it
 	// Only attempt to get it if the build generation succeeded, otherwise the route won't exist
 	if len(component.Status.Conditions) > 0 && component.Status.Conditions[len(component.Status.Conditions)-1].Status == metav1.ConditionTrue &&
-		component.Spec.Source.GitSource != nil && component.Spec.Source.GitSource.URL != "" {
+		component.Spec.Source.GitSource != nil && component.Spec.Source.GitSource.URL != "" &&
+		(component.ObjectMeta.Annotations == nil || component.ObjectMeta.Annotations[gitops.PaCAnnotation] != "1") {
 		createdWebhook := &routev1.Route{}
 		err = r.Client.Get(ctx, types.NamespacedName{Name: "el" + component.Name, Namespace: component.Namespace}, createdWebhook)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

This PR adds fix for https://github.com/redhat-appstudio/application-service/pull/136 that prevents awaiting for tekton event listener route (which is not created) if pipelines as code is used.
Fixes errors in logs:
```
1.6572909153280342e+09	ERROR	controllers.Component	Unable to fetch the created webhook el-devfile-sample-go-basic, retrying	{"Component": "default/devfile-sample-go-basic", "error": "Route.route.openshift.io \"eldevfile-sample-go-basic\" not found"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:114
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:311
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:227
```