### PR TITLE
Command 'make build' not downloading dependencies.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef


### PR DESCRIPTION
When running the command `make build` or `make test`, no dependencies are downloaded. Fixing the issue by replacing 'go get' to 'go install'.