### PR TITLE
Tekton chains needs a pull secret to push attestations and signatures

### DIFF
--- a/gitops/generate_build.go
+++ b/gitops/generate_build.go
@@ -156,13 +156,24 @@ func DetermineBuildExecution(component appstudiov1alpha1.Component, params []tek
 		},
 	}
 	if gitopsConfig.AppStudioRegistrySecretPresent {
-		pipelineRunSpec.Workspaces = append(pipelineRunSpec.Workspaces, tektonapi.WorkspaceBinding{
-			Name: "registry-auth",
-			Secret: &corev1.SecretVolumeSource{
-				SecretName: "redhat-appstudio-registry-pull-secret",
+		pipelineRunSpec.Workspaces = append(pipelineRunSpec.Workspaces,
+			tektonapi.WorkspaceBinding{
+				Name: "registry-auth",
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: gitopsprepare.RegistrySecret,
+				},
 			},
-		})
+		)
+		// imagePullSecret to be set in the podTemplate used by chains
+		pipelineRunSpec.PodTemplate = &tektonapi.PodTemplate{
+			ImagePullSecrets: []corev1.LocalObjectReference{
+				{
+					Name: gitopsprepare.RegistrySecret,
+				},
+			},
+		}
 	}
+
 	return pipelineRunSpec
 }
 

--- a/gitops/generate_build_test.go
+++ b/gitops/generate_build_test.go
@@ -346,6 +346,13 @@ func TestGenerateInitialBuildPipelineRun(t *testing.T) {
 							},
 						},
 					},
+					PodTemplate: &tektonapi.PodTemplate{
+						ImagePullSecrets: []corev1.LocalObjectReference{
+							{
+								Name: "redhat-appstudio-registry-pull-secret",
+							},
+						},
+					},
 				},
 			},
 		},
@@ -483,6 +490,13 @@ func TestDetermineBuildExecution(t *testing.T) {
 						},
 					},
 				},
+				PodTemplate: &tektonapi.PodTemplate{
+					ImagePullSecrets: []corev1.LocalObjectReference{
+						{
+							Name: "redhat-appstudio-registry-pull-secret",
+						},
+					},
+				},
 			},
 		},
 		{
@@ -515,6 +529,13 @@ func TestDetermineBuildExecution(t *testing.T) {
 						Name: "registry-auth",
 						Secret: &corev1.SecretVolumeSource{
 							SecretName: "redhat-appstudio-registry-pull-secret",
+						},
+					},
+				},
+				PodTemplate: &tektonapi.PodTemplate{
+					ImagePullSecrets: []corev1.LocalObjectReference{
+						{
+							Name: "redhat-appstudio-registry-pull-secret",
 						},
 					},
 				},


### PR DESCRIPTION
When the redhat-appstudio-pull-secret is used, this change injects
the secret into the podTemplate under the imgPullSecret field

Signed-off-by: Joe Stuart <jstuart@redhat.com>