### PR TITLE
[DEVHAS-129] Add basic sniff test for HAS on KCP

### DIFF
--- a/.github/workflows/kcp-test.yml
+++ b/.github/workflows/kcp-test.yml
@@ -36,7 +36,3 @@ jobs:
       - name: Run KCP Tests
         run: |
           ./hack/kcp/test-has.sh application-service:latest $PWD
-      - name: Check if Manager Kustomize has the right image
-        run: |
-          ./check-manager-kustomize.sh
-          exit $?

--- a/.github/workflows/kcp-test.yml
+++ b/.github/workflows/kcp-test.yml
@@ -33,9 +33,6 @@ jobs:
           driver: 'docker'
           github token: ${{ secrets.GITHUB_TOKEN }}
           start args: '--addons=ingress'
-      - name: Build HAS container image
-        run: |
-          docker build -t application-service:latest .
       - name: Run KCP Tests
         run: |
           ./hack/kcp/test-has.sh application-service:latest $PWD

--- a/.github/workflows/kcp-test.yml
+++ b/.github/workflows/kcp-test.yml
@@ -1,0 +1,44 @@
+name: Validate PRs
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  kcp:
+    name: Test KCP
+    runs-on: ubuntu-20.04
+    env:
+      OPERATOR_SDK_VERSION: v1.12.0
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.4.2
+        with:
+          minikube version: 'v1.21.0'
+          kubernetes version: 'v1.21.0'
+          driver: 'docker'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          start args: '--addons=ingress'
+      - name: Install KCP
+        run: |
+          git clone https://github.com/kcp-dev/kcp -b v0.9.1 ~/kcp
+          cd ~/kcp
+          make install
+      - name: Build HAS container image
+        run: |
+          docker build -t application-service:latest .
+      - name: Run KCP Tests
+        run: |
+          ./hack/kcp/test-has.sh application-service:latest $PWD
+      - name: Check if Manager Kustomize has the right image
+        run: |
+          ./check-manager-kustomize.sh
+          exit $?

--- a/.github/workflows/kcp-test.yml
+++ b/.github/workflows/kcp-test.yml
@@ -19,6 +19,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Install KCP
+        run: |
+          git clone https://github.com/kcp-dev/kcp -b v0.9.1 ~/kcp
+          cd ~/kcp
+          make install
+          cd ..
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.4.2
         with:
@@ -27,11 +33,6 @@ jobs:
           driver: 'docker'
           github token: ${{ secrets.GITHUB_TOKEN }}
           start args: '--addons=ingress'
-      - name: Install KCP
-        run: |
-          git clone https://github.com/kcp-dev/kcp -b v0.9.1 ~/kcp
-          cd ~/kcp
-          make install
       - name: Build HAS container image
         run: |
           docker build -t application-service:latest .

--- a/.github/workflows/kcp-test.yml
+++ b/.github/workflows/kcp-test.yml
@@ -26,7 +26,7 @@ jobs:
           make install
           cd ..
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.4.2
+        uses: manusa/actions-setup-minikube@v2.7.1
         with:
           minikube version: 'v1.21.0'
           kubernetes version: 'v1.21.0'

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ tmp
 .idea/
 .vscode/
 .tmp/
+.kcp/
+output.log
+syncer.yaml

