### PR TITLE
[DEVHAS-53] Use go-github to get commit ID

### DIFF
--- a/controllers/applicationsnapshotenvironmentbinding_controller.go
+++ b/controllers/applicationsnapshotenvironmentbinding_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	gh "github.com/google/go-github/v41/github"
 	gitopsgenv1alpha1 "github.com/redhat-developer/gitops-generator/api/v1alpha1"
 	gitopsgen "github.com/redhat-developer/gitops-generator/pkg"
 	"go.uber.org/zap/zapcore"
@@ -29,6 +30,7 @@ import (
 	"github.com/go-logr/logr"
 	logicalcluster "github.com/kcp-dev/logicalcluster/v2"
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	github "github.com/redhat-appstudio/application-service/pkg/github"
 	logutil "github.com/redhat-appstudio/application-service/pkg/log"
 	"github.com/redhat-appstudio/application-service/pkg/util"
 	"github.com/redhat-appstudio/application-service/pkg/util/ioutils"
@@ -49,11 +51,12 @@ import (
 // SnapshotEnvironmentBindingReconciler reconciles a SnapshotEnvironmentBinding object
 type SnapshotEnvironmentBindingReconciler struct {
 	client.Client
-	Scheme    *runtime.Scheme
-	Log       logr.Logger
-	AppFS     afero.Afero
-	Generator gitopsgen.Generator
-	GitToken  string
+	Scheme       *runtime.Scheme
+	Log          logr.Logger
+	AppFS        afero.Afero
+	Generator    gitopsgen.Generator
+	GitHubClient *gh.Client
+	GitToken     string
 }
 
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=snapshotenvironmentbindings,verbs=get;list;watch;create;update;patch;delete
@@ -252,12 +255,15 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 
 		// Retrieve the commit ID
 		var commitID string
-		repoPath := filepath.Join(tempDir, applicationName)
-		if commitID, err = r.Generator.GetCommitIDFromRepo(r.AppFS, repoPath); err != nil {
-			gitOpsErr := util.SanitizeErrorMessage(err)
-			log.Error(gitOpsErr, "unable to retrieve gitops repository commit id due to error")
-			r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, gitOpsErr)
-			return ctrl.Result{}, gitOpsErr
+		repoName, orgName, err := github.GetRepoAndOrgFromURL(gitOpsRemoteURL)
+		if err != nil {
+			log.Error(err, "unable to retrieve org and repository name from URL")
+			return ctrl.Result{}, err
+		}
+		commitID, err = github.GetLatestCommitSHAFromRepository(r.GitHubClient, ctx, repoName, orgName, gitOpsBranch)
+		if err != nil {
+			log.Error(err, "unable to retrieve gitops repository commit id due to error")
+			return ctrl.Result{}, err
 		}
 
 		if !isStatusUpdated {

--- a/controllers/applicationsnapshotenvironmentbinding_controller_test.go
+++ b/controllers/applicationsnapshotenvironmentbinding_controller_test.go
@@ -1767,7 +1767,7 @@ var _ = Describe("SnapshotEnvironmentBinding controller", func() {
 
 			replicas := int32(3)
 
-			createAndFetchSimpleApp(applicationName, HASAppNamespace, DisplayName, Description)
+			createAndFetchSimpleAppWithRepo(applicationName, HASAppNamespace, DisplayName, Description, "https://github.com/fakeorg/test-error-response")
 			hasComp := createAndFetchSimpleComponent(componentName, HASAppNamespace, ComponentName, applicationName, SampleRepoLink, false)
 			// Make sure the devfile model was properly set in Component
 			Expect(hasComp.Status.Devfile).Should(Not(Equal("")))
@@ -1874,7 +1874,149 @@ var _ = Describe("SnapshotEnvironmentBinding controller", func() {
 			// Validate that the GitOps resources for the bound component(s) were generated, but not for any that explicitly had skipGitOpsResourceGeneration set
 			Expect(createdBinding.Status.GitOpsRepoConditions[0].Status).Should(Equal(metav1.ConditionFalse))
 			Expect(createdBinding.Status.GitOpsRepoConditions[0].Reason).Should(Equal("GenerateError"))
-			Expect(createdBinding.Status.GitOpsRepoConditions[0].Message).Should(ContainSubstring("failed to retrieve commit id for repository"))
+			Expect(createdBinding.Status.GitOpsRepoConditions[0].Message).Should(ContainSubstring("unable to retrieve gitops repository commit id due to error"))
+
+			// Delete the specified Component resources
+			hasCompLookupKey := types.NamespacedName{Name: componentName, Namespace: HASAppNamespace}
+			deleteHASCompCR(hasCompLookupKey)
+
+			// Delete the specified App resource
+			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
+			deleteHASAppCR(hasAppLookupKey)
+
+			// Delete the specified binding
+			deleteBinding(bindingLookupKey)
+
+			// Delete the specified snapshot
+			deleteSnapshot(appSnapshotLookupKey)
+
+			// Delete the specified environment
+			stagingEnvLookupKey := types.NamespacedName{Name: environmentName, Namespace: HASAppNamespace}
+			deleteEnvironment(stagingEnvLookupKey)
+
+		})
+	})
+
+	Context("Create SnapshotEnvironmentBinding with error parsing gitops repository URL", func() {
+		It("Should return error with the proper message set", func() {
+			ctx := context.Background()
+
+			applicationName := HASAppName + "test-git-error" + "13"
+			componentName := HASCompName + "13"
+			snapshotName := HASSnapshotName + "13"
+			bindingName := HASBindingName + "13"
+			environmentName := "staging"
+
+			replicas := int32(3)
+
+			createAndFetchSimpleAppWithRepo(applicationName, HASAppNamespace, DisplayName, Description, "https://github.com///")
+			hasComp := createAndFetchSimpleComponent(componentName, HASAppNamespace, ComponentName, applicationName, SampleRepoLink, false)
+			// Make sure the devfile model was properly set in Component
+			Expect(hasComp.Status.Devfile).Should(Not(Equal("")))
+
+			appSnapshot := &appstudiov1alpha1.Snapshot{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "Snapshot",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      snapshotName,
+					Namespace: HASAppNamespace,
+				},
+				Spec: appstudiov1alpha1.SnapshotSpec{
+					Application:        applicationName,
+					DisplayName:        "My Snapshot",
+					DisplayDescription: "My Snapshot",
+					Components: []appstudiov1alpha1.SnapshotComponent{
+						{
+							Name:           componentName,
+							ContainerImage: "image1",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, appSnapshot)).Should(Succeed())
+
+			appSnapshotLookupKey := types.NamespacedName{Name: snapshotName, Namespace: HASAppNamespace}
+			createdAppSnapshot := &appstudiov1alpha1.Snapshot{}
+			Eventually(func() bool {
+				k8sClient.Get(context.Background(), appSnapshotLookupKey, createdAppSnapshot)
+				return len(createdAppSnapshot.Spec.Components) > 0
+			}, timeout, interval).Should(BeTrue())
+
+			stagingEnv := &appstudiov1alpha1.Environment{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "Environment",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      environmentName,
+					Namespace: HASAppNamespace,
+				},
+				Spec: appstudiov1alpha1.EnvironmentSpec{
+					Type:               "POC",
+					DisplayName:        DisplayName,
+					DeploymentStrategy: appstudiov1alpha1.DeploymentStrategy_AppStudioAutomated,
+					Configuration: appstudiov1alpha1.EnvironmentConfiguration{
+						Env: []appstudiov1alpha1.EnvVarPair{
+							{
+								Name:  "FOO",
+								Value: "BAR",
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, stagingEnv)).Should(Succeed())
+
+			appBinding := &appstudiov1alpha1.SnapshotEnvironmentBinding{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "SnapshotEnvironmentBinding",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      bindingName,
+					Namespace: HASAppNamespace,
+				},
+				Spec: appstudiov1alpha1.SnapshotEnvironmentBindingSpec{
+					Application: applicationName,
+					Environment: environmentName,
+					Snapshot:    snapshotName,
+					Components: []appstudiov1alpha1.BindingComponent{
+						{
+							Name: componentName,
+							Configuration: appstudiov1alpha1.BindingComponentConfiguration{
+								Replicas: int(replicas),
+								Env: []appstudiov1alpha1.EnvVarPair{
+									{
+										Name:  "FOO",
+										Value: "BAR",
+									},
+								},
+								Resources: &corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU: resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, appBinding)).Should(Succeed())
+
+			bindingLookupKey := types.NamespacedName{Name: bindingName, Namespace: HASAppNamespace}
+			createdBinding := &appstudiov1alpha1.SnapshotEnvironmentBinding{}
+			Eventually(func() bool {
+				k8sClient.Get(context.Background(), bindingLookupKey, createdBinding)
+				return len(createdBinding.Status.GitOpsRepoConditions) > 0
+			}, timeout, interval).Should(BeTrue())
+
+			// Validate that the GitOps resources for the bound component(s) were generated, but not for any that explicitly had skipGitOpsResourceGeneration set
+			Expect(createdBinding.Status.GitOpsRepoConditions[0].Status).Should(Equal(metav1.ConditionFalse))
+			Expect(createdBinding.Status.GitOpsRepoConditions[0].Reason).Should(Equal("GenerateError"))
+			Expect(createdBinding.Status.GitOpsRepoConditions[0].Message).Should(ContainSubstring("unable to parse gitops repository"))
 
 			// Delete the specified Component resources
 			hasCompLookupKey := types.NamespacedName{Name: componentName, Namespace: HASAppNamespace}

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -496,14 +496,14 @@ func (r *ComponentReconciler) generateGitops(ctx context.Context, req ctrl.Reque
 	var commitID string
 	repoName, orgName, err := github.GetRepoAndOrgFromURL(gitOpsURL)
 	if err != nil {
-		gitOpsErr := util.SanitizeErrorMessage(err)
-		log.Error(gitOpsErr, "unable to retrieve org and repository name from URL")
+		gitOpsErr := util.SanitizeErrorMessage(fmt.Errorf("unable to parse gitops repository %s due to error: %v", gitOpsURL, err))
+		log.Error(gitOpsErr, "")
 		return gitOpsErr
 	}
 	commitID, err = github.GetLatestCommitSHAFromRepository(r.GitHubClient, ctx, repoName, orgName, gitOpsBranch)
 	if err != nil {
-		gitOpsErr := util.SanitizeErrorMessage(err)
-		log.Error(err, "unable to retrieve gitops repository commit id due to error")
+		gitOpsErr := util.SanitizeErrorMessage(fmt.Errorf("unable to retrieve gitops repository commit id due to error: %v", err))
+		log.Error(gitOpsErr, "")
 		return gitOpsErr
 	}
 	component.Status.GitOps.CommitID = commitID

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -496,13 +496,15 @@ func (r *ComponentReconciler) generateGitops(ctx context.Context, req ctrl.Reque
 	var commitID string
 	repoName, orgName, err := github.GetRepoAndOrgFromURL(gitOpsURL)
 	if err != nil {
-		log.Error(err, "unable to retrieve org and repository name from URL")
-		return err
+		gitOpsErr := util.SanitizeErrorMessage(err)
+		log.Error(gitOpsErr, "unable to retrieve org and repository name from URL")
+		return gitOpsErr
 	}
 	commitID, err = github.GetLatestCommitSHAFromRepository(r.GitHubClient, ctx, repoName, orgName, gitOpsBranch)
 	if err != nil {
+		gitOpsErr := util.SanitizeErrorMessage(err)
 		log.Error(err, "unable to retrieve gitops repository commit id due to error")
-		return err
+		return gitOpsErr
 	}
 	component.Status.GitOps.CommitID = commitID
 

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"reflect"
 	"time"
 
@@ -43,6 +42,7 @@ import (
 	"github.com/devfile/api/v2/pkg/attributes"
 	data "github.com/devfile/library/pkg/devfile/parser/data"
 	"github.com/go-logr/logr"
+	gh "github.com/google/go-github/v41/github"
 	logicalcluster "github.com/kcp-dev/logicalcluster/v2"
 	routev1 "github.com/openshift/api/route/v1"
 
@@ -50,6 +50,7 @@ import (
 	appservicegitops "github.com/redhat-appstudio/application-service/gitops"
 	"github.com/redhat-appstudio/application-service/gitops/prepare"
 	devfile "github.com/redhat-appstudio/application-service/pkg/devfile"
+	"github.com/redhat-appstudio/application-service/pkg/github"
 	logutil "github.com/redhat-appstudio/application-service/pkg/log"
 	"github.com/redhat-appstudio/application-service/pkg/spi"
 	"github.com/redhat-appstudio/application-service/pkg/util"
@@ -70,6 +71,7 @@ type ComponentReconciler struct {
 	Generator       gitopsgen.Generator
 	AppFS           afero.Afero
 	SPIClient       spi.SPI
+	GitHubClient    *gh.Client
 }
 
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components,verbs=get;list;watch;create;update;patch;delete
@@ -492,11 +494,15 @@ func (r *ComponentReconciler) generateGitops(ctx context.Context, req ctrl.Reque
 
 	// Get the commit ID for the gitops repository
 	var commitID string
-	repoPath := filepath.Join(tempDir, component.Name)
-	if commitID, err = r.Generator.GetCommitIDFromRepo(r.AppFS, repoPath); err != nil {
-		gitOpsErr := util.SanitizeErrorMessage(err)
-		log.Error(gitOpsErr, "unable to retrieve gitops repository commit id due to error")
-		return gitOpsErr
+	repoName, orgName, err := github.GetRepoAndOrgFromURL(gitOpsURL)
+	if err != nil {
+		log.Error(err, "unable to retrieve org and repository name from URL")
+		return err
+	}
+	commitID, err = github.GetLatestCommitSHAFromRepository(r.GitHubClient, ctx, repoName, orgName, gitOpsBranch)
+	if err != nil {
+		log.Error(err, "unable to retrieve gitops repository commit id due to error")
+		return err
 	}
 	component.Status.GitOps.CommitID = commitID
 

--- a/controllers/component_controller_unit_test.go
+++ b/controllers/component_controller_unit_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -151,26 +152,29 @@ func TestSetGitOpsStatus(t *testing.T) {
 func TestGenerateGitops(t *testing.T) {
 	appFS := ioutils.NewMemoryFilesystem()
 	readOnlyFs := ioutils.NewReadOnlyFs()
+	ctx := context.Background()
 
 	fakeClient := fake.NewClientBuilder().Build()
 
 	r := &ComponentReconciler{
-		Log:       ctrl.Log.WithName("controllers").WithName("Component"),
-		GitHubOrg: github.AppStudioAppDataOrg,
-		GitToken:  "fake-token",
-		Generator: gitops.NewMockGenerator(),
-		Client:    fakeClient,
+		Log:          ctrl.Log.WithName("controllers").WithName("Component"),
+		GitHubOrg:    github.AppStudioAppDataOrg,
+		GitToken:     "fake-token",
+		Generator:    gitops.NewMockGenerator(),
+		Client:       fakeClient,
+		GitHubClient: github.GetMockedClient(),
 	}
 
 	// Create a second reconciler for testing error scenarios
 	errGen := gitops.NewMockGenerator()
 	errGen.Errors.Push(errors.New("Fatal error"))
 	errReconciler := &ComponentReconciler{
-		Log:       ctrl.Log.WithName("controllers").WithName("Component"),
-		GitHubOrg: github.AppStudioAppDataOrg,
-		GitToken:  "fake-token",
-		Generator: errGen,
-		Client:    fakeClient,
+		Log:          ctrl.Log.WithName("controllers").WithName("Component"),
+		GitHubOrg:    github.AppStudioAppDataOrg,
+		GitToken:     "fake-token",
+		Generator:    errGen,
+		Client:       fakeClient,
+		GitHubClient: github.GetMockedClient(),
 	}
 
 	componentSpec := appstudiov1alpha1.ComponentSpec{
@@ -356,7 +360,7 @@ func TestGenerateGitops(t *testing.T) {
 				Spec: componentSpec,
 				Status: appstudiov1alpha1.ComponentStatus{
 					GitOps: appstudiov1alpha1.GitOpsStatus{
-						RepositoryURL: "https://github.com/test/repo",
+						RepositoryURL: "https://github.com/test/test-error-response",
 					},
 				},
 			},

--- a/controllers/component_controller_unit_test.go
+++ b/controllers/component_controller_unit_test.go
@@ -366,6 +366,28 @@ func TestGenerateGitops(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name:       "Fail to retrieve commit ID for GitOps repository with invalid repo [Mock]",
+			reconciler: r,
+			fs:         appFS,
+			component: &appstudiov1alpha1.Component{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "Component",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-git-error",
+					Namespace: "test-namespace",
+				},
+				Spec: componentSpec,
+				Status: appstudiov1alpha1.ComponentStatus{
+					GitOps: appstudiov1alpha1.GitOpsStatus{
+						RepositoryURL: "https://github.com///",
+					},
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -118,6 +118,7 @@ var _ = BeforeSuite(func() {
 		AppFS:           ioutils.NewMemoryFilesystem(),
 		ImageRepository: "docker.io/foo/customized",
 		SPIClient:       spi.MockSPIClient{},
+		GitHubClient:    github.GetMockedClient(),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -133,11 +134,12 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&SnapshotEnvironmentBindingReconciler{
-		Client:    k8sManager.GetClient(),
-		Scheme:    k8sManager.GetScheme(),
-		Log:       ctrl.Log.WithName("controllers").WithName("SnapshotEnvironmentBinding"),
-		Generator: gitops.NewMockGenerator(),
-		AppFS:     ioutils.NewMemoryFilesystem(),
+		Client:       k8sManager.GetClient(),
+		Scheme:       k8sManager.GetScheme(),
+		Log:          ctrl.Log.WithName("controllers").WithName("SnapshotEnvironmentBinding"),
+		Generator:    gitops.NewMockGenerator(),
+		AppFS:        ioutils.NewMemoryFilesystem(),
+		GitHubClient: github.GetMockedClient(),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/go-github/v41 v41.0.0
 	github.com/kcp-dev/kcp/pkg/apis v0.7.0
 	github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1
-	github.com/migueleliasweb/go-github-mock v0.0.10
+	github.com/migueleliasweb/go-github-mock v0.0.13
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.20.1

--- a/go.sum
+++ b/go.sum
@@ -1144,8 +1144,8 @@ github.com/miekg/dns v1.1.35/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
-github.com/migueleliasweb/go-github-mock v0.0.10 h1:VTaNa4eYzkRpnZ7Fqop7Jldgh7vsUsgnKWXDOnAvm3k=
-github.com/migueleliasweb/go-github-mock v0.0.10/go.mod h1:mD5w+9J3oBBMLr7uD6owEYlYBAL8tZd+BA7iGjI4EU8=
+github.com/migueleliasweb/go-github-mock v0.0.13 h1:pV4yG4XlL/fEPE1Er6MzErAYFyiRSBYw1oo2OojTiCQ=
+github.com/migueleliasweb/go-github-mock v0.0.13/go.mod h1:mD5w+9J3oBBMLr7uD6owEYlYBAL8tZd+BA7iGjI4EU8=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=

--- a/main.go
+++ b/main.go
@@ -197,6 +197,7 @@ func main() {
 		GitToken:        ghToken,
 		ImageRepository: imageRepository,
 		SPIClient:       spi.SPIClient{},
+		GitHubClient:    client,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Component")
 		os.Exit(1)
@@ -227,12 +228,13 @@ func main() {
 	}
 
 	if err = (&controllers.SnapshotEnvironmentBindingReconciler{
-		Client:    mgr.GetClient(),
-		Scheme:    mgr.GetScheme(),
-		Log:       ctrl.Log.WithName("controllers").WithName("SnapshotEnvironmentBinding").WithValues("appstudio-component", "HAS"),
-		Generator: gitopsgen.NewGitopsGen(),
-		AppFS:     ioutils.NewFilesystem(),
-		GitToken:  ghToken,
+		Client:       mgr.GetClient(),
+		Scheme:       mgr.GetScheme(),
+		Log:          ctrl.Log.WithName("controllers").WithName("SnapshotEnvironmentBinding").WithValues("appstudio-component", "HAS"),
+		Generator:    gitopsgen.NewGitopsGen(),
+		AppFS:        ioutils.NewFilesystem(),
+		GitToken:     ghToken,
+		GitHubClient: client,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SnapshotEnvironmentBinding")
 		os.Exit(1)

--- a/pkg/github/mock.go
+++ b/pkg/github/mock.go
@@ -69,6 +69,20 @@ func GetMockedClient() *github.Client {
 				}))
 			}),
 		),
+		mock.WithRequestMatchHandler(
+			mock.GetReposCommitsByOwnerByRepoByRef,
+			http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if strings.Contains(req.RequestURI, "test-error-response") {
+					mock.WriteError(w,
+						http.StatusInternalServerError,
+						"github went belly up or something",
+					)
+				} else {
+					/* #nosec G104 -- test code */
+					w.Write([]byte("ca82a6dff817ec66f44342007202690a93763949"))
+				}
+			}),
+		),
 	)
 
 	return github.NewClient(mockedHTTPClient)


### PR DESCRIPTION
### What does this PR do?:
Updates the logic in the Component and ASEB controllers to use go-github to get the Commit ID instead of using the gitops generator library. This will allow us to separate out the gitops resource generation to a job, without having to report back the commit ID from it somehow.

### Which issue(s)/story(ies) does this PR fixes:
Part of https://issues.redhat.com/projects/DEVHAS/issues/DEVHAS-53?filter=allopenissues

### PR acceptance criteria:
Commit ID is added and present in the status of Component and ASEB resources (as was before).