### PR TITLE
fix: evaluate devfile before dockerfile

### DIFF
--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -236,6 +236,14 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 					}
 				}
 
+			} else if source.GitSource.DevfileURL != "" {
+				devfileBytes, err = util.CurlEndpoint(source.GitSource.DevfileURL)
+				if err != nil {
+					log.Error(err, fmt.Sprintf("Unable to GET %s, exiting reconcile loop %v", source.GitSource.DevfileURL, req.NamespacedName))
+					err := fmt.Errorf("unable to GET from %s", source.GitSource.DevfileURL)
+					r.SetCreateConditionAndUpdateCR(ctx, req, &component, err)
+					return ctrl.Result{}, err
+				}
 			} else if source.GitSource.DockerfileURL != "" {
 				devfileData, err := devfile.CreateDevfileForDockerfileBuild(source.GitSource.DockerfileURL, context)
 				if err != nil {
@@ -249,14 +257,6 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 					log.Error(err, fmt.Sprintf("Unable to marshall devfile, exiting reconcile loop %v", req.NamespacedName))
 					r.SetCreateConditionAndUpdateCR(ctx, req, &component, err)
 					return ctrl.Result{}, nil
-				}
-			} else if source.GitSource.DevfileURL != "" {
-				devfileBytes, err = util.CurlEndpoint(source.GitSource.DevfileURL)
-				if err != nil {
-					log.Error(err, fmt.Sprintf("Unable to GET %s, exiting reconcile loop %v", source.GitSource.DevfileURL, req.NamespacedName))
-					err := fmt.Errorf("unable to GET from %s", source.GitSource.DevfileURL)
-					r.SetCreateConditionAndUpdateCR(ctx, req, &component, err)
-					return ctrl.Result{}, err
 				}
 			}
 


### PR DESCRIPTION
When component provides devfileUrl and dockerfileUrl then prefer devfileUrl. Otherwise devfileUrl is completely ignored - metadata are lost.

We need to pass language metadata from devfile to status so that build-service can properly select pipeline - [PLNSRVCE-799](https://issues.redhat.com//browse/PLNSRVCE-799)

### What does this PR do?:
<!-- _Summarize the changes_ -->

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
