### PR TITLE
Assess and fix sast-go findings from pipeline run

### DIFF
--- a/controllers/applicationsnapshotenvironmentbinding_controller.go
+++ b/controllers/applicationsnapshotenvironmentbinding_controller.go
@@ -234,7 +234,7 @@ func (r *ApplicationSnapshotEnvironmentBindingReconciler) Reconcile(ctx context.
 		if err != nil {
 			gitOpsErr := util.SanitizeErrorMessage(err)
 			log.Error(gitOpsErr, fmt.Sprintf("unable to get generate gitops resources for %s %v", componentName, req.NamespacedName))
-			r.AppFS.RemoveAll(tempDir) // not worried with an err, its a best case attempt to delete the temp clone dir
+			_ = r.AppFS.RemoveAll(tempDir) // not worried with an err, its a best case attempt to delete the temp clone dir
 			r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, gitOpsErr)
 			return ctrl.Result{}, gitOpsErr
 		}

--- a/pkg/devfile/detect.go
+++ b/pkg/devfile/detect.go
@@ -68,6 +68,7 @@ func search(log logr.Logger, a Alizer, localpath string, devfileRegistryURL stri
 			for _, f := range files {
 				if f.Name() == DevfileName || f.Name() == HiddenDevfileName {
 					// Check for devfile.yaml or .devfile.yaml
+					/* #nosec G304 -- false positive, filename is not based on user input*/
 					devfileBytes, err := ioutil.ReadFile(path.Join(curPath, f.Name()))
 					if err != nil {
 						return nil, nil, nil, err
@@ -87,6 +88,7 @@ func search(log logr.Logger, a Alizer, localpath string, devfileRegistryURL stri
 					for _, f := range hiddenfiles {
 						if f.Name() == DevfileName || f.Name() == HiddenDevfileName {
 							// Check for devfile.yaml or .devfile.yaml
+							/* #nosec G304 -- false positive, filename is not based on user input*/
 							devfileBytes, err := ioutil.ReadFile(path.Join(hiddenDirPath, f.Name()))
 							if err != nil {
 								return nil, nil, nil, err

--- a/pkg/devfile/devfile.go
+++ b/pkg/devfile/devfile.go
@@ -127,7 +127,10 @@ func ConvertImageComponentToDevfile(comp appstudiov1alpha1.Component) (data.Devf
 		},
 	}
 
-	devfileData.AddComponents(components)
+	err = devfileData.AddComponents(components)
+	if err != nil {
+		return nil, err
+	}
 
 	return devfileData, nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -126,6 +126,7 @@ func ConvertGitHubURL(URL string, revision string) (string, error) {
 // CurlEndpoint curls the endpoint and returns the response or an error if the response is a non-200 status
 func CurlEndpoint(endpoint string) ([]byte, error) {
 	var respBytes []byte
+	/* #nosec G107 --  The URL is validated by the CDQ if the request is coming from the UI.  If we do happen to download invalid bytes, the devfile parser will catch this and fail. */
 	resp, err := http.Get(endpoint)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Clean up errors and warnings.  Annotated findings that do not need fixing with `#nosec` so future scans will skip over them

Signed-off-by: Kim Tsao <ktsao@redhat.com>