### PR TITLE
Add apibindings for testing staging on KCP

### DIFF
--- a/docs/appstudio-kcp.md
+++ b/docs/appstudio-kcp.md
@@ -1,0 +1,30 @@
+# Testing HAS on AppStudio-KCP Staging
+
+## Prereqs
+
+- Access to CPS
+- A workspace created under your home workspace
+
+## Testing HAS
+
+1. Log on to CPS (either stable or unstable)
+
+2. Navigate to your home workspace: `kubectl ws`
+
+3. Create a workspace to test in: `kubectl ws create <workspace-name> --enter`
+
+   - Alternatively, navigate to a preexisting workspace of your choosing with `kubectl ws <workspace-name>`
+
+4. Create the necessary API Bindings for HAS:
+
+   ```
+   $ kubectl create -f hack/appstudio-kcp/api-binding.yaml && kubectl create -f hack/appstudio-kcp/has-binding.yaml
+   ```
+
+   This will create two API Bindings: One for the HAS API, the other to allow HAS to watch your workspace
+
+5. If you need to test with SPI for private source repositories, then add the API Binding for SPI as well:
+
+   ```
+   $ kubectl create -f hack/appstudio-kcp/spi-binding.yaml
+   ```

--- a/hack/appstudio-kcp/api-binding.yaml
+++ b/hack/appstudio-kcp/api-binding.yaml
@@ -1,0 +1,19 @@
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIBinding
+metadata:
+  name: application-api-binding
+spec:
+  reference:
+    workspace:
+      exportName: application-api
+      path: root:redhat-appstudio
+  permissionClaims:
+    - group: ""
+      resource: "secrets"
+      state: Accepted
+    - group: ""
+      resource: "configmaps"
+      state: Accepted
+    - group: ""
+      resource: "namespaces"
+      state: Accepted

--- a/hack/appstudio-kcp/has-binding.yaml
+++ b/hack/appstudio-kcp/has-binding.yaml
@@ -1,0 +1,48 @@
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIBinding
+metadata:
+  name: has
+spec:
+  reference:
+    workspace:
+      path: root:redhat-appstudio
+      exportName: application-service
+  permissionClaims:
+    - group: ""
+      resource: "secrets"
+      state: Accepted
+    - group: ""
+      resource: "configmaps"
+      state: Accepted
+    - identityHash: 835cb978eda43fb9776eab29818632aab365fedac2ee8e137440be5e5ed10e1d
+      group: "appstudio.redhat.com"
+      resource: "applications"
+      state: Accepted
+    - identityHash: 835cb978eda43fb9776eab29818632aab365fedac2ee8e137440be5e5ed10e1d
+      group: "appstudio.redhat.com"
+      resource: "snapshots"
+      state: Accepted
+    - identityHash: 835cb978eda43fb9776eab29818632aab365fedac2ee8e137440be5e5ed10e1d
+      group: "appstudio.redhat.com"
+      resource: "snapshotenvironmentbindings"
+      state: Accepted
+    - identityHash: 835cb978eda43fb9776eab29818632aab365fedac2ee8e137440be5e5ed10e1d
+      group: "appstudio.redhat.com"
+      resource: "components"
+      state: Accepted
+    - identityHash: 835cb978eda43fb9776eab29818632aab365fedac2ee8e137440be5e5ed10e1d
+      group: "appstudio.redhat.com"
+      resource: "componentdetectionqueries"
+      state: Accepted
+    - identityHash: 835cb978eda43fb9776eab29818632aab365fedac2ee8e137440be5e5ed10e1dk
+      group: "appstudio.redhat.com"
+      resource: "environments"
+      state: Accepted
+    - identityHash: f7ae9a3fe4e40a9052ddb96488af50b28b094c1d65044c9cf844b4fab8c73d3d
+      group: "appstudio.redhat.com"
+      resource: "spiaccesstokens"
+      state: Accepted
+    - identityHash: f7ae9a3fe4e40a9052ddb96488af50b28b094c1d65044c9cf844b4fab8c73d3d
+      group: "appstudio.redhat.com"
+      resource: "spiaccesstokenbindings"
+      state: Accepted

--- a/hack/appstudio-kcp/spi-binding.yaml
+++ b/hack/appstudio-kcp/spi-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIBinding
+metadata:
+  name: application-api-binding
+spec:
+  reference:
+    workspace:
+      exportName: spi
+      path: root:redhat-appstudio
+  permissionClaims:
+    - group: ""
+      resource: "secrets"
+      state: Accepted


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

### What does this PR do?:
Adds apibindings under `hack/` to allow for testing HAS in staging, along with supporting documentation.

### Which issue(s)/story(ies) does this PR fixes:
N/A

### PR acceptance criteria:
The documentation and bindings allow HAS to be tested on staging on CPS.