### PR TITLE
[DEVHAS-178] Use MergePatch to update CDQ status

### DIFF
--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -86,11 +86,6 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 		return ctrl.Result{}, err
 	}
 
-	// If on KCP, requeue if the "kcp.dev/cluster" annotation has not been added yet
-	if req.ClusterName != "" && componentDetectionQuery.GetAnnotations()["kcp.dev/cluster"] == "" {
-		return ctrl.Result{Requeue: true}, nil
-	}
-
 	// If there are no conditions attached to the CDQ, the resource was just created
 	if len(componentDetectionQuery.Status.Conditions) == 0 {
 		// Start the ComponentDetectionQuery, and update its status condition accordingly

--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -86,6 +86,11 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 		return ctrl.Result{}, err
 	}
 
+	// If on KCP, requeue if the "kcp.dev/cluster" annotation has not been added yet
+	if req.ClusterName != "" && componentDetectionQuery.GetAnnotations()["kcp.dev/cluster"] == "" {
+		return ctrl.Result{Requeue: true}, nil
+	}
+
 	// If there are no conditions attached to the CDQ, the resource was just created
 	if len(componentDetectionQuery.Status.Conditions) == 0 {
 		// Start the ComponentDetectionQuery, and update its status condition accordingly

--- a/controllers/componentdetectionquery_controller_conditions.go
+++ b/controllers/componentdetectionquery_controller_conditions.go
@@ -46,10 +46,10 @@ func (r *ComponentDetectionQueryReconciler) SetDetectingConditionAndUpdateCR(ctx
 	}
 }
 
-func (r *ComponentDetectionQueryReconciler) SetCompleteConditionAndUpdateCR(ctx context.Context, req ctrl.Request, componentDetectionQuery *appstudiov1alpha1.ComponentDetectionQuery, completeError error) {
+func (r *ComponentDetectionQueryReconciler) SetCompleteConditionAndUpdateCR(ctx context.Context, req ctrl.Request, componentDetectionQuery *appstudiov1alpha1.ComponentDetectionQuery, originalCDQ *appstudiov1alpha1.ComponentDetectionQuery, completeError error) {
 	log := r.Log.WithValues("ComponentDetectionQuery", req.NamespacedName).WithValues("clusterName", req.ClusterName)
 
-	patch := client.MergeFrom(componentDetectionQuery.DeepCopy())
+	patch := client.MergeFrom(originalCDQ.DeepCopy())
 
 	if completeError == nil {
 		meta.SetStatusCondition(&componentDetectionQuery.Status.Conditions, metav1.Condition{

--- a/controllers/componentdetectionquery_controller_conditions.go
+++ b/controllers/componentdetectionquery_controller_conditions.go
@@ -23,12 +23,15 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
 )
 
 func (r *ComponentDetectionQueryReconciler) SetDetectingConditionAndUpdateCR(ctx context.Context, req ctrl.Request, componentDetectionQuery *appstudiov1alpha1.ComponentDetectionQuery) {
 	log := r.Log.WithValues("ComponentDetectionQuery", req.NamespacedName).WithValues("clusterName", req.ClusterName)
+
+	patch := client.MergeFrom(componentDetectionQuery.DeepCopy())
 
 	meta.SetStatusCondition(&componentDetectionQuery.Status.Conditions, metav1.Condition{
 		Type:    "Processing",
@@ -37,7 +40,7 @@ func (r *ComponentDetectionQueryReconciler) SetDetectingConditionAndUpdateCR(ctx
 		Message: "ComponentDetectionQuery is processing",
 	})
 
-	err := r.Client.Status().Update(ctx, componentDetectionQuery)
+	err := r.Client.Status().Patch(ctx, componentDetectionQuery, patch)
 	if err != nil {
 		log.Error(err, "Unable to update ComponentDetectionQuery")
 	}
@@ -45,6 +48,8 @@ func (r *ComponentDetectionQueryReconciler) SetDetectingConditionAndUpdateCR(ctx
 
 func (r *ComponentDetectionQueryReconciler) SetCompleteConditionAndUpdateCR(ctx context.Context, req ctrl.Request, componentDetectionQuery *appstudiov1alpha1.ComponentDetectionQuery, completeError error) {
 	log := r.Log.WithValues("ComponentDetectionQuery", req.NamespacedName).WithValues("clusterName", req.ClusterName)
+
+	patch := client.MergeFrom(componentDetectionQuery.DeepCopy())
 
 	if completeError == nil {
 		meta.SetStatusCondition(&componentDetectionQuery.Status.Conditions, metav1.Condition{
@@ -61,8 +66,7 @@ func (r *ComponentDetectionQueryReconciler) SetCompleteConditionAndUpdateCR(ctx 
 			Message: fmt.Sprintf("ComponentDetectionQuery failed: %v", completeError),
 		})
 	}
-
-	err := r.Client.Status().Update(ctx, componentDetectionQuery)
+	err := r.Client.Status().Patch(ctx, componentDetectionQuery, patch)
 	if err != nil {
 		log.Error(err, "Unable to update ComponentDetectionQuery")
 	}


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

### What does this PR do?:
~This PR makes sure we don't start reconciling CDQ resources on KCP until after the `kcp.dev/cluster` annotation has been added.~

Since KCP may attach a number of KCP-specific annotations and labels to the resource, this may cause conflicts when trying to update the resource:
```
2022-10-13T15:16:51.519Z    ERROR   controllers.ComponentDetectionQuery Unable to update ComponentDetectionQuery    {"ComponentDetectionQuery": "has-e2e-ndry/quarkus-component-e2e-madtwgalft", "clusterName": "test", "error": "Operation cannot be fulfilled on componentdetectionqueries.appstudio.redhat.com \"quarkus-component-e2e-madtwgalft\": the object has been modified; please apply your changes to the latest version and try again"}
```

Since we only allow CDQs to  run once by design, this may be problematic. Switching to a MergePatch when we update the CDQs status will prevent this from occurring.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-178

