### PR TITLE
PLNSRVCE-624: Detect HACBS workflow

### DIFF
--- a/gitops/generate_build.go
+++ b/gitops/generate_build.go
@@ -73,7 +73,7 @@ func SetDefaultImageRepo(repo string) {
 func GenerateBuild(fs afero.Fs, outputFolder string, component appstudiov1alpha1.Component, gitopsConfig gitopsprepare.GitopsConfig) error {
 	var buildResources map[string]interface{}
 	val, ok := component.Annotations[PaCAnnotation]
-	if ok && val == "1" {
+	if (ok && val == "1") || gitopsConfig.IsHACBS {
 		repository, err := GeneratePACRepository(component, gitopsConfig.PipelinesAsCodeCredentials)
 		if err != nil {
 			return err


### PR DESCRIPTION
* Detect HACBS by checking if hacbs configmap exists
* When HACBS is enabled then:
  - select hacbs tekton bundle
  - enable PipelinesAsCode

Note: HACBS detection by configmap is temporary solution, will be
changed to detection based on APIBinding API in KCP environment.