### PR TITLE
Add CommitID to ASEB status

### DIFF
--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"time"
 
@@ -472,7 +473,8 @@ func (r *ComponentReconciler) generateGitops(ctx context.Context, req ctrl.Reque
 
 	// Get the commit ID for the gitops repository
 	var commitID string
-	if commitID, err = gitops.GetCommitIDFromRepo(r.AppFS, r.Executor, tempDir); err != nil {
+	repoPath := filepath.Join(tempDir, component.Name)
+	if commitID, err = gitops.GetCommitIDFromRepo(r.AppFS, r.Executor, repoPath); err != nil {
 		gitOpsErr := util.SanitizeErrorMessage(err)
 		log.Error(gitOpsErr, "unable to retrieve gitops repository commit id due to error")
 		return gitOpsErr

--- a/controllers/component_controller_finalizer_test.go
+++ b/controllers/component_controller_finalizer_test.go
@@ -262,7 +262,7 @@ var _ = Describe("Application controller finalizer counter tests", func() {
 			createdHasComp := &appstudiov1alpha1.Component{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompLookupKey, createdHasComp)
-				return len(createdHasComp.Status.Conditions) > 0 && createdHasComp.Status.GitOps.RepositoryURL != ""
+				return len(createdHasComp.Status.Conditions) > 1 && createdHasComp.Status.GitOps.RepositoryURL != ""
 			}, timeout, interval).Should(BeTrue())
 
 			// Make sure the devfile model was properly set in Component
@@ -314,8 +314,8 @@ var _ = Describe("Application controller finalizer counter tests", func() {
 
 	Context("Delete Component CR with specified git branch and context", func() {
 		It("Should delete successfully", func() {
-			applicationName := AppName + "3"
-			componentName := CompName + "3"
+			applicationName := AppName + "4"
+			componentName := CompName + "4"
 
 			// Create a simple Application CR and get its devfile
 			createAndFetchSimpleApp(applicationName, AppNamespace, DisplayName, Description)

--- a/controllers/component_controller_unit_test.go
+++ b/controllers/component_controller_unit_test.go
@@ -340,6 +340,28 @@ func TestGenerateGitops(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name:       "Fail to retrieve commit ID for GitOps repository [Mock]",
+			reconciler: r,
+			fs:         appFS,
+			component: &appstudiov1alpha1.Component{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "Component",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-git-error",
+					Namespace: "test-namespace",
+				},
+				Spec: componentSpec,
+				Status: appstudiov1alpha1.ComponentStatus{
+					GitOps: appstudiov1alpha1.GitOpsStatus{
+						RepositoryURL: "https://github.com/test/repo",
+					},
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -70,7 +70,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
-	managedGitOpsDepVersion := "v0.0.0-20220623041404-010a781bb3fb"
+	managedGitOpsDepVersion := "v0.0.0-20220826075641-33705d2bf7fa"
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{

--- a/gitops/testutils/testutils.go
+++ b/gitops/testutils/testutils.go
@@ -16,7 +16,9 @@
 package testutils
 
 import (
+	"fmt"
 	"regexp"
+	"strings"
 	"sync"
 	"testing"
 
@@ -47,7 +49,12 @@ func NewMockExecutor(outputs ...[]byte) *MockExecutor {
 func (m *MockExecutor) Execute(basedir, command string, args ...string) ([]byte, error) {
 	m.Executed = append(m.Executed, Execution{BaseDir: basedir, Command: command, Args: args})
 	if command == "git" && len(args) > 0 && args[0] == "rev-parse" {
-		return []byte("ca82a6dff817ec66f44342007202690a93763949"), m.Errors.Pop()
+		if strings.Contains(basedir, "test-git-error") {
+			return []byte(""), fmt.Errorf("unable to retrive git commit id")
+		} else {
+			return []byte("ca82a6dff817ec66f44342007202690a93763949"), m.Errors.Pop()
+		}
+
 	} else {
 		return m.Outputs.Pop(), m.Errors.Pop()
 	}

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/onsi/gomega v1.19.0
 	github.com/openshift-pipelines/pipelines-as-code v0.0.0-20220622161720-2a6007e17200
 	github.com/openshift/api v0.0.0-20200930075302-db52bc4ef99f
-	github.com/redhat-appstudio/managed-gitops/appstudio-shared v0.0.0-20220623041404-010a781bb3fb // Update mod version in suite_test.go for tests
+	github.com/redhat-appstudio/managed-gitops/appstudio-shared v0.0.0-20220826075641-33705d2bf7fa // Update mod version in suite_test.go for tests
 	github.com/redhat-appstudio/service-provider-integration-scm-file-retriever v0.6.10
 	github.com/redhat-developer/alizer/go v0.0.0-20220704150640-ef50ead0b279
 	github.com/spf13/afero v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1907,6 +1907,8 @@ github.com/rcrowley/go-metrics v0.0.0-20190706150252-9beb055b7962/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redhat-appstudio/managed-gitops/appstudio-shared v0.0.0-20220623041404-010a781bb3fb h1:w0yj4jUZotnRVa3TFmaNBQj2pgZmgUOvSjinQrC2wxk=
 github.com/redhat-appstudio/managed-gitops/appstudio-shared v0.0.0-20220623041404-010a781bb3fb/go.mod h1:zI6l6177ZbAu4MNovCWinVq3Ii3qpD9svV7t9a58b/s=
+github.com/redhat-appstudio/managed-gitops/appstudio-shared v0.0.0-20220826075641-33705d2bf7fa h1:uiA9T0W+hHSBTroeAq1PIzxyw7Jn89i0oNppfpwnsJk=
+github.com/redhat-appstudio/managed-gitops/appstudio-shared v0.0.0-20220826075641-33705d2bf7fa/go.mod h1:zI6l6177ZbAu4MNovCWinVq3Ii3qpD9svV7t9a58b/s=
 github.com/redhat-appstudio/service-provider-integration-operator v0.6.9 h1:SKPMsROcJLfJMK3pc+SrjUxjfswomUGW5Z1N7V7wlgE=
 github.com/redhat-appstudio/service-provider-integration-operator v0.6.9/go.mod h1:hp1bIdqAzmMrqFH1CuuqWEs0D/PQ03sSzzQhvSt+MCQ=
 github.com/redhat-appstudio/service-provider-integration-scm-file-retriever v0.6.10 h1:EGeBp8ZRwzvvfjFN5GpWTus8MOGkMbABCP5Tj2Ori6o=

--- a/go.sum
+++ b/go.sum
@@ -1905,8 +1905,6 @@ github.com/rboyer/safeio v0.2.1/go.mod h1:Cq/cEPK+YXFn622lsQ0K4KsPZSPtaptHHEldsy
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20190706150252-9beb055b7962/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/redhat-appstudio/managed-gitops/appstudio-shared v0.0.0-20220623041404-010a781bb3fb h1:w0yj4jUZotnRVa3TFmaNBQj2pgZmgUOvSjinQrC2wxk=
-github.com/redhat-appstudio/managed-gitops/appstudio-shared v0.0.0-20220623041404-010a781bb3fb/go.mod h1:zI6l6177ZbAu4MNovCWinVq3Ii3qpD9svV7t9a58b/s=
 github.com/redhat-appstudio/managed-gitops/appstudio-shared v0.0.0-20220826075641-33705d2bf7fa h1:uiA9T0W+hHSBTroeAq1PIzxyw7Jn89i0oNppfpwnsJk=
 github.com/redhat-appstudio/managed-gitops/appstudio-shared v0.0.0-20220826075641-33705d2bf7fa/go.mod h1:zI6l6177ZbAu4MNovCWinVq3Ii3qpD9svV7t9a58b/s=
 github.com/redhat-appstudio/service-provider-integration-operator v0.6.9 h1:SKPMsROcJLfJMK3pc+SrjUxjfswomUGW5Z1N7V7wlgE=


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/DEVHAS-148

- Adds CommitID to ASEB status
- Updates GitOps generator executor mock to trigger an error for test cases testing git commit id retrieval
- Fixes a bug retrieving the commitID for Components (wrong dir was used)
- Fixes a misc. bug in the tests causing a flake in the finalizer tests