### PR TITLE
Use Go 1.18 in GitHub workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -88,9 +88,9 @@ jobs:
             git --no-pager diff
             exit 1
           fi
-      - uses: dominikh/staticcheck-action@v1.1.0
+      - uses: dominikh/staticcheck-action@v1.2.0
         with:
-          version: "2021.1.2"
+          version: "2022.1"
           install-go: false
       - name: Check manifests
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -78,8 +78,8 @@ jobs:
           fi
       - name: Check format
         run: |
-          go get -u github.com/google/addlicense
-          go get -u golang.org/x/tools/cmd/goimports
+          go install github.com/google/addlicense@lateset
+          go install golang.org/x/tools/cmd/goimports@latest
           git reset HEAD --hard
           make check_fmt
           if [[ $? != 0 ]]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -78,7 +78,7 @@ jobs:
           fi
       - name: Check format
         run: |
-          go install github.com/google/addlicense@lateset
+          go install github.com/google/addlicense@latest
           go install golang.org/x/tools/cmd/goimports@latest
           git reset HEAD --hard
           make check_fmt


### PR DESCRIPTION
KCP now requires Go 1.18 to build now, so need to update our PR workflow to use it.