### PR TITLE
Update to use GitRemoveComponent API (#2398)

### DIFF
--- a/controllers/component_controller_finalizer.go
+++ b/controllers/component_controller_finalizer.go
@@ -81,7 +81,7 @@ func (r *ComponentReconciler) Finalize(ctx context.Context, component *appstudio
 		return fmt.Errorf("unable to create temp directory for gitops resources due to error: %v", err)
 	}
 
-	err = gitopsgen.RemoveAndPush(tempDir, gitOpsURL, component.Name, r.Executor, r.AppFS, gitOpsBranch, gitOpsContext, true)
+	err = gitopsgen.GitRemoveComponent(tempDir, gitOpsURL, component.Name, r.Executor, gitOpsBranch, gitOpsContext)
 	if err != nil {
 		gitOpsErr := util.SanitizeErrorMessage(err)
 		return gitOpsErr

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/redhat-appstudio/application-api v0.0.0-20221108172336-c9e003808d1f
 	github.com/redhat-appstudio/service-provider-integration-scm-file-retriever v0.6.10
 	github.com/redhat-developer/alizer/go v0.0.0-20220704150640-ef50ead0b279
-	github.com/redhat-developer/gitops-generator v0.0.0-20221019171158-4833b032e3f9
+	github.com/redhat-developer/gitops-generator v0.0.0-20221026163641-76ad94f921b3
 	github.com/spf13/afero v1.8.0
 	github.com/stretchr/testify v1.8.0
 	github.com/tektoncd/pipeline v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -1425,8 +1425,8 @@ github.com/redhat-appstudio/service-provider-integration-scm-file-retriever v0.6
 github.com/redhat-appstudio/service-provider-integration-scm-file-retriever v0.6.10/go.mod h1:/id8d2MdgW1X5kKO3IMXiSQ/hrXv20iIopuIv/kmrzc=
 github.com/redhat-developer/alizer/go v0.0.0-20220704150640-ef50ead0b279 h1:+S8l0Q94mtvZjvYUICUltPEpH/8AEhzhcD+WqtdaDB8=
 github.com/redhat-developer/alizer/go v0.0.0-20220704150640-ef50ead0b279/go.mod h1:jzZFFoqYo3vQfo6dNNEv1biEZ1g55GPvvNPeP2gu43c=
-github.com/redhat-developer/gitops-generator v0.0.0-20221019171158-4833b032e3f9 h1:QMoKgiLFW3VQMDKZBFHMNiKK1sU4Lr/9hnLk4KUDx9c=
-github.com/redhat-developer/gitops-generator v0.0.0-20221019171158-4833b032e3f9/go.mod h1:oRmoPfhkSvjOCncDigpalGvU2AaZeaivDpf9H7DxDuU=
+github.com/redhat-developer/gitops-generator v0.0.0-20221026163641-76ad94f921b3 h1:7cV5AGUCN6ro6Ggysg5nT6c4rldYFU1zYZ4MZ6HMQV4=
+github.com/redhat-developer/gitops-generator v0.0.0-20221026163641-76ad94f921b3/go.mod h1:oRmoPfhkSvjOCncDigpalGvU2AaZeaivDpf9H7DxDuU=
 github.com/rickb777/date v1.13.0/go.mod h1:GZf3LoGnxPWjX+/1TXOuzHefZFDovTyNLHDMd3qH70k=
 github.com/rickb777/plural v1.2.1/go.mod h1:j058+3M5QQFgcZZ2oKIOekcygoZUL8gKW5yRO14BuAw=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

### What does this PR do?:
Update to pull in the gitops-generator that includes.
https://github.com/redhat-developer/gitops-generator/pull/24
This pulls the latest changes to the gitops-generator except for the change for 
https://github.com/redhat-developer/gitops-generator/pull/28

@kim-tsao FYI

### Which issue(s)/story(ies) does this PR fixes:
No HAS issue/story has been opened

### PR acceptance criteria:
Just refactoring and pulling in the updated generator module.


- [x] Unit/Functional tests

I ran make test, and they all pass.  Existing tests sufficient.

- [ ] Documentation 

N/A

- [ ] Client Impact

N/A

### How to test changes / Special notes to the reviewer:
Just run the tests locally.

