### PR TITLE
Do not add `appstudio` pvc to gitops

### DIFF
--- a/gitops/generate.go
+++ b/gitops/generate.go
@@ -64,7 +64,6 @@ func Generate(fs afero.Afero, gitOpsFolder string, outputFolder string, componen
 		resources[routeFileName] = route
 	}
 
-	var commonStorage *corev1.PersistentVolumeClaim
 	if component.Spec.Source.GitSource != nil && component.Spec.Source.GitSource.URL != "" {
 		tektonResourcesDirName := ".tekton"
 		k.AddResources(tektonResourcesDirName + "/")
@@ -72,9 +71,6 @@ func Generate(fs afero.Afero, gitOpsFolder string, outputFolder string, componen
 		if err := GenerateBuild(fs, filepath.Join(outputFolder, tektonResourcesDirName), component, gitopsConfig); err != nil {
 			return err
 		}
-
-		// Generate the common pvc for git components, and place it at application-level in the repository
-		commonStorage = GenerateCommonStorage(component, "appstudio")
 	}
 
 	resources[kustomizeFileName] = k
@@ -85,7 +81,7 @@ func Generate(fs afero.Afero, gitOpsFolder string, outputFolder string, componen
 	}
 
 	// Re-generate the parent kustomize file and return
-	return GenerateParentKustomize(fs, gitOpsFolder, commonStorage)
+	return GenerateParentKustomize(fs, gitOpsFolder)
 }
 
 // GenerateOverlays generates the overlays dir from a given BindingComponent
