### PR TITLE
[DEVHAS-176] Remove namespace from the GitOps repository name

### DIFF
--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -129,7 +129,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		appModelRepo := application.Spec.AppModelRepository.URL
 		if gitOpsRepo == "" {
 			// If both repositories are blank, just generate a single shared repository
-			repoName := github.GenerateNewRepositoryName(application.Spec.DisplayName, application.Namespace)
+			repoName := github.GenerateNewRepositoryName(application.Spec.DisplayName, application.Namespace, req.ClusterName)
 
 			// Generate the git repo in the redhat-appstudio-appdata org
 			repoUrl, err := github.GenerateNewRepository(r.GitHubClient, ctx, r.GitHubOrg, repoName, "GitOps Repository")

--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -86,6 +86,11 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 		return ctrl.Result{}, err
 	}
 
+	// If on KCP, requeue if the kcp.dev/cluster annotation has not yet been added
+	if req.ClusterName != "" && componentDetectionQuery.GetAnnotations()["kcp.dev/cluster"] == "" {
+		return ctrl.Result{Requeue: true}, nil
+	}
+
 	// If there are no conditions attached to the CDQ, the resource was just created
 	if len(componentDetectionQuery.Status.Conditions) == 0 {
 		// Start the ComponentDetectionQuery, and update its status condition accordingly

--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -86,11 +86,6 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 		return ctrl.Result{}, err
 	}
 
-	// If on KCP, requeue if the kcp.dev/cluster annotation has not yet been added
-	if req.ClusterName != "" && componentDetectionQuery.GetAnnotations()["kcp.dev/cluster"] == "" {
-		return ctrl.Result{Requeue: true}, nil
-	}
-
 	// If there are no conditions attached to the CDQ, the resource was just created
 	if len(componentDetectionQuery.Status.Conditions) == 0 {
 		// Start the ComponentDetectionQuery, and update its status condition accordingly

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -18,6 +18,7 @@ package github
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
 	"strings"
 
@@ -34,7 +35,7 @@ func GenerateNewRepositoryName(displayName, namespace, clusterName string) strin
 	sanitizedName := util.SanitizeName(displayName)
 	h := sha256.New()
 	h.Write([]byte(clusterName + namespace))
-	namespaceClusterHash := string(h.Sum(nil))[0:5]
+	namespaceClusterHash := base64.URLEncoding.EncodeToString(h.Sum(nil))[0:5]
 	repoName := sanitizedName + "-" + namespaceClusterHash + "-" + util.SanitizeName(gofakeit.Verb()) + "-" + util.SanitizeName(gofakeit.Verb())
 	return repoName
 }

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -17,6 +17,7 @@ package github
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"strings"
 
@@ -27,10 +28,14 @@ import (
 
 const AppStudioAppDataOrg = "redhat-appstudio-appdata"
 
-func GenerateNewRepositoryName(displayName string, namespace string) string {
+// GenerateNewRepositoryName creates a new gitops repository name, based on the following format:
+// <display-name>-<partial-hash-of-clustername-and-namespace>-<random-word>-<random-word>
+func GenerateNewRepositoryName(displayName, namespace, clusterName string) string {
 	sanitizedName := util.SanitizeName(displayName)
-
-	repoName := sanitizedName + "-" + namespace + "-" + util.SanitizeName(gofakeit.Verb()) + "-" + util.SanitizeName(gofakeit.Verb())
+	h := sha256.New()
+	h.Write([]byte(clusterName + namespace))
+	namespaceClusterHash := string(h.Sum(nil))[0:5]
+	repoName := sanitizedName + "-" + namespaceClusterHash + "-" + util.SanitizeName(gofakeit.Verb()) + "-" + util.SanitizeName(gofakeit.Verb())
 	return repoName
 }
 

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -34,7 +34,7 @@ func GenerateNewRepositoryName(displayName, namespace, clusterName string) strin
 	sanitizedName := util.SanitizeName(displayName)
 	h := sha256.New()
 	h.Write([]byte(clusterName + namespace))
-	namespaceClusterHash := string(h.Sum(nil))
+	namespaceClusterHash := string(h.Sum(nil))[0:5]
 	repoName := sanitizedName + "-" + namespaceClusterHash + "-" + util.SanitizeName(gofakeit.Verb()) + "-" + util.SanitizeName(gofakeit.Verb())
 	return repoName
 }

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -34,7 +34,7 @@ func GenerateNewRepositoryName(displayName, namespace, clusterName string) strin
 	sanitizedName := util.SanitizeName(displayName)
 	h := sha256.New()
 	h.Write([]byte(clusterName + namespace))
-	namespaceClusterHash := string(h.Sum(nil))[0:5]
+	namespaceClusterHash := string(h.Sum(nil))
 	repoName := sanitizedName + "-" + namespaceClusterHash + "-" + util.SanitizeName(gofakeit.Verb()) + "-" + util.SanitizeName(gofakeit.Verb())
 	return repoName
 }

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -18,6 +18,7 @@ package github
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"strings"
 	"testing"
 
