### PR TITLE
[DEVHAS-200] Remove duplicate application-api crd from default kustomize

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -13,7 +13,6 @@ namePrefix: application-service-
 #  someName: someValue
 
 bases:
-- https://github.com/redhat-appstudio/application-api/config/crd?ref=main
 - ../rbac
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

### What does this PR do?:
Removes the entry in the default kustomization.yaml that installs the application-api CRDs. The CRDs are installed via their own component (`application-api`) in infra-deployments, and our `make install` target also takes care of their installation for development. 

We do not want to duplicate the installation of the CRDs to avoid any potential conflicts.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-200
