### PR TITLE
[DEVHAS-129] Run controller tests against KCP

### DIFF
--- a/.github/workflows/kcp-test.yml
+++ b/.github/workflows/kcp-test.yml
@@ -1,0 +1,58 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: KCP
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  go:
+    name: Run controller tests
+    runs-on: ubuntu-20.04
+    env:
+      OPERATOR_SDK_VERSION: v1.12.0
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup kubectl
+        id: install-kubectl
+        uses: azure/setup-kubectl@v3
+      - name: Install kcp
+        run: |
+          git clone https://github.com/kcp-dev/kcp ~/kcp
+          cd ~/kcp
+          make install
+      - name: Cache go modules
+        id: cache-mod
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Download dependencies
+        run: go mod download
+        if: steps.cache-mod.outputs.cache-hit != 'true'
+      - name: Run Go Tests
+        run: |
+          ./hack/kcp/test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ tmp
 
 .idea/
 .vscode/
+.kcp/
+kcp-output.log

--- a/hack/kcp/test.sh
+++ b/hack/kcp/test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+#trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+
+## This script runs the HAS controller tests against a KCP environment
+CURDIR=`pwd`
+rm -rf $CURDIR/.kcp || true
+rm -rf $CURDIR/kcp-output.log || true
+export KUBECONFIG=$CURDIR/.kcp/admin.KUBECONFIG
+
+# Start KCP
+kcp start &> kcp-output.log &
+
+# Wait for KCP to finish starting
+timeout 2m bash -c 'until cat kcp-output.log | grep "finished bootstrapping root workspace"; do echo Retry; sleep 5; done'
+if [[ $? -ne 0 ]]; then
+   echo "KCP failed to become ready"
+   cat kcp-output.log
+   exit 1
+fi
+
+# Run the controller tests
+# Set USE_EXISTING_CLUSTER to tell envtest to use KCPs kubeconfig
+export USE_EXISTING_CLUSTER=true
+go test ./controllers -coverprofile cover.out -v


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/DEVHAS-129

Sets up a GitHub workflow to run out controller's tests against KCP, by utilizing the `USE_EXISTING_CLUSTER` configuration in EnvTest.