### PR TITLE
Bump application-api dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/onsi/gomega v1.20.1
 	github.com/openshift-pipelines/pipelines-as-code v0.0.0-20220622161720-2a6007e17200
 	github.com/openshift/api v0.0.0-20210503193030-25175d9d392d
-	github.com/redhat-appstudio/application-api v0.0.0-20221005164756-847094032024
+	github.com/redhat-appstudio/application-api v0.0.0-20221027190652-c77187d59b28
 	github.com/redhat-appstudio/service-provider-integration-scm-file-retriever v0.6.10
 	github.com/redhat-developer/alizer/go v0.0.0-20220704150640-ef50ead0b279
 	github.com/redhat-developer/gitops-generator v0.0.0-20221006150505-48bd0619bdcc

--- a/go.sum
+++ b/go.sum
@@ -1417,8 +1417,8 @@ github.com/rabbitmq/amqp091-go v1.1.0/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0V
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20190706150252-9beb055b7962/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/redhat-appstudio/application-api v0.0.0-20221005164756-847094032024 h1:0obibT/WLSDfeaaqVY9FugemhVgeZwlAFo3X1gaKaR0=
-github.com/redhat-appstudio/application-api v0.0.0-20221005164756-847094032024/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
+github.com/redhat-appstudio/application-api v0.0.0-20221027190652-c77187d59b28 h1:avWRxe8HYRHClWpYtKaQsMcOU/Ox81VFfDR/UKzr/Gs=
+github.com/redhat-appstudio/application-api v0.0.0-20221027190652-c77187d59b28/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
 github.com/redhat-appstudio/service-provider-integration-operator v0.6.9 h1:SKPMsROcJLfJMK3pc+SrjUxjfswomUGW5Z1N7V7wlgE=
 github.com/redhat-appstudio/service-provider-integration-operator v0.6.9/go.mod h1:hp1bIdqAzmMrqFH1CuuqWEs0D/PQ03sSzzQhvSt+MCQ=
 github.com/redhat-appstudio/service-provider-integration-scm-file-retriever v0.6.10 h1:EGeBp8ZRwzvvfjFN5GpWTus8MOGkMbABCP5Tj2Ori6o=


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

### What does this PR do?:
Bumps up the version of application-api pulled into HAS to the latest version.

### Which issue(s)/story(ies) does this PR fixes:
N/A

### PR acceptance criteria:
N/A
