### PR TITLE
Pull in latest application-api changes

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -68,7 +68,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
-	applicationAPIDepVersion := "v0.0.0-20221114151952-77cba9006505"
+	applicationAPIDepVersion := "v0.0.0-20221205185405-03f73a06d978"
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/onsi/gomega v1.20.1
 	github.com/openshift-pipelines/pipelines-as-code v0.0.0-20220622161720-2a6007e17200
 	github.com/openshift/api v0.0.0-20210503193030-25175d9d392d
-	github.com/redhat-appstudio/application-api v0.0.0-20221114151952-77cba9006505
+	github.com/redhat-appstudio/application-api v0.0.0-20221205185405-03f73a06d978
 	github.com/redhat-appstudio/service-provider-integration-scm-file-retriever v0.6.10
 	github.com/redhat-developer/alizer/go v0.0.0-20220704150640-ef50ead0b279
 	github.com/redhat-developer/gitops-generator v0.0.0-20221117222854-240399c18bc0

--- a/go.sum
+++ b/go.sum
@@ -1419,6 +1419,8 @@ github.com/rcrowley/go-metrics v0.0.0-20190706150252-9beb055b7962/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redhat-appstudio/application-api v0.0.0-20221114151952-77cba9006505 h1:8x+HtXDPJ9xmQbtWMdV5ntb0T+uEXjsmzzLgxpKFR1M=
 github.com/redhat-appstudio/application-api v0.0.0-20221114151952-77cba9006505/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
+github.com/redhat-appstudio/application-api v0.0.0-20221205185405-03f73a06d978 h1:ph20Fw9vs64KAHVCx3VoiaUBXY8A66cbtuDex+M9A8A=
+github.com/redhat-appstudio/application-api v0.0.0-20221205185405-03f73a06d978/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
 github.com/redhat-appstudio/service-provider-integration-operator v0.6.9 h1:SKPMsROcJLfJMK3pc+SrjUxjfswomUGW5Z1N7V7wlgE=
 github.com/redhat-appstudio/service-provider-integration-operator v0.6.9/go.mod h1:hp1bIdqAzmMrqFH1CuuqWEs0D/PQ03sSzzQhvSt+MCQ=
 github.com/redhat-appstudio/service-provider-integration-scm-file-retriever v0.6.10 h1:EGeBp8ZRwzvvfjFN5GpWTus8MOGkMbABCP5Tj2Ori6o=

--- a/go.sum
+++ b/go.sum
@@ -1417,8 +1417,6 @@ github.com/rabbitmq/amqp091-go v1.1.0/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0V
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20190706150252-9beb055b7962/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/redhat-appstudio/application-api v0.0.0-20221114151952-77cba9006505 h1:8x+HtXDPJ9xmQbtWMdV5ntb0T+uEXjsmzzLgxpKFR1M=
-github.com/redhat-appstudio/application-api v0.0.0-20221114151952-77cba9006505/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
 github.com/redhat-appstudio/application-api v0.0.0-20221205185405-03f73a06d978 h1:ph20Fw9vs64KAHVCx3VoiaUBXY8A66cbtuDex+M9A8A=
 github.com/redhat-appstudio/application-api v0.0.0-20221205185405-03f73a06d978/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
 github.com/redhat-appstudio/service-provider-integration-operator v0.6.9 h1:SKPMsROcJLfJMK3pc+SrjUxjfswomUGW5Z1N7V7wlgE=


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

### What does this PR do?:
Updates the application-api package version to latest, which pulls in the webhook validation for the `spec.displayName` field in Applications

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/projects/DEVHAS/issues/DEVHAS-206

