### PR TITLE
PLNSRVCE-700: use volumeClaimTemplate instead of static PVC

### DIFF
--- a/gitops/generate_build_test.go
+++ b/gitops/generate_build_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
@@ -389,10 +390,18 @@ func TestGenerateInitialBuildPipelineRun(t *testing.T) {
 					Workspaces: []tektonapi.WorkspaceBinding{
 						{
 							Name: "workspace",
-							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-								ClaimName: "appstudio",
+							VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
+								Spec: corev1.PersistentVolumeClaimSpec{
+									AccessModes: []corev1.PersistentVolumeAccessMode{
+										"ReadWriteOnce",
+									},
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											"storage": resource.MustParse("1Gi"),
+										},
+									},
+								},
 							},
-							SubPath: "testcomponent/" + getInitialBuildWorkspaceSubpath(),
 						},
 						{
 							Name: "registry-auth",
@@ -440,10 +449,18 @@ func TestGenerateInitialBuildPipelineRun(t *testing.T) {
 					Workspaces: []tektonapi.WorkspaceBinding{
 						{
 							Name: "workspace",
-							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-								ClaimName: "appstudio",
+							VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
+								Spec: corev1.PersistentVolumeClaimSpec{
+									AccessModes: []corev1.PersistentVolumeAccessMode{
+										"ReadWriteOnce",
+									},
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											"storage": resource.MustParse("1Gi"),
+										},
+									},
+								},
 							},
-							SubPath: "testcomponent/" + getInitialBuildWorkspaceSubpath(),
 						},
 					},
 				},
@@ -492,9 +509,8 @@ func TestGenerateInitialBuildPipelineRun(t *testing.T) {
 
 func TestDetermineBuildExecution(t *testing.T) {
 	type args struct {
-		component        appstudiov1alpha1.Component
-		params           []tektonapi.Param
-		workspaceSubPath string
+		component appstudiov1alpha1.Component
+		params    []tektonapi.Param
 	}
 
 	buildBundle := "quay.io/redhat-appstudio/build-templates-bundle:0.0.1"
@@ -514,8 +530,7 @@ func TestDetermineBuildExecution(t *testing.T) {
 						Namespace: "kcpworkspacename",
 					},
 				},
-				workspaceSubPath: "initialbuild",
-				params:           []tektonapi.Param{},
+				params: []tektonapi.Param{},
 			},
 			want: tektonapi.PipelineRunSpec{
 				PipelineRef: &tektonapi.PipelineRef{
@@ -526,10 +541,18 @@ func TestDetermineBuildExecution(t *testing.T) {
 				Workspaces: []tektonapi.WorkspaceBinding{
 					{
 						Name: "workspace",
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "appstudio",
+						VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
+							Spec: corev1.PersistentVolumeClaimSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{
+									"ReadWriteOnce",
+								},
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"storage": resource.MustParse("1Gi"),
+									},
+								},
+							},
 						},
-						SubPath: "testcomponent/initialbuild",
 					},
 					{
 						Name: "registry-auth",
@@ -549,8 +572,7 @@ func TestDetermineBuildExecution(t *testing.T) {
 						Namespace: "kcpworkspacename",
 					},
 				},
-				workspaceSubPath: "a-long-git-reference",
-				params:           []tektonapi.Param{},
+				params: []tektonapi.Param{},
 			},
 			want: tektonapi.PipelineRunSpec{
 				PipelineRef: &tektonapi.PipelineRef{
@@ -561,10 +583,18 @@ func TestDetermineBuildExecution(t *testing.T) {
 				Workspaces: []tektonapi.WorkspaceBinding{
 					{
 						Name: "workspace",
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "appstudio",
+						VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
+							Spec: corev1.PersistentVolumeClaimSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{
+									"ReadWriteOnce",
+								},
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"storage": resource.MustParse("1Gi"),
+									},
+								},
+							},
 						},
-						SubPath: "testcomponent/a-long-git-reference",
 					},
 					{
 						Name: "registry-auth",
@@ -585,8 +615,7 @@ func TestDetermineBuildExecution(t *testing.T) {
 						Namespace: "kcpworkspacename",
 					},
 				},
-				workspaceSubPath: "a-long-git-reference",
-				params:           []tektonapi.Param{},
+				params: []tektonapi.Param{},
 			},
 			want: tektonapi.PipelineRunSpec{
 				PipelineRef: &tektonapi.PipelineRef{
@@ -597,10 +626,18 @@ func TestDetermineBuildExecution(t *testing.T) {
 				Workspaces: []tektonapi.WorkspaceBinding{
 					{
 						Name: "workspace",
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "appstudio",
+						VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
+							Spec: corev1.PersistentVolumeClaimSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{
+									"ReadWriteOnce",
+								},
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"storage": resource.MustParse("1Gi"),
+									},
+								},
+							},
 						},
-						SubPath: "testcomponent/a-long-git-reference",
 					},
 				},
 			},
@@ -609,7 +646,7 @@ func TestDetermineBuildExecution(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gitopsConfig := gitopsprepare.GitopsConfig{BuildBundle: buildBundle, AppStudioRegistrySecretPresent: !tt.registrySecretMissing}
-			if got := DetermineBuildExecution(tt.args.component, tt.args.params, tt.args.workspaceSubPath, gitopsConfig); !reflect.DeepEqual(got, tt.want) {
+			if got := DetermineBuildExecution(tt.args.component, tt.args.params, gitopsConfig); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("DetermineBuildExecution() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
Signed-off-by: Chenxiong Qi <cqi@redhat.com>

### What does this PR do?:
<!-- _Summarize the changes_ -->
Use volumeClaimTemplate instead of static PVC in the pipeline run spec returned from `DetermineBuildExecution`
### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
[PLNSRVCE-700](https://issues.redhat.com//browse/PLNSRVCE-700)
### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests
  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->
### How to test changes / Special notes to the reviewer:

The trigger template should use `volumeClaimTemplate`.