### PR TITLE
Update infra-deployments with identityHashes

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -20,7 +20,8 @@ spec:
       value: Dockerfile
     - name: infra-deployment-update-script
       value: |
-        sed -i -e 's|\(https://github.com/redhat-appstudio/application-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/has/kustomization.yaml
+        sed -i -e 's|\(https://github.com/redhat-appstudio/application-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/application-service/base/kustomization.yaml
+        ./hack/generate-apiexport-overlays.sh components/application-service/
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest

--- a/config/kcp/apiexport_application-service.yaml
+++ b/config/kcp/apiexport_application-service.yaml
@@ -1,0 +1,33 @@
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIExport
+metadata:
+  name: application-service
+spec:
+  permissionClaims:
+    - group: ""
+      resource: "secrets"
+    - group: ""
+      resource: "namespaces"
+    - group: ""
+      resource: "configmaps"
+    - identityHash: application-api
+      group: "appstudio.redhat.com"
+      resource: "applications"
+    - identityHash: application-api
+      group: "appstudio.redhat.com"
+      resource: "applicationsnapshotenvironmentbindings"
+    - identityHash: application-api
+      group: "appstudio.redhat.com"
+      resource: "components"
+    - identityHash: application-api
+      group: "appstudio.redhat.com"
+      resource: "componentdetectionqueries"
+    - identityHash: application-api
+      group: "appstudio.redhat.com"
+      resource: "environments"
+    - identityHash: spi
+      group: "appstudio.redhat.com"
+      resource: "spiaccesstokens"
+    - identityHash: spi
+      group: "appstudio.redhat.com"
+      resource: "spiaccesstokenbindings"

--- a/config/kcp/kustomization.yaml
+++ b/config/kcp/kustomization.yaml
@@ -16,5 +16,5 @@ bases:
 - ../kcp-manager
 
 resources:
-- apiexport_has.yaml
+- apiexport_application-service.yaml
 - apiresourceschema_has.yaml


### PR DESCRIPTION
- Create APIExport which can be reused by infra-deployments
- Use APIExport application-service by default

Infra-deployments changes related to this change -> https://github.com/redhat-appstudio/infra-deployments/pull/790

### What does this PR do?:
Updates infra-deployments with APIExports