--- a/hack/kcp/test-has.sh
+++ b/hack/kcp/test-has.sh
@@ -56,6 +56,7 @@ function waitForHASDeployment() {
     KUBECONFIG=$KCP_KUBECONFIG kubectl get deployment application-service-controller-manager -n application-service-system -o yaml
     kubectl get deployments --all-namespaces -o yaml
     kubectl get rs --all-namespaces -o yaml
+    kubectl get po --all-namespaces -o yaml
     while [ $counter -gt 0 ]
     do
         if [ "$(KUBECONFIG=$KCP_KUBECONFIG kubectl get deployments -n application-service-system application-service-controller-manager -o jsonpath='{.status.readyReplicas}')" != 1 ]; then
@@ -70,6 +71,7 @@ function waitForHASDeployment() {
     done
     kubectl get deployments --all-namespaces -o yaml
     kubectl get rs --all-namespaces -o yaml
+    kubectl get po --all-namespaces -o yaml
     return 1
 }
 

--- a/hack/kcp/test-has.sh
+++ b/hack/kcp/test-has.sh
@@ -87,14 +87,16 @@ function executeTests() {
     # Wait for HAS to become ready
     echo "[INFO] Waiting for HAS deployment rollout to succeed"
     sleep 10
-    waitForHASDeployment
-    #KUBECONFIG=$KCP_KUBECONFIG kubectl rollout status deployment application-service-controller-manager -n application-service-system --timeout=300s
+    #waitForHASDeployment
+    KUBECONFIG=$KCP_KUBECONFIG kubectl rollout status deployment application-service-controller-manager -n application-service-system --timeout=300s
 
     # Create a CDQ and validate it succeeds on KCP
     echo "[INFO] Creating a ComponentDetectionResource on KCP"
     KUBECONFIG=$KCP_KUBECONFIG kubectl create -f $TESTPATH/config/samples/componentdetectionquery/componentdetectionquery-basic.yaml
     KUBECONFIG=$KCP_KUBECONFIG kubectl wait hcdq componentdetectionquery-sample --for condition=Completed --timeout=120s
 }
+
+docker build -t application-service:latest .
 
 # Start KCP
 kcp start > output.log 2>&1 &

--- a/hack/kcp/test-has.sh
+++ b/hack/kcp/test-has.sh
@@ -96,7 +96,7 @@ function executeTests() {
     KUBECONFIG=$KCP_KUBECONFIG kubectl wait hcdq componentdetectionquery-sample --for condition=Completed --timeout=120s
 }
 
-docker build -t application-service:latest .
+docker build -t $HAS_IMAGE .
 
 # Start KCP
 kcp start > output.log 2>&1 &

--- a/hack/kcp/test-has.sh
+++ b/hack/kcp/test-has.sh
@@ -53,11 +53,11 @@ function setupTests() {
 
 function waitForHASDeployment() {
     counter=100
-    kubectl describe deployment application-service-controller-manager -n application-service-system
+    KUBECONFIG=$KCP_KUBECONFIG kubectl describe deployment application-service-controller-manager -n application-service-system
     while [ $counter -gt 0 ]
     do
         if [ "$(KUBECONFIG=$KCP_KUBECONFIG kubectl get deployments -n application-service-system application-service-controller-manager -o jsonpath='{.status.readyReplicas}')" != 1 ]; then
-            kubectl describe deployment application-service-controller-manager -n application-service-system
+            KUBECONFIG=$KCP_KUBECONFIG kubectl describe deployment application-service-controller-manager -n application-service-system
             
             counter=$(( $counter - 1 ))
             sleep 5

--- a/hack/kcp/test-has.sh
+++ b/hack/kcp/test-has.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -e
+
+HAS_IMAGE=$1
+
+# Test path needs to point to a valid HAS repo folder
+TESTPATH=$2
+
+KCP_KUBECONFIG=$TESTPATH/.kcp/admin.kubeconfig
+
+function waitForKCPToBeReady() {
+    while true; do
+        KUBECONFIG=$PWD/.kcp/admin.kubeconfig kubectl kcp ws
+        if [[ $? -eq 0 ]]; then
+            break
+        fi
+        echo "[INFO] Waiting for KCP to be ready."
+        sleep 5
+    done
+}
+
+function waitForSyncTargetToBeReady() {
+    while [ "$(kubectl api-resources --kubeconfig $PWD/.kcp/admin.kubeconfig)" ]; do
+        echo "[INFO] Waiting for KCP to be ready."
+        sleep 5
+    done
+}
+
+function setupTests() {
+    # Create a workspace for HAS
+    echo "[INFO] Creating test workspace on KCP"
+    KUBECONFIG=$KCP_KUBECONFIG kubectl kcp ws
+    KUBECONFIG=$KCP_KUBECONFIG kubectl kcp ws create tests --enter
+
+    # Generate the syncer.yaml
+    KUBECONFIG=$KCP_KUBECONFIG kubectl kcp workload sync minikube \
+    --syncer-image ghcr.io/kcp-dev/kcp/syncer:v0.9.1 \
+    --output-file=syncer.yaml
+
+    # On Minikube, create the syncer resources
+    kubectl create -f syncer.yaml
+
+    # Wait for the SyncTarget to become ready
+    KUBECONFIG=~/test/application-service/.kcp/admin.kubeconfig kubectl wait synctargets minikube --for condition=Ready --timeout=120s
+
+    # Create namespace and stub github secret for HAS
+    KUBECONFIG=$KCP_KUBECONFIG kubectl create ns application-service-system
+    KUBECONFIG=$KCP_KUBECONFIG kubectl create secret generic has-github-token --from-literal=token=testvalue -n application-service-system
+}
+
+# Execute tests deploys HAS on KCP, validates it becomes ready, and that a CDQ resource successfully completes
+function executeTests() {
+    # Deploy HAS
+    echo "[INFO] Deploying HAS on KCP"
+    KUBECONFIG=$KCP_KUBECONFIG IMG=$HAS_IMAGE make deploy-kcp
+
+    # Wait for HAS to become ready
+    echo "[INFO] Waiting for HAS deployment rollout to succeed"
+    KUBECONFIG=$KCP_KUBECONFIG kubectl rollout status deployment application-service-controller-manager -n application-service-system --timeout=300s
+
+    # Create a CDQ and validate it succeeds on KCP
+    echo "[INFO] Creating a ComponentDetectionResource on KCP"
+    KUBECONFIG=$KCP_KUBECONFIG kubectl create -f $TESTPATH/config/samples/componentdetectionquery/componentdetectionquery-basic.yaml
+    KUBECONFIG=$KCP_KUBECONFIG kubectl wait hcdq componentdetectionquery-sample --for condition=Completed --timeout=120s
+}
+
+# Start KCP
+kcp start > output.log 2>&1 &
+
+# Wait for KCP to become available
+
+export -f waitForKCPToBeReady
+
+timeout --foreground 1m bash -c waitForKCPToBeReady
+
+setupTests
+
+executeTests

--- a/hack/kcp/test-has.sh
+++ b/hack/kcp/test-has.sh
@@ -54,6 +54,7 @@ function setupTests() {
 function waitForHASDeployment() {
     counter=100
     KUBECONFIG=$KCP_KUBECONFIG kubectl describe deployment application-service-controller-manager -n application-service-system
+    kubectl get po --all-namespaces -o yaml
     while [ $counter -gt 0 ]
     do
         if [ "$(KUBECONFIG=$KCP_KUBECONFIG kubectl get deployments -n application-service-system application-service-controller-manager -o jsonpath='{.status.readyReplicas}')" != 1 ]; then
@@ -66,6 +67,8 @@ function waitForHASDeployment() {
         fi
         
     done
+    kubectl get po --all-namespaces -o yaml
+    return 1
 }
 
 # Execute tests deploys HAS on KCP, validates it becomes ready, and that a CDQ resource successfully completes

--- a/hack/kcp/test-has.sh
+++ b/hack/kcp/test-has.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Share docker env with Minikube
+eval $(minikube docker-env)
+
 set -e
 
 HAS_IMAGE=$1

--- a/hack/kcp/test-has.sh
+++ b/hack/kcp/test-has.sh
@@ -50,6 +50,9 @@ function setupTests() {
 
 # Execute tests deploys HAS on KCP, validates it becomes ready, and that a CDQ resource successfully completes
 function executeTests() {
+    # Set the imagePullPolicy for HAS to Never, as we're using a locally built image
+    sed -i 's/Always/Never/g' config/manager/manager.yaml
+
     # Deploy HAS
     echo "[INFO] Deploying HAS on KCP"
     KUBECONFIG=$KCP_KUBECONFIG IMG=$HAS_IMAGE make deploy-kcp

--- a/hack/kcp/test-has.sh
+++ b/hack/kcp/test-has.sh
@@ -41,7 +41,7 @@ function setupTests() {
     kubectl create -f syncer.yaml
 
     # Wait for the SyncTarget to become ready
-    KUBECONFIG=~/test/application-service/.kcp/admin.kubeconfig kubectl wait synctargets minikube --for condition=Ready --timeout=120s
+    KUBECONFIG=$KCP_KUBECONFIG kubectl wait synctargets minikube --for condition=Ready --timeout=120s
 
     # Create namespace and stub github secret for HAS
     KUBECONFIG=$KCP_KUBECONFIG kubectl create ns application-service-system

--- a/hack/kcp/test-has.sh
+++ b/hack/kcp/test-has.sh
@@ -52,7 +52,7 @@ function setupTests() {
 }
 
 function waitForHASDeployment() {
-    counter=100
+    counter=200
     KUBECONFIG=$KCP_KUBECONFIG kubectl get deployment application-service-controller-manager -n application-service-system -o yaml
     kubectl get deployments --all-namespaces -o yaml
     kubectl get rs --all-namespaces -o yaml

--- a/hack/kcp/test-has.sh
+++ b/hack/kcp/test-has.sh
@@ -53,12 +53,13 @@ function setupTests() {
 
 function waitForHASDeployment() {
     counter=100
-    KUBECONFIG=$KCP_KUBECONFIG kubectl describe deployment application-service-controller-manager -n application-service-system
-    kubectl get po --all-namespaces -o yaml
+    KUBECONFIG=$KCP_KUBECONFIG kubectl get deployment application-service-controller-manager -n application-service-system -o yaml
+    kubectl get deployments --all-namespaces -o yaml
+    kubectl get rs --all-namespaces -o yaml
     while [ $counter -gt 0 ]
     do
         if [ "$(KUBECONFIG=$KCP_KUBECONFIG kubectl get deployments -n application-service-system application-service-controller-manager -o jsonpath='{.status.readyReplicas}')" != 1 ]; then
-            KUBECONFIG=$KCP_KUBECONFIG kubectl describe deployment application-service-controller-manager -n application-service-system
+            KUBECONFIG=$KCP_KUBECONFIG kubectl get deployment application-service-controller-manager -n application-service-system -o yaml
             
             counter=$(( $counter - 1 ))
             sleep 5
@@ -67,7 +68,8 @@ function waitForHASDeployment() {
         fi
         
     done
-    kubectl get po --all-namespaces -o yaml
+    kubectl get deployments --all-namespaces -o yaml
+    kubectl get rs --all-namespaces -o yaml
     return 1
 }
 


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

### What does this PR do?:
This PR adds a basic GitHub workflow to test HAS on KCP. Since we cannot access GitHub secrets on workflows (which most HAS functionality requires) from PRs and to avoid duplication with the existing KCP e2e tests, this workflow runs just some basic sniff tests:

1. Sets up Minikube and KCP, and creates a SyncTarget pointing to the Minikube cluster
2. Deploys HAS using `make deploy-kcp`
3. Creates a CDQ resource and validates it succeeds

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/projects/DEVHAS/issues/DEVHAS-129

### PR acceptance criteria:
GitHub workflow passes
