### PR TITLE
[DEVHAS-213] Properly handle CDQs for repo URL with tailing '/'

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,5 @@
 ignore:
   - "api/v1alpha1/zz_generated.deepcopy.go" # generated file, does not need to be included in the coverage
   - "pkg/spi/spi_mock.go" # mock file for testing
-  - "pkg/devfile/detect_mock.go" #mock file for testing
+  - "pkg/devfile/detect_mock.go" # mock file for testing
+  - "gitops/generate_mock.go" # mock file for testing

--- a/controllers/componentdetectionquery_controller_conditions_test.go
+++ b/controllers/componentdetectionquery_controller_conditions_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Red Hat, Inc.
+Copyright 2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/componentdetectionquery_controller_conditions_test.go
+++ b/controllers/componentdetectionquery_controller_conditions_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+)
+
+func TestSetCompleteConditionAndUpdateCR(t *testing.T) {
+	// Set up a fake Kubernetes client and Component reconciler
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(appstudiov1alpha1.AddToScheme(scheme))
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &ComponentDetectionQueryReconciler{
+		Log:    ctrl.Log.WithName("controllers").WithName("Component"),
+		Client: fakeClient,
+	}
+
+	originalCDQ := appstudiov1alpha1.ComponentDetectionQuery{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "appstudio.redhat.com/v1alpha1",
+			Kind:       "ComponentDetectionQuery",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cdq",
+			Namespace: "test-namespace",
+		},
+		Spec: appstudiov1alpha1.ComponentDetectionQuerySpec{
+			GitSource: appstudiov1alpha1.GitSource{
+				URL: "https://github.com/fakeorg/fakerepo",
+			},
+		},
+	}
+	r.Client.Create(context.Background(), &originalCDQ)
+
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "test-namespace",
+			Name:      "test-cdq",
+		},
+	}
+
+	tests := []struct {
+		name          string
+		originalCDQ   appstudiov1alpha1.ComponentDetectionQuery
+		updateCDQ     appstudiov1alpha1.ComponentDetectionQuery
+		err           error
+		wantCondition metav1.Condition
+	}{
+		{
+			name:        "Simple CDQ, no error",
+			originalCDQ: originalCDQ,
+			updateCDQ:   originalCDQ,
+			wantCondition: metav1.Condition{
+				Type:    "Completed",
+				Status:  metav1.ConditionTrue,
+				Reason:  "OK",
+				Message: "ComponentDetectionQuery has successfully finished",
+			},
+		},
+		{
+			name:        "Simple CDQ, with error",
+			originalCDQ: originalCDQ,
+			updateCDQ:   originalCDQ,
+			err:         fmt.Errorf("some error"),
+			wantCondition: metav1.Condition{
+				Type:    "Completed",
+				Status:  metav1.ConditionFalse,
+				Reason:  "Error",
+				Message: fmt.Sprintf("ComponentDetectionQuery failed: %v", fmt.Errorf("some error")),
+			},
+		},
+		{
+			name:        "CDQ with invalid status fields",
+			originalCDQ: originalCDQ,
+			updateCDQ: appstudiov1alpha1.ComponentDetectionQuery{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "ComponentDetectionQuery",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cdq",
+					Namespace: "test-namespace",
+				},
+				Spec: appstudiov1alpha1.ComponentDetectionQuerySpec{
+					GitSource: appstudiov1alpha1.GitSource{
+						URL: "https://github.com/fakeorg/fakerepo",
+					},
+				},
+				Status: appstudiov1alpha1.ComponentDetectionQueryStatus{
+					ComponentDetected: appstudiov1alpha1.ComponentDetectionMap{
+						"-ohu7": appstudiov1alpha1.ComponentDetectionDescription{
+							ComponentStub: appstudiov1alpha1.ComponentSpec{
+								ComponentName: "-ohu7",
+							},
+						},
+					},
+				},
+			},
+			err: fmt.Errorf("some error"),
+			wantCondition: metav1.Condition{
+				Type:    "Completed",
+				Status:  metav1.ConditionFalse,
+				Reason:  "Error",
+				Message: fmt.Sprintf("ComponentDetectionQuery failed: %v", fmt.Errorf("some error")),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r.SetCompleteConditionAndUpdateCR(context.Background(), request, &tt.updateCDQ, &tt.originalCDQ, tt.err)
+
+			// Now get the resource and verify its status condition
+			getCDQ := appstudiov1alpha1.ComponentDetectionQuery{}
+			err := r.Client.Get(context.Background(), types.NamespacedName{Namespace: "test-namespace", Name: "test-cdq"}, &getCDQ)
+			if err != nil {
+				t.Errorf("TestSetCompleteConditionAndUpdateCR(): Unexpected error: %v", err)
+			}
+
+			if len(getCDQ.Status.Conditions) != 1 {
+				t.Errorf("TestSetCompleteConditionAndUpdateCR(): Unexpected error, length of %v was %v, not 1", getCDQ.Status.Conditions, len(getCDQ.Status.Conditions))
+			}
+			tt.wantCondition.LastTransitionTime = getCDQ.Status.Conditions[0].LastTransitionTime
+			tt.wantCondition.ObservedGeneration = getCDQ.Status.Conditions[0].ObservedGeneration
+			if !reflect.DeepEqual(getCDQ.Status.Conditions[0], tt.wantCondition) {
+				t.Errorf("TestSetCompleteConditionAndUpdateCR(): expected %v, got %v", tt.wantCondition, getCDQ.Status.Conditions[0])
+			}
+		})
+	}
+}