@@ -46,7 +47,7 @@ func TestGenerateNewRepositoryName(t *testing.T) {
 			sanitizedName := util.SanitizeName(tt.displayName)
 			h := sha256.New()
 			h.Write([]byte(tt.clusterName + tt.namespace))
-			namespaceClusterHash := string(h.Sum(nil))[0:5]
+			namespaceClusterHash := base64.URLEncoding.EncodeToString(h.Sum(nil))[0:5]
 			generatedRepo := GenerateNewRepositoryName(tt.displayName, tt.namespace, tt.clusterName)
 
 			if !strings.Contains(generatedRepo, sanitizedName) || !strings.Contains(generatedRepo, namespaceClusterHash) {

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -46,7 +46,7 @@ func TestGenerateNewRepositoryName(t *testing.T) {
 			sanitizedName := util.SanitizeName(tt.displayName)
 			h := sha256.New()
 			h.Write([]byte(tt.clusterName + tt.namespace))
-			namespaceClusterHash := string(h.Sum(nil))
+			namespaceClusterHash := string(h.Sum(nil))[0:5]
 			generatedRepo := GenerateNewRepositoryName(tt.displayName, tt.namespace, tt.clusterName)
 
 			if !strings.Contains(generatedRepo, sanitizedName) || !strings.Contains(generatedRepo, namespaceClusterHash) {

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -41,7 +41,7 @@ func TestGenerateNewRepositoryName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sanitizedName := util.SanitizeName(tt.displayName)
-			generatedRepo := GenerateNewRepositoryName(tt.displayName, tt.namespace)
+			generatedRepo := GenerateNewRepositoryName(tt.displayName, tt.namespace, "root:test-workspace")
 
 			if !strings.Contains(generatedRepo, sanitizedName) {
 				t.Errorf("TestSanitizeDisplayName() error: expected %v got %v", tt.want, sanitizedName)

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -17,6 +17,7 @@ package github
 
 import (
 	"context"
+	"crypto/sha256"
 	"strings"
 	"testing"
 
@@ -28,12 +29,14 @@ func TestGenerateNewRepositoryName(t *testing.T) {
 		name        string
 		displayName string
 		namespace   string
+		clusterName string
 		want        string
 	}{
 		{
 			name:        "Simple display name, no spaces",
 			displayName: "PetClinic",
 			namespace:   "default",
+			clusterName: "root:test-workspace",
 			want:        "petclinic-default",
 		},
 	}
@@ -41,9 +44,12 @@ func TestGenerateNewRepositoryName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sanitizedName := util.SanitizeName(tt.displayName)
-			generatedRepo := GenerateNewRepositoryName(tt.displayName, tt.namespace, "root:test-workspace")
+			h := sha256.New()
+			h.Write([]byte(tt.clusterName + tt.namespace))
+			namespaceClusterHash := string(h.Sum(nil))
+			generatedRepo := GenerateNewRepositoryName(tt.displayName, tt.namespace, tt.clusterName)
 
-			if !strings.Contains(generatedRepo, sanitizedName) {
+			if !strings.Contains(generatedRepo, sanitizedName) || !strings.Contains(generatedRepo, namespaceClusterHash) {
 				t.Errorf("TestSanitizeDisplayName() error: expected %v got %v", tt.want, sanitizedName)
 			}
 		})


### PR DESCRIPTION
### What does this PR do?:
This PR updates the GitOps repository name generation to no longer use the Component's namespace, and instead uses a hash of the combined clusterName and namespace. 

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-176

### PR acceptance criteria:

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->