@@ -115,8 +111,7 @@ func GenerateOverlays(fs afero.Afero, gitOpsFolder string, outputFolder string, 
 
 // GenerateParentKustomize takes in a folder of components, and outputs a kustomize file to the outputFolder dir
 // containing entries for each Component.
-// If commonStoragePVC is non-nil, it will also add the common storage pvc yaml file to the parent kustomize. If it's nil, it will not be added
-func GenerateParentKustomize(fs afero.Afero, gitOpsFolder string, commonStoragePVC *corev1.PersistentVolumeClaim) error {
+func GenerateParentKustomize(fs afero.Afero, gitOpsFolder string) error {
 	componentsFolder := filepath.Join(gitOpsFolder, "components")
 	k := resources.Kustomization{
 		Kind:       "Kustomization",
@@ -133,21 +128,6 @@ func GenerateParentKustomize(fs afero.Afero, gitOpsFolder string, commonStorageP
 		if file.IsDir() {
 			k.AddBases(filepath.Join("components", file.Name(), "base"))
 		}
-	}
-
-	// if the common storage PVC yaml file was passed in, write to disk and add it to the parent kustomize file
-	if commonStoragePVC != nil {
-		resources["common-storage-pvc.yaml"] = commonStoragePVC
-		k.AddResources("common-storage-pvc.yaml")
-	}
-
-	// if the common storage PVC already exist, make sure too add it to the parent kustomize file
-	commonStorageExist, err := fs.Exists(filepath.Join(gitOpsFolder, "common-storage-pvc.yaml"))
-	if err != nil {
-		return err
-	}
-	if commonStorageExist {
-		k.AddResources("common-storage-pvc.yaml")
 	}
 
 	resources[kustomizeFileName] = k

--- a/gitops/generate_test.go
+++ b/gitops/generate_test.go
@@ -574,7 +574,6 @@ func TestGenerateRoute(t *testing.T) {
 
 func TestGenerateParentKustomize(t *testing.T) {
 	fs := ioutils.NewMemoryFilesystem()
-	readOnlyDir := ioutils.NewReadOnlyFs()
 
 	// Prepopulate the fs with components
 	gitOpsFolder := "/tmp/gitops"
@@ -587,44 +586,18 @@ func TestGenerateParentKustomize(t *testing.T) {
 	tests := []struct {
 		name    string
 		fs      afero.Afero
-		pvc     *corev1.PersistentVolumeClaim
 		wantErr bool
 	}{
 		{
-			name:    "Simple gitops repo with 3 components - no pvc",
+			name:    "Simple gitops repo with 3 components",
 			fs:      fs,
 			wantErr: false,
-		},
-		{
-			name:    "Simple gitops repo with 3 components, no pvc - generation failure",
-			fs:      readOnlyDir,
-			wantErr: true,
-		},
-		{
-			name: "Simple gitops repo with 3 components - with pvc",
-			fs:   fs,
-			pvc: &corev1.PersistentVolumeClaim{
-				ObjectMeta: v1.ObjectMeta{
-					Name: "test",
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "Simple gitops repo with 3 components, wth pvc - generation failure",
-			fs:   readOnlyDir,
-			pvc: &corev1.PersistentVolumeClaim{
-				ObjectMeta: v1.ObjectMeta{
-					Name: "test",
-				},
-			},
-			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := GenerateParentKustomize(tt.fs, gitOpsFolder, tt.pvc)
+			err := GenerateParentKustomize(tt.fs, gitOpsFolder)
 
 			if tt.wantErr != (err != nil) {
 				t.Errorf("unexpected error return value. Got %v", err)
@@ -652,20 +625,6 @@ func TestGenerateParentKustomize(t *testing.T) {
 				// There should be 3 entries in the kustomization file
 				if len(k.Bases) != 3 {
 					t.Errorf("expected %v kustomization bases, got %v", 3, len(k.Bases))
-				}
-
-				// Test that the common storage pvc was added when appropriate
-				if tt.pvc != nil {
-					if len(k.Resources) != 1 {
-						t.Errorf("expected %v kustomization resources, got %v", 1, len(k.Resources))
-					}
-					if k.Resources[0] != "common-storage-pvc.yaml" {
-						t.Errorf("expected common storage pvc path %v, got %v", "common-storage-pvc.yaml", k.Resources[0])
-					}
-				} else {
-					if len(k.Resources) != 0 {
-						t.Errorf("expected %v kustomization resources, got %v", 0, len(k.Resources))
-					}
 				}
 
 				// Validate that the APIVersion and Kind are set properly

--- a/gitops/gitops.go
+++ b/gitops/gitops.go
@@ -24,12 +24,11 @@ import (
 	"github.com/redhat-appstudio/application-service/gitops/prepare"
 	appstudioshared "github.com/redhat-appstudio/managed-gitops/appstudio-shared/apis/appstudio.redhat.com/v1alpha1"
 	"github.com/spf13/afero"
-	corev1 "k8s.io/api/core/v1"
 )
 
 type Executor interface {
 	Execute(baseDir, command string, args ...string) ([]byte, error)
-	GenerateParentKustomize(fs afero.Afero, gitOpsFolder string, commonStoragePVC *corev1.PersistentVolumeClaim) error
+	GenerateParentKustomize(fs afero.Afero, gitOpsFolder string) error
 }
 
 // GenerateAndPush takes in the following args and generates the gitops resources for a given component
@@ -162,7 +161,7 @@ func RemoveAndPush(outputPath string, remote string, component appstudiov1alpha1
 	if out, err := e.Execute(repoPath, "rm", "-rf", componentPath); err != nil {
 		return fmt.Errorf("failed to delete %q folder in repository in %q %q: %s", componentPath, repoPath, string(out), err)
 	}
-	if err := e.GenerateParentKustomize(appFs, gitopsFolder, nil); err != nil {
+	if err := e.GenerateParentKustomize(appFs, gitopsFolder); err != nil {
 		return fmt.Errorf("failed to re-generate the gitops resources in %q for component %q: %s", componentPath, componentName, err)
 	}
 
@@ -202,6 +201,6 @@ func (e CmdExecutor) Execute(baseDir, command string, args ...string) ([]byte, e
 	return output, err
 }
 
-func (e CmdExecutor) GenerateParentKustomize(fs afero.Afero, gitOpsFolder string, commonStoragePVC *corev1.PersistentVolumeClaim) error {
-	return GenerateParentKustomize(fs, gitOpsFolder, commonStoragePVC)
+func (e CmdExecutor) GenerateParentKustomize(fs afero.Afero, gitOpsFolder string) error {
+	return GenerateParentKustomize(fs, gitOpsFolder)
 }

--- a/gitops/testutils/testutils.go
+++ b/gitops/testutils/testutils.go
@@ -22,8 +22,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/afero"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
 type MockExecutor struct {
@@ -51,7 +49,7 @@ func (m *MockExecutor) Execute(basedir, command string, args ...string) ([]byte,
 	return m.Outputs.Pop(), m.Errors.Pop()
 }
 
-func (m *MockExecutor) GenerateParentKustomize(fs afero.Afero, gitOpsFolder string, commonStoragePVC *corev1.PersistentVolumeClaim) error {
+func (m *MockExecutor) GenerateParentKustomize(fs afero.Afero, gitOpsFolder string) error {
 	return m.Errors.Pop()
 }
 


### PR DESCRIPTION
If a namespace has two or more AppStudio applications, and one of them gets deleted, the `appstudio` volume is switched into deletion state. Such behavior causes some errors for the others components. To avoid this problem, we do not manage `appstudio` pvc via gitops, but create it from build-service operator.