### PR TITLE
infra-deployment updater: update all application-service resources

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -20,7 +20,7 @@ spec:
       value: Dockerfile
     - name: infra-deployment-update-script
       value: |
-        sed -i -e 's|\(https://github.com/redhat-appstudio/application-service/config/default?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/has/kustomization.yaml
+        sed -i -e 's|\(https://github.com/redhat-appstudio/application-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/has/kustomization.yaml
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest


### PR DESCRIPTION
The config changed in infra-deployments from 'config/default' to 'config/kcp', improving regexp to match all subfolders of application-service