### PR TITLE
[DEVHAS-151] Add PermissionClaims for HAS ApiExports

### DIFF
--- a/config/kcp/apiexport_has.yaml
+++ b/config/kcp/apiexport_has.yaml
@@ -4,8 +4,18 @@
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIExport
 metadata:
-  name: has
+  name: apiexport-identity-has
 spec:
+  permissionClaims:
+  - group: ""
+    resource: "secrets"
+    verbs: ["get", "list", "watch"]
+  - group: ""
+    resource: "configmaps"
+    verbs: ["get", "list", "watch"]
+  - group: "route.openshift.io"
+    resource: "routes"
+    verbs: ["get", "list", "watch"]
   latestResourceSchemas:
     - v202207121506.applications.appstudio.redhat.com
     - v202207121506.componentdetectionqueries.appstudio.redhat.com

--- a/hack/generate-kcp-api.sh
+++ b/hack/generate-kcp-api.sh
@@ -45,13 +45,24 @@ fi
 
 
 # now create APIExport and link all created APIResourceSchemas there
+# ToDo: Figure out better way of including permission claims
 KCP_API_EXPORT_FILE="${KCP_API_DIR}/apiexport_has.yaml"
 cat << EOF > ${KCP_API_EXPORT_FILE}
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIExport
 metadata:
-  name: has
+  name: apiexport-identity-has
 spec:
+  permissionClaims:
+  - group: ""
+    resource: "secrets"
+    verbs: ["get", "list", "watch"]
+  - group: ""
+    resource: "configmaps"
+    verbs: ["get", "list", "watch"]
+  - group: "route.openshift.io"
+    resource: "routes"
+    verbs: ["get", "list", "watch"]
   latestResourceSchemas:
 EOF
 


### PR DESCRIPTION
Updates the KCP API generator script to include Permission Claims for the non-KCP dependencies that HAS has (secrets, routes, configmaps). Also updated the APIExport for HAS to the preferred format (`appstudio-identity-<component-name>`)