### PR TITLE
[DEVHAS-188] Add missing ApplicationSnapshot permission claim

### DIFF
--- a/config/kcp/apiexport_application-service.yaml
+++ b/config/kcp/apiexport_application-service.yaml
@@ -15,6 +15,9 @@ spec:
       resource: "applications"
     - identityHash: application-api
       group: "appstudio.redhat.com"
+      resource: "applicationsnapshots"
+    - identityHash: application-api
+      group: "appstudio.redhat.com"
       resource: "applicationsnapshotenvironmentbindings"
     - identityHash: application-api
       group: "appstudio.redhat.com"


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

### What does this PR do?:
This PR adds `ApplicationSnapshot` to the apiexport used for HAS in infra-deployments

### Which issue(s)/story(ies) does this PR fixes:
Fixes https://issues.redhat.com/browse/DEVHAS-188

### PR acceptance criteria:
N/A

