### PR TITLE
[DEVHAS-162] Make sure deployment patch selector is not null

### DIFF
--- a/gitops/generate.go
+++ b/gitops/generate.go
@@ -252,6 +252,7 @@ func generateDeploymentPatch(component appstudioshared.BindingComponent, environ
 			Namespace: namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
+			Selector: &v1.LabelSelector{},
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{

--- a/gitops/generate_test.go
+++ b/gitops/generate_test.go
@@ -375,6 +375,7 @@ func TestGenerateDeploymentPatch(t *testing.T) {
 				},
 				Spec: appsv1.DeploymentSpec{
 					Replicas: &replicas,
+					Selector: &v1.LabelSelector{},
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/DEVHAS-162

If we don't specify an empty struct for the deployment patch, the `null` selector field overwrite the existing selector in the base deployment file. If it's set to an empty struct (`{}`), then the selector specified in the base deployment will be used.

```
johncollier@jcollier-mac ~ % cd petclinic-default-assess-read/components/component-sample/overlays/staging 
johncollier@jcollier-mac staging % cat deployment-patch.yaml 
apiVersion: apps/v1
kind: Deployment
metadata:
  creationTimestamp: null
  name: component-sample
  namespace: default
spec:
  replicas: 3
  selector: {}
  strategy: {}
  template:
    metadata:
      creationTimestamp: null
    spec:
      containers:
      - env:
        - name: FOO
          value: BAR
        image: quay.io/redhat-appstudio/user-workload:application-service-system-component-sample
        name: container-image
        resources:
          limits:
            cpu: "2"
            memory: 500Mi
            storage: 400Mi
          requests:
            cpu: 700m
            memory: 400Mi
            storage: 200Mi
status: {}
johncollier@jcollier-mac staging % kustomize build .
apiVersion: v1
kind: Service
metadata:
  creationTimestamp: null
  labels:
    app.kubernetes.io/created-by: application-service
    app.kubernetes.io/instance: component-sample
    app.kubernetes.io/managed-by: kustomize
    app.kubernetes.io/name: backend
    app.kubernetes.io/part-of: application-sample
  name: component-sample
  namespace: default
spec:
  ports:
  - port: 1111
    targetPort: 1111
  selector:
    app.kubernetes.io/instance: component-sample
status:
  loadBalancer: {}
---
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/created-by: application-service
    app.kubernetes.io/instance: component-sample
    app.kubernetes.io/managed-by: kustomize
    app.kubernetes.io/name: backend
    app.kubernetes.io/part-of: application-sample
  name: component-sample
  namespace: default
spec:
  replicas: 3
  selector:
    matchLabels:
      app.kubernetes.io/instance: component-sample
  strategy: {}
  template:
    metadata:
      labels:
        app.kubernetes.io/instance: component-sample
    spec:
      containers:
      - env:
        - name: FOO
          value: BAR
        - name: BAR
          value: bar1
        image: quay.io/redhat-appstudio/user-workload:application-service-system-component-sample
        imagePullPolicy: Always
        livenessProbe:
          httpGet:
            path: /
            port: 1111
          initialDelaySeconds: 10
          periodSeconds: 10
        name: container-image
        ports:
        - containerPort: 1111
        readinessProbe:
          initialDelaySeconds: 10
          periodSeconds: 10
          tcpSocket:
            port: 1111
        resources:
          limits:
            cpu: "2"
            memory: 500Mi
            storage: 400Mi
          requests:
            cpu: 700m
            memory: 400Mi
            storage: 200Mi
status: {}
---
```