### PR TITLE
Delete local client

### DIFF
--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -62,7 +62,6 @@ import (
 // ComponentReconciler reconciles a Component object
 type ComponentReconciler struct {
 	client.Client
-	LocalClient     client.Client
 	Scheme          *runtime.Scheme
 	Log             logr.Logger
 	GitToken        string
@@ -466,7 +465,7 @@ func (r *ComponentReconciler) generateGitops(ctx context.Context, req ctrl.Reque
 	}
 
 	// Generate and push the gitops resources
-	gitopsConfig := prepare.PrepareGitopsConfig(ctx, r.LocalClient, r.Client, *component)
+	gitopsConfig := prepare.PrepareGitopsConfig(ctx, r.Client, *component)
 	mappedGitOpsComponent := util.GetMappedGitOpsComponent(*component)
 	err = gitopsgen.CloneGenerateAndPush(tempDir, gitOpsURL, mappedGitOpsComponent, r.Executor, r.AppFS, gitOpsBranch, gitOpsContext, false)
 	if err != nil {

--- a/controllers/component_controller_unit_test.go
+++ b/controllers/component_controller_unit_test.go
@@ -155,24 +155,22 @@ func TestGenerateGitops(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().Build()
 
 	r := &ComponentReconciler{
-		Log:         ctrl.Log.WithName("controllers").WithName("Component"),
-		GitHubOrg:   github.AppStudioAppDataOrg,
-		GitToken:    "fake-token",
-		Executor:    executor,
-		Client:      fakeClient,
-		LocalClient: fakeClient,
+		Log:       ctrl.Log.WithName("controllers").WithName("Component"),
+		GitHubOrg: github.AppStudioAppDataOrg,
+		GitToken:  "fake-token",
+		Executor:  executor,
+		Client:    fakeClient,
 	}
 
 	// Create a second reconciler for testing error scenarios
 	errExec := testutils.NewMockExecutor()
 	errExec.Errors.Push(errors.New("Fatal error"))
 	errReconciler := &ComponentReconciler{
-		Log:         ctrl.Log.WithName("controllers").WithName("Component"),
-		GitHubOrg:   github.AppStudioAppDataOrg,
-		GitToken:    "fake-token",
-		Executor:    errExec,
-		Client:      fakeClient,
-		LocalClient: fakeClient,
+		Log:       ctrl.Log.WithName("controllers").WithName("Component"),
+		GitHubOrg: github.AppStudioAppDataOrg,
+		GitToken:  "fake-token",
+		Executor:  errExec,
+		Client:    fakeClient,
 	}
 
 	componentSpec := appstudiov1alpha1.ComponentSpec{

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -111,7 +111,6 @@ var _ = BeforeSuite(func() {
 
 	err = (&ComponentReconciler{
 		Client:          k8sManager.GetClient(),
-		LocalClient:     k8sManager.GetClient(),
 		Scheme:          k8sManager.GetScheme(),
 		Log:             ctrl.Log.WithName("controllers").WithName("Component"),
 		Executor:        testutils.NewMockExecutor(),

--- a/gitops/prepare/prepare_test.go
+++ b/gitops/prepare/prepare_test.go
@@ -85,7 +85,7 @@ func TestPrepareGitopsConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := fake.NewClientBuilder().WithRuntimeObjects(&tt.buildBundleConfigMap, &tt.pacSecret).Build()
-			if got := PrepareGitopsConfig(context.TODO(), client, client, component); !reflect.DeepEqual(got, tt.want) {
+			if got := PrepareGitopsConfig(context.TODO(), client, component); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("PrepareGitopsConfig() = %v, want %v", got, tt.want)
 			}
 		})
@@ -230,7 +230,7 @@ func TestResolveBuildBundle(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			client := fake.NewClientBuilder().WithRuntimeObjects(&tt.data).Build()
 
-			if got := ResolveBuildBundle(ctx, client, client, component.Namespace, tt.isHACBS); got != tt.want {
+			if got := ResolveBuildBundle(ctx, client, component.Namespace, tt.isHACBS); got != tt.want {
 				t.Errorf("ResolveBuildBundle() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?:
Removes KCP client that can access the workspace where the operator is deployed.
Changes behavior of gitops prepare, so now everything is taken from current cluster (KCP workspace)

### Which issue(s)/story(ies) does this PR fixes:
Removing KCP epic