--- a/controllers/update.go
+++ b/controllers/update.go
@@ -496,18 +496,25 @@ func (r *ComponentDetectionQueryReconciler) updateComponentStub(req ctrl.Request
 }
 
 func getComponentName(gitSource *appstudiov1alpha1.GitSource) string {
+	var componentName string
 	repoUrl := gitSource.URL
-	// If the repository URL ends in a forward slash, remove it to avoid issues with parsing the repository name
-	if string(repoUrl[len(repoUrl)-1]) == "/" {
-		repoUrl = repoUrl[0 : len(repoUrl)-1]
+
+	if len(repoUrl) != 0 {
+		// If the repository URL ends in a forward slash, remove it to avoid issues with parsing the repository name
+		if string(repoUrl[len(repoUrl)-1]) == "/" {
+			repoUrl = repoUrl[0 : len(repoUrl)-1]
+		}
+		lastElement := repoUrl[strings.LastIndex(repoUrl, "/")+1:]
+		repoName := strings.Split(lastElement, ".git")[0]
+		componentName = repoName
+		context := gitSource.Context
+		if context != "" && context != "./" && context != "." {
+			componentName = fmt.Sprintf("%s-%s", context, repoName)
+		}
 	}
-	lastElement := repoUrl[strings.LastIndex(repoUrl, "/")+1:]
-	repoName := strings.Split(lastElement, ".git")[0]
-	componentName := repoName
-	context := gitSource.Context
-	if context != "" && context != "./" && context != "." {
-		componentName = fmt.Sprintf("%s-%s", context, repoName)
-	}
+
+	// Return a sanitized version of the component name
+	// If len(componentName) is 0, then it will also handle generating a random name for it.
 	return sanitizeComponentName(componentName)
 }
 

--- a/gitops/generate_build.go
+++ b/gitops/generate_build.go
@@ -29,8 +29,6 @@ import (
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	gitopsprepare "github.com/redhat-appstudio/application-service/gitops/prepare"
 	"github.com/spf13/afero"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -82,22 +80,6 @@ func GenerateBuild(fs afero.Fs, outputFolder string, component appstudiov1alpha1
 		return err
 	}
 	return nil
-}
-
-// Generate volumeClaimTemplate for pipeline runs that requires their own PVC during run.
-func GenerateVolumeClaimTemplate() *corev1.PersistentVolumeClaim {
-	return &corev1.PersistentVolumeClaim{
-		Spec: corev1.PersistentVolumeClaimSpec{
-			AccessModes: []corev1.PersistentVolumeAccessMode{
-				"ReadWriteOnce",
-			},
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					"storage": resource.MustParse("1Gi"),
-				},
-			},
-		},
-	}
 }
 
 func getBuildCommonLabelsForComponent(component *appstudiov1alpha1.Component) map[string]string {

--- a/gitops/generate_test.go
+++ b/gitops/generate_test.go
@@ -122,3 +122,34 @@ func TestGenerateTektonBuild(t *testing.T) {
 		})
 	}
 }
+
+func TestGetAndSetDefaultImageRepo(t *testing.T) {
+
+	tests := []struct {
+		name      string
+		imageRepo string
+		want      string
+	}{
+		{
+			name: "Get default image repo",
+			want: "quay.io/redhat-appstudio/user-workload",
+		},
+		{
+			name:      "Override default image repo",
+			imageRepo: "quay.io/myuser/myrepo",
+			want:      "quay.io/myuser/myrepo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.imageRepo != "" {
+				SetDefaultImageRepo(tt.imageRepo)
+			}
+			imageRepo := GetDefaultImageRepo()
+			if imageRepo != tt.want {
+				t.Errorf("TestGetAndSetDefaultImageRepo(): want %v, got %v", tt.want, imageRepo)
+			}
+		})
+	}
+}

--- a/license_header.txt
+++ b/license_header.txt
@@ -1,5 +1,5 @@
 
-Copyright 2022 Red Hat, Inc.
+Copyright 2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

### What does this PR do?:
This PR updates the logic for the component name generation that CDQs use to properly handle Git repositories that end with a tailing forward slash (e.g. https://github.com/devfile-samples/devfile-sample-java-springboot-basic/). Previously, an empty string would be returned, instead of the Git repository name, leading to an invalid Component name like `-ohu7`.  With this change, we now properly handle URLs with a tailing slash. Furthermore, if `sanitizeComponentName` is called with an empty name, we use the `gofakeit` package to generate an empty string. 

Additionally, I've updated the logic setting the status on CDQs, where if the status update fails, we try again by only updating the status condition.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-213

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
