### PR TITLE
remove ReleaseStrategies

### DIFF
--- a/api/v1alpha1/component_types.go
+++ b/api/v1alpha1/component_types.go
@@ -85,9 +85,6 @@ type ComponentSpec struct {
 	// Source describes the Component source
 	Source ComponentSource `json:"source,omitempty"`
 
-	// List of references to ReleaseStrategies to use when releasing the component
-	ReleaseStrategies []string `json:"releaseStrategies,omitempty"`
-
 	// Compute Resources required by this component
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -380,11 +380,6 @@ func (in *ComponentSourceUnion) DeepCopy() *ComponentSourceUnion {
 func (in *ComponentSpec) DeepCopyInto(out *ComponentSpec) {
 	*out = *in
 	in.Source.DeepCopyInto(&out.Source)
-	if in.ReleaseStrategies != nil {
-		in, out := &in.ReleaseStrategies, &out.ReleaseStrategies
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	in.Resources.DeepCopyInto(&out.Resources)
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env

--- a/bundle/manifests/appstudio.redhat.com_componentdetectionqueries.yaml
+++ b/bundle/manifests/appstudio.redhat.com_componentdetectionqueries.yaml
@@ -215,12 +215,6 @@ spec:
                             - name
                             type: object
                           type: array
-                        releaseStrategies:
-                          description: List of references to ReleaseStrategies to
-                            use when releasing the component
-                          items:
-                            type: string
-                          type: array
                         replicas:
                           description: The number of replicas to deploy the component
                             with

--- a/bundle/manifests/appstudio.redhat.com_components.yaml
+++ b/bundle/manifests/appstudio.redhat.com_components.yaml
@@ -167,12 +167,6 @@ spec:
                   - name
                   type: object
                 type: array
-              releaseStrategies:
-                description: List of references to ReleaseStrategies to use when releasing
-                  the component
-                items:
-                  type: string
-                type: array
               replicas:
                 description: The number of replicas to deploy the component with
                 type: integer

--- a/config/crd/bases/appstudio.redhat.com_componentdetectionqueries.yaml
+++ b/config/crd/bases/appstudio.redhat.com_componentdetectionqueries.yaml
@@ -217,12 +217,6 @@ spec:
                             - name
                             type: object
                           type: array
-                        releaseStrategies:
-                          description: List of references to ReleaseStrategies to
-                            use when releasing the component
-                          items:
-                            type: string
-                          type: array
                         replicas:
                           description: The number of replicas to deploy the component
                             with

--- a/config/crd/bases/appstudio.redhat.com_components.yaml
+++ b/config/crd/bases/appstudio.redhat.com_components.yaml
@@ -159,12 +159,6 @@ spec:
                   - name
                   type: object
                 type: array
-              releaseStrategies:
-                description: List of references to ReleaseStrategies to use when releasing
-                  the component
-                items:
-                  type: string
-                type: array
               replicas:
                 description: The number of replicas to deploy the component with
                 type: integer

--- a/config/kcp/apiexport_has.yaml
+++ b/config/kcp/apiexport_has.yaml
@@ -7,6 +7,6 @@ metadata:
   name: has
 spec:
   latestResourceSchemas:
-    - v202207121506.applications.appstudio.redhat.com
-    - v202207121506.componentdetectionqueries.appstudio.redhat.com
-    - v202207121506.components.appstudio.redhat.com
+    - v202208112106.applications.appstudio.redhat.com
+    - v202208112106.componentdetectionqueries.appstudio.redhat.com
+    - v202208112106.components.appstudio.redhat.com

--- a/config/kcp/apiresourceschema_has.yaml
+++ b/config/kcp/apiresourceschema_has.yaml
@@ -5,7 +5,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202207121506.applications.appstudio.redhat.com
+  name: v202208112106.applications.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -179,7 +179,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202207121506.componentdetectionqueries.appstudio.redhat.com
+  name: v202208112106.componentdetectionqueries.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -387,12 +387,6 @@ spec:
                           - name
                           type: object
                         type: array
-                      releaseStrategies:
-                        description: List of references to ReleaseStrategies to use
-                          when releasing the component
-                        items:
-                          type: string
-                        type: array
                       replicas:
                         description: The number of replicas to deploy the component
                           with
@@ -572,7 +566,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202207121506.components.appstudio.redhat.com
+  name: v202208112106.components.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -722,12 +716,6 @@ spec:
                 required:
                 - name
                 type: object
-              type: array
-            releaseStrategies:
-              description: List of references to ReleaseStrategies to use when releasing
-                the component
-              items:
-                type: string
               type: array
             replicas:
               description: The number of replicas to deploy the component with


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

`ReleaseStrategies` in component spec was moved in https://github.com/redhat-appstudio/application-service/pull/95
but accidentally being added back after that. removing the field