### PR TITLE
No longer use default serviceaccount on KCP

### DIFF
--- a/config/kcp-manager/kustomization.yaml
+++ b/config/kcp-manager/kustomization.yaml
@@ -29,15 +29,6 @@ patches:
     kind: Deployment
     name: controller-manager
 
-# HAS on KCP needs to use default service account name right now
-- patch: |-
-    - op: replace
-      path: /spec/template/spec/serviceAccountName
-      value: default
-  target:
-    kind: Deployment
-    name: controller-manager
-
 # HAS on KCP needs to pass in the APIExport for HAS when the operator starts up
 - patch: |-
     - op: add

--- a/config/kcp-rbac/kustomization.yaml
+++ b/config/kcp-rbac/kustomization.yaml
@@ -18,7 +18,7 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
-
+- service_account.yaml
 # Aggegating roles which are otherwise done by OLM
 - application_editor_role.yaml
 - application_viewer_role.yaml

--- a/config/kcp-rbac/leader_election_role_binding.yaml
+++ b/config/kcp-rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/config/kcp-rbac/role_binding.yaml
+++ b/config/kcp-rbac/role_binding.yaml
@@ -8,7 +8,7 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -21,7 +21,7 @@ roleRef:
   name: manager-role-build
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -34,5 +34,5 @@ roleRef:
   name: manager-role-spi
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system


### PR DESCRIPTION
No longer uses the default service account on KCP, as it's no longer required.