### PR TITLE
[DEVHAS-148] Add GitOps commit ID to Component status

### DIFF
--- a/api/v1alpha1/component_types.go
+++ b/api/v1alpha1/component_types.go
@@ -141,6 +141,9 @@ type GitOpsStatus struct {
 
 	// ResourceGenerationSkipped is whether or not GitOps resource generation was skipped for the component
 	ResourceGenerationSkipped bool `json:"resourceGenerationSkipped,omitempty"`
+
+	// CommitID is the most recent commit ID in the GitOps repository for this component
+	CommitID string `json:"commitID,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/appstudio.redhat.com_components.yaml
+++ b/config/crd/bases/appstudio.redhat.com_components.yaml
@@ -325,6 +325,10 @@ spec:
                   branch:
                     description: Branch is the branch used for the gitops repository
                     type: string
+                  commitID:
+                    description: CommitID is the most recent commit ID in the GitOps
+                      repository for this component
+                    type: string
                   context:
                     description: Context is the path within the gitops repository
                       used for the gitops resources

--- a/config/kcp/apiexport_has.yaml
+++ b/config/kcp/apiexport_has.yaml
@@ -7,6 +7,6 @@ metadata:
   name: has
 spec:
   latestResourceSchemas:
-    - v202208112106.applications.appstudio.redhat.com
-    - v202208112106.componentdetectionqueries.appstudio.redhat.com
-    - v202208112106.components.appstudio.redhat.com
+    - v202208221503.applications.appstudio.redhat.com
+    - v202208221503.componentdetectionqueries.appstudio.redhat.com
+    - v202208221503.components.appstudio.redhat.com

--- a/config/kcp/apiresourceschema_has.yaml
+++ b/config/kcp/apiresourceschema_has.yaml
@@ -5,7 +5,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202208112106.applications.appstudio.redhat.com
+  name: v202208221503.applications.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -179,7 +179,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202208112106.componentdetectionqueries.appstudio.redhat.com
+  name: v202208221503.componentdetectionqueries.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -566,7 +566,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202208112106.components.appstudio.redhat.com
+  name: v202208221503.components.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -882,6 +882,10 @@ spec:
               properties:
                 branch:
                   description: Branch is the branch used for the gitops repository
+                  type: string
+                commitID:
+                  description: CommitID is the most recent commit ID in the GitOps
+                    repository for this component
                   type: string
                 context:
                   description: Context is the path within the gitops repository used

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -472,9 +472,9 @@ func (r *ComponentReconciler) generateGitops(ctx context.Context, req ctrl.Reque
 
 	// Get the commit ID for the gitops repository
 	var commitID string
-	if commitID, err = gitops.GetCommitSHAFromRepo(r.AppFS, r.Executor, tempDir); err != nil {
+	if commitID, err = gitops.GetCommitIDFromRepo(r.AppFS, r.Executor, tempDir); err != nil {
 		gitOpsErr := util.SanitizeErrorMessage(err)
-		log.Error(gitOpsErr, "unable to retrieve gitops repository commit sha due to error")
+		log.Error(gitOpsErr, "unable to retrieve gitops repository commit id due to error")
 		return gitOpsErr
 	}
 	component.Status.GitOps.CommitID = commitID

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -470,6 +470,15 @@ func (r *ComponentReconciler) generateGitops(ctx context.Context, req ctrl.Reque
 		return gitOpsErr
 	}
 
+	// Get the commit ID for the gitops repository
+	var commitID string
+	if commitID, err = gitops.GetCommitSHAFromRepo(r.AppFS, r.Executor, tempDir); err != nil {
+		gitOpsErr := util.SanitizeErrorMessage(err)
+		log.Error(gitOpsErr, "unable to retrieve gitops repository commit sha due to error")
+		return gitOpsErr
+	}
+	component.Status.GitOps.CommitID = commitID
+
 	// Remove the temp folder that was created
 	return r.AppFS.RemoveAll(tempDir)
 }

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -130,6 +130,9 @@ var _ = Describe("Component controller", func() {
 			Expect(err).Should(Not(HaveOccurred()))
 			Expect(string(createdHasComp.Status.GitOps.RepositoryURL)).Should(Equal(gitopsRepo))
 
+			// Commit ID should be set in the gitops repository and not be empty
+			Expect(createdHasComp.Status.GitOps.CommitID).Should(Not(BeEmpty()))
+
 			hasProjects, err := hasAppDevfile.GetProjects(common.DevfileOptions{})
 			Expect(err).Should(Not(HaveOccurred()))
 			Expect(len(hasProjects)).ShouldNot(Equal(0))

--- a/gitops/gitops.go
+++ b/gitops/gitops.go
@@ -205,12 +205,12 @@ func (e CmdExecutor) GenerateParentKustomize(fs afero.Afero, gitOpsFolder string
 	return GenerateParentKustomize(fs, gitOpsFolder)
 }
 
-// GetCommitSHAFromRepo returns the commit SHA for the given repository
-func GetCommitSHAFromRepo(fs afero.Afero, e Executor, repoPath string) (string, error) {
+// GetCommitIDFromRepo returns the commit ID for the given repository
+func GetCommitIDFromRepo(fs afero.Afero, e Executor, repoPath string) (string, error) {
 	var out []byte
 	var err error
 	if out, err = e.Execute(repoPath, "git", "rev-parse", "HEAD"); err != nil {
-		return "", fmt.Errorf("failed to retrieve commit sha for repository in %q %q: %s", repoPath, string(out), err)
+		return "", fmt.Errorf("failed to retrieve commit id for repository in %q %q: %s", repoPath, string(out), err)
 	}
 	return string(out), nil
 }

--- a/gitops/gitops.go
+++ b/gitops/gitops.go
@@ -204,3 +204,13 @@ func (e CmdExecutor) Execute(baseDir, command string, args ...string) ([]byte, e
 func (e CmdExecutor) GenerateParentKustomize(fs afero.Afero, gitOpsFolder string) error {
 	return GenerateParentKustomize(fs, gitOpsFolder)
 }
+
+// GetCommitSHAFromRepo returns the commit SHA for the given repository
+func GetCommitSHAFromRepo(fs afero.Afero, e Executor, repoPath string) (string, error) {
+	var out []byte
+	var err error
+	if out, err = e.Execute(repoPath, "git", "rev-parse", "HEAD"); err != nil {
+		return "", fmt.Errorf("failed to retrieve commit sha for repository in %q %q: %s", repoPath, string(out), err)
+	}
+	return string(out), nil
+}

--- a/gitops/gitops_test.go
+++ b/gitops/gitops_test.go
@@ -1624,13 +1624,13 @@ func TestGetCommitSHAFromRepo(t *testing.T) {
 // createEmptyGitRepository generates an empty git repository under the specified folder
 func createEmptyGitRepository(e Executor, repoPath string) error {
 	// Initialize the Git repository
-	if _, err := e.Execute(repoPath, "git", "init"); err != nil {
-		return err
+	if out, err := e.Execute(repoPath, "git", "init"); err != nil {
+		return fmt.Errorf("Unable to intialize git repository in %q %q: %s", repoPath, out, err)
 	}
 
 	// Create an empty commit
-	if _, err := e.Execute(repoPath, "git", "commit", "--allow-empty", "-m", "\"Empty commit\""); err != nil {
-		return err
+	if out, err := e.Execute(repoPath, "git", "commit", "--allow-empty", "-m", "\"Empty commit\""); err != nil {
+		return fmt.Errorf("Unable to create empty commit in %q %q: %s", repoPath, out, err)
 	}
 	return nil
 }

--- a/gitops/gitops_test.go
+++ b/gitops/gitops_test.go
@@ -1629,7 +1629,7 @@ func createEmptyGitRepository(e Executor, repoPath string) error {
 	}
 
 	// Create an empty commit
-	if out, err := e.Execute(repoPath, "git", "commit", "--allow-empty", "-m", "\"Empty commit\""); err != nil {
+	if out, err := e.Execute(repoPath, "git", "commit", "--author", "Test User", "<>", "--allow-empty", "-m", "\"Empty commit\""); err != nil {
 		return fmt.Errorf("Unable to create empty commit in %q %q: %s", repoPath, out, err)
 	}
 	return nil

--- a/gitops/gitops_test.go
+++ b/gitops/gitops_test.go
@@ -1629,7 +1629,7 @@ func createEmptyGitRepository(e Executor, repoPath string) error {
 	}
 
 	// Create an empty commit
-	if out, err := e.Execute(repoPath, "git", "commit", "--author", "Test User <>", "--allow-empty", "-m", "\"Empty commit\""); err != nil {
+	if out, err := e.Execute(repoPath, "git", "-c", "user.name='Test User'", "-c", "user.email='test@test.org'", "commit", "--allow-empty", "-m", "\"Empty commit\""); err != nil {
 		return fmt.Errorf("Unable to create empty commit in %q %q: %s", repoPath, out, err)
 	}
 	return nil

--- a/gitops/gitops_test.go
+++ b/gitops/gitops_test.go
@@ -1565,7 +1565,10 @@ func TestGetCommitSHAFromRepo(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	createEmptyGitRepository(NewCmdExecutor(), tempDir)
+	err = createEmptyGitRepository(NewCmdExecutor(), tempDir)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 	commitSha, err := getCommitSHAFromDotGit(tempDir)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)

--- a/gitops/gitops_test.go
+++ b/gitops/gitops_test.go
@@ -1558,7 +1558,7 @@ func TestExecute(t *testing.T) {
 	}
 }
 
-func TestGetCommitSHAFromRepo(t *testing.T) {
+func TestGetCommitIDFromRepo(t *testing.T) {
 	// Create an empty git repository and git commit to test with
 	fs := ioutils.NewFilesystem()
 	tempDir, err := fs.TempDir(os.TempDir(), "test")
@@ -1569,7 +1569,7 @@ func TestGetCommitSHAFromRepo(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	commitSha, err := getCommitSHAFromDotGit(tempDir)
+	commitID, err := getCommitIDFromDotGit(tempDir)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -1585,7 +1585,7 @@ func TestGetCommitSHAFromRepo(t *testing.T) {
 			name:     "No errors, successfully retrieve git commit ID",
 			e:        e,
 			repoPath: tempDir,
-			want:     commitSha,
+			want:     commitID,
 			wantErr:  false,
 		},
 		{
@@ -1606,16 +1606,16 @@ func TestGetCommitSHAFromRepo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			commitID, err := GetCommitSHAFromRepo(fs, tt.e, tt.repoPath)
+			commitID, err := GetCommitIDFromRepo(fs, tt.e, tt.repoPath)
 
 			if err != nil && !tt.wantErr {
-				t.Errorf("TestGetCommitSHAFromRepo() unexpected error: %s", err.Error())
+				t.Errorf("TestGetCommitIDFromRepo() unexpected error: %s", err.Error())
 			}
 			if err == nil && tt.wantErr {
-				t.Errorf("TestGetCommitSHAFromRepo() did not get expected error")
+				t.Errorf("TestGetCommitIDFromRepo() did not get expected error")
 			}
 			if commitID != tt.want {
-				t.Errorf("TestGetCommitSHAFromRepo() wanted: %v, got: %v", tt.want, commitID)
+				t.Errorf("TestGetCommitIDFromRepo() wanted: %v, got: %v", tt.want, commitID)
 			}
 		})
 	}
@@ -1635,8 +1635,8 @@ func createEmptyGitRepository(e Executor, repoPath string) error {
 	return nil
 }
 
-// getCommitSHAFromDotGit returns the latest commit SHA for the default branch in the given git repository
-func getCommitSHAFromDotGit(repoPath string) (string, error) {
+// getCommitIDFromDotGit returns the latest commit ID for the default branch in the given git repository
+func getCommitIDFromDotGit(repoPath string) (string, error) {
 	fs := ioutils.NewFilesystem()
 	var fileBytes []byte
 	fileBytes, err := fs.ReadFile(filepath.Join(repoPath, ".git", "refs", "heads", "master"))

--- a/gitops/gitops_test.go
+++ b/gitops/gitops_test.go
@@ -1629,7 +1629,7 @@ func createEmptyGitRepository(e Executor, repoPath string) error {
 	}
 
 	// Create an empty commit
-	if out, err := e.Execute(repoPath, "git", "commit", "--author", "Test User", "<>", "--allow-empty", "-m", "\"Empty commit\""); err != nil {
+	if out, err := e.Execute(repoPath, "git", "commit", "--author", "Test User <>", "--allow-empty", "-m", "\"Empty commit\""); err != nil {
 		return fmt.Errorf("Unable to create empty commit in %q %q: %s", repoPath, out, err)
 	}
 	return nil

--- a/gitops/testutils/testutils.go
+++ b/gitops/testutils/testutils.go
@@ -46,7 +46,11 @@ func NewMockExecutor(outputs ...[]byte) *MockExecutor {
 
 func (m *MockExecutor) Execute(basedir, command string, args ...string) ([]byte, error) {
 	m.Executed = append(m.Executed, Execution{BaseDir: basedir, Command: command, Args: args})
-	return m.Outputs.Pop(), m.Errors.Pop()
+	if command == "git" && len(args) > 0 && args[0] == "rev-parse" {
+		return []byte("ca82a6dff817ec66f44342007202690a93763949"), m.Errors.Pop()
+	} else {
+		return m.Outputs.Pop(), m.Errors.Pop()
+	}
 }
 
 func (m *MockExecutor) GenerateParentKustomize(fs afero.Afero, gitOpsFolder string) error {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -27,8 +27,6 @@ import (
 	"github.com/go-git/go-git/v5"
 	transportHttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
-
-	"github.com/go-git/go-git/v5/plumbing"
 )
 
 func SanitizeName(name string) string {
@@ -180,17 +178,4 @@ func CheckWithRegex(pattern, name string) bool {
 	}
 
 	return reg.MatchString(name)
-}
-
-// GetCommitIDFromRepo returns the corresponding commit ID for the given git repository
-func GetCommitIDFromRepo(path, revision string) (string, error) {
-	r, err := git.PlainOpen(path)
-	if err != nil {
-		return "", err
-	}
-	commitSha, err := r.ResolveRevision(plumbing.Revision(revision))
-	if err != nil {
-		return "", err
-	}
-	return commitSha.String(), nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -27,6 +27,8 @@ import (
 	"github.com/go-git/go-git/v5"
 	transportHttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
+
+	"github.com/go-git/go-git/v5/plumbing"
 )
 
 func SanitizeName(name string) string {
@@ -178,4 +180,17 @@ func CheckWithRegex(pattern, name string) bool {
 	}
 
 	return reg.MatchString(name)
+}
+
+// GetCommitIDFromRepo returns the corresponding commit ID for the given git repository
+func GetCommitIDFromRepo(path, revision string) (string, error) {
+	r, err := git.PlainOpen(path)
+	if err != nil {
+		return "", err
+	}
+	commitSha, err := r.ResolveRevision(plumbing.Revision(revision))
+	if err != nil {
+		return "", err
+	}
+	return commitSha.String(), nil
 }


### PR DESCRIPTION
Part 1 of https://issues.redhat.com/browse/DEVHAS-148

This PR adds a new field to the status of Component resources, `commitID`, which corresponds to the most recent commitID in the GitOps repository for that given Component. To retrieve the commitID, I added a function `GetCommitSHAFromRepo`, which calls `git rev-parse HEAD` on the given repository folder. (Note: There are multiple approaches to get the commit ID, but this approach was the most straightforward and testable). 

For the controller unit tests, which do not use 'real' GitOps repositories (which means there is no commit SHA to retrieve), I updated the mock executor that we use to return a dummy commit SHA when `git rev-parse HEAD` is called. 