### PR TITLE
PLNSRVCE-715: Unify labels to use appstudio.openshift.io/application

### DIFF
--- a/gitops/generate_build.go
+++ b/gitops/generate_build.go
@@ -325,12 +325,12 @@ func getParamsForComponentBuild(component appstudiov1alpha1.Component, isInitial
 
 func getBuildCommonLabelsForComponent(component *appstudiov1alpha1.Component) map[string]string {
 	labels := map[string]string{
-		"pipelines.appstudio.openshift.io/type":    "build",
-		"build.appstudio.openshift.io/build":       "true",
-		"build.appstudio.openshift.io/type":        "build",
-		"build.appstudio.openshift.io/version":     "0.1",
-		"build.appstudio.openshift.io/component":   component.Name,
-		"build.appstudio.openshift.io/application": component.Spec.Application,
+		"pipelines.appstudio.openshift.io/type": "build",
+		"build.appstudio.openshift.io/build":    "true",
+		"build.appstudio.openshift.io/type":     "build",
+		"build.appstudio.openshift.io/version":  "0.1",
+		"appstudio.openshift.io/component":      component.Name,
+		"appstudio.openshift.io/application":    component.Spec.Application,
 	}
 	return labels
 }

--- a/gitops/generate_build_test.go
+++ b/gitops/generate_build_test.go
@@ -778,11 +778,11 @@ func TestGenerateTriggerTemplate(t *testing.T) {
 						if pr.Namespace != tt.component.Namespace {
 							t.Errorf("GenerateTriggerTemplate() namespace mismatch: got %s want %s", pr.Namespace, tt.component.Namespace)
 						}
-						compA, ok := pr.Annotations["build.appstudio.openshift.io/component"]
+						compA, ok := pr.Annotations["appstudio.openshift.io/component"]
 						if !ok || compA != tt.component.Name {
 							t.Errorf("GenerateTriggerTemplate() component annotation incorrect: %v %s", ok, compA)
 						}
-						appA, ok := pr.Annotations["build.appstudio.openshift.io/application"]
+						appA, ok := pr.Annotations["appstudio.openshift.io/application"]
 						if !ok || appA != tt.component.Spec.Application {
 							t.Errorf("GenerateTriggerTemplate() app annotation incorrect: %v %s", ok, appA)
 						}
@@ -1164,7 +1164,7 @@ func TestGeneratePACRepository(t *testing.T) {
 			if len(pacRepo.Annotations) == 0 {
 				t.Errorf("Generated PaC repository must have annotations")
 			}
-			if pacRepo.Annotations["build.appstudio.openshift.io/component"] != component.Name {
+			if pacRepo.Annotations["appstudio.openshift.io/component"] != component.Name {
 				t.Errorf("Generated PaC repository must have component annotation")
 			}
 


### PR DESCRIPTION
Use appstudio.openshift.io/[component|application] instead of build.appstudio.openshift.io/[component|application]

### What does this PR do?:
Unification of labels, component and application is global identifications, it's not just for build part.

### Which issue(s)/story(ies) does this PR fixes:
[PLNSRVCE-715](https://issues.redhat.com//browse/PLNSRVCE-715)

### PR acceptance criteria:

- [x] Unit/Functional tests
