### PR TITLE
Fix PaC Repository CR generation in gitops

### DIFF
--- a/gitops/prepare/prepare.go
+++ b/gitops/prepare/prepare.go
@@ -45,6 +45,8 @@ const (
 	RegistrySecret = "redhat-appstudio-registry-pull-secret"
 	// Pipelines as Code global configuration secret name
 	PipelinesAsCodeSecretName = "pipelines-as-code-secret"
+	// Pipelines as Code global configuration secret namespace
+	buildServiceNamespaceName = "build-service"
 	// ConfigMap name for detection hacbs workflow
 	// Note: HACBS detection by configmap is temporary solution, will be changed to detection based
 	// on APIBinding API in KCP environment.
@@ -131,7 +133,7 @@ func resolveRegistrySecretPresence(ctx context.Context, cli client.Client, compo
 
 func getPipelinesAsCodeConfigurationSecretData(ctx context.Context, cli client.Client, component appstudiov1alpha1.Component) map[string][]byte {
 	pacSecret := &corev1.Secret{}
-	err := cli.Get(ctx, types.NamespacedName{Name: PipelinesAsCodeSecretName, Namespace: component.Namespace}, pacSecret)
+	err := cli.Get(ctx, types.NamespacedName{Name: PipelinesAsCodeSecretName, Namespace: buildServiceNamespaceName}, pacSecret)
 	if err != nil {
 		return make(map[string][]byte)
 	}

--- a/gitops/prepare/prepare_test.go
+++ b/gitops/prepare/prepare_test.go
@@ -67,7 +67,7 @@ func TestPrepareGitopsConfig(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      PipelinesAsCodeSecretName,
-					Namespace: component.Namespace,
+					Namespace: buildServiceNamespaceName,
 				},
 				Data: map[string][]byte{
 					"github.token": []byte("ghp_token"),
@@ -311,7 +311,7 @@ func TestGetPipelinesAsCodeConfigurationSecretData(t *testing.T) {
 			name: "secret exists",
 			data: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: component.Namespace,
+					Namespace: buildServiceNamespaceName,
 					Name:      PipelinesAsCodeSecretName,
 				},
 				Data: map[string][]byte{


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?:
Change the namespace from component's to the global where `pipelines-as-code-secret` is searched for.
This allows to correctly detect if GitHub PaC Application is used and crerate PaC Repository CR correctly in GitOps repository.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/PLNSRVCE-983

### PR acceptance criteria:

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:

Test build via PaC GitHub Application after ArgoCD syncs gitops repository to the cluster.
