### PR TITLE
Read default build bundle from APIExport workspace

### DIFF
--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -58,6 +58,7 @@ import (
 // ComponentReconciler reconciles a Component object
 type ComponentReconciler struct {
 	client.Client
+	LocalClient     client.Client
 	Scheme          *runtime.Scheme
 	Log             logr.Logger
 	GitToken        string
@@ -460,7 +461,7 @@ func (r *ComponentReconciler) generateGitops(ctx context.Context, req ctrl.Reque
 	}
 
 	// Generate and push the gitops resources
-	gitopsConfig := prepare.PrepareGitopsConfig(ctx, r.Client, *component)
+	gitopsConfig := prepare.PrepareGitopsConfig(ctx, r.LocalClient, r.Client, *component)
 	mappedGitOpsComponent := util.GetMappedGitOpsComponent(*component)
 	err = gitopsgen.CloneGenerateAndPush(tempDir, gitOpsURL, mappedGitOpsComponent, r.Executor, r.AppFS, gitOpsBranch, gitOpsContext, false)
 	if err != nil {

--- a/controllers/component_controller_unit_test.go
+++ b/controllers/component_controller_unit_test.go
@@ -155,22 +155,24 @@ func TestGenerateGitops(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().Build()
 
 	r := &ComponentReconciler{
-		Log:       ctrl.Log.WithName("controllers").WithName("Component"),
-		GitHubOrg: github.AppStudioAppDataOrg,
-		GitToken:  "fake-token",
-		Executor:  executor,
-		Client:    fakeClient,
+		Log:         ctrl.Log.WithName("controllers").WithName("Component"),
+		GitHubOrg:   github.AppStudioAppDataOrg,
+		GitToken:    "fake-token",
+		Executor:    executor,
+		Client:      fakeClient,
+		LocalClient: fakeClient,
 	}
 
 	// Create a second reconciler for testing error scenarios
 	errExec := testutils.NewMockExecutor()
 	errExec.Errors.Push(errors.New("Fatal error"))
 	errReconciler := &ComponentReconciler{
-		Log:       ctrl.Log.WithName("controllers").WithName("Component"),
-		GitHubOrg: github.AppStudioAppDataOrg,
-		GitToken:  "fake-token",
-		Executor:  errExec,
-		Client:    fakeClient,
+		Log:         ctrl.Log.WithName("controllers").WithName("Component"),
+		GitHubOrg:   github.AppStudioAppDataOrg,
+		GitToken:    "fake-token",
+		Executor:    errExec,
+		Client:      fakeClient,
+		LocalClient: fakeClient,
 	}
 
 	componentSpec := appstudiov1alpha1.ComponentSpec{

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -116,6 +116,7 @@ var _ = BeforeSuite(func() {
 
 	err = (&ComponentReconciler{
 		Client:          k8sManager.GetClient(),
+		LocalClient:     k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
 		Log:             ctrl.Log.WithName("controllers").WithName("Component"),
 		Executor:        testutils.NewMockExecutor(),

--- a/gitops/generate_build_test.go
+++ b/gitops/generate_build_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/gitops/prepare/prepare_test.go
+++ b/gitops/prepare/prepare_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -85,7 +85,7 @@ func TestPrepareGitopsConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := fake.NewClientBuilder().WithRuntimeObjects(&tt.buildBundleConfigMap, &tt.pacSecret).Build()
-			if got := PrepareGitopsConfig(context.TODO(), client, component); !reflect.DeepEqual(got, tt.want) {
+			if got := PrepareGitopsConfig(context.TODO(), client, client, component); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("PrepareGitopsConfig() = %v, want %v", got, tt.want)
 			}
 		})
@@ -150,7 +150,7 @@ func TestResolveBuildBundle(t *testing.T) {
 		{
 			name: "should fall back to the hard-coded bundle in case the resolution fails",
 			data: corev1.ConfigMap{},
-			want: "",
+			want: AppStudioFallbackBuildBundle,
 		},
 		{
 			name: "should ignore malformed configmaps",
@@ -167,7 +167,7 @@ func TestResolveBuildBundle(t *testing.T) {
 					Namespace: BuildBundleDefaultNamespace,
 				},
 			},
-			want: "",
+			want: AppStudioFallbackBuildBundle,
 		},
 		{
 			name: "should ignore configmaps with empty keys",
@@ -184,7 +184,7 @@ func TestResolveBuildBundle(t *testing.T) {
 					Namespace: BuildBundleDefaultNamespace,
 				},
 			},
-			want: "",
+			want: AppStudioFallbackBuildBundle,
 		},
 		{
 			name: "should return HACBS bundle from user namespace",
@@ -230,7 +230,7 @@ func TestResolveBuildBundle(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			client := fake.NewClientBuilder().WithRuntimeObjects(&tt.data).Build()
 
-			if got := ResolveBuildBundle(ctx, client, component.Namespace, tt.isHACBS); got != tt.want {
+			if got := ResolveBuildBundle(ctx, client, client, component.Namespace, tt.isHACBS); got != tt.want {
 				t.Errorf("ResolveBuildBundle() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?:
Changes default build bundle configuration way.
With this changes the following order is used:
1. `build-pipelines-defaults` ConfigMap in the Component namespace
2. `build-pipelines-defaults` ConfigMap in the `build-templates` namespace
3. Fallback bundle (hardcoded)

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/PLNSRVCE-782

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [x] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
1. Deploy AppStudio into KCP cluster
2. Go to `redhat-appstudio` KCP-workspace, create `build-templates` namespace and create there ConfigMap named `build-pipelines-defaults` with `default_build_bundle` key and bundle as value.
3. Go to `appstudio` KCP-workspace, create an Application and a Component.
4. Check for a new build Pipeline and for the bundle used. It must be the bundle from the ConfigMap.
