### PR TITLE
Use Go 1.18 in OpenShift CI

### DIFF
--- a/.ci/openshift-ci/Dockerfile
+++ b/.ci/openshift-ci/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/redhat-appstudio/e2e-tests:latest as e2e
-FROM registry.ci.openshift.org/openshift/release:golang-1.17
+FROM registry.ci.openshift.org/openshift/release:golang-1.18
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
Need to switch to 1.18 for https://github.com/redhat-appstudio/application-service/pull/195