### PR TITLE
Event listeners removed, should not not be handled

### DIFF
--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -44,7 +44,6 @@ import (
 	"github.com/go-logr/logr"
 	gh "github.com/google/go-github/v41/github"
 	logicalcluster "github.com/kcp-dev/logicalcluster/v2"
-	routev1 "github.com/openshift/api/route/v1"
 
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	appservicegitops "github.com/redhat-appstudio/application-service/gitops"
@@ -415,35 +414,6 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		} else {
 			log.Info(fmt.Sprintf("The Component devfile data was not updated %v", req.NamespacedName))
-		}
-	}
-
-	// Get the Webhook from the event listener route and update it
-	// Only attempt to get it if the build generation succeeded, otherwise the route won't exist
-	// Don't get webhook route on KCP
-	if req.ClusterName == "" {
-		if len(component.Status.Conditions) > 0 && component.Status.Conditions[len(component.Status.Conditions)-1].Status == metav1.ConditionTrue &&
-			component.Spec.Source.GitSource != nil && component.Spec.Source.GitSource.URL != "" &&
-			(component.ObjectMeta.Annotations == nil || component.ObjectMeta.Annotations[appservicegitops.PaCAnnotation] != "1") {
-			createdWebhook := &routev1.Route{}
-			err = r.Client.Get(ctx, types.NamespacedName{Name: "el" + component.Name, Namespace: component.Namespace}, createdWebhook)
-			if err != nil {
-				if errors.IsNotFound(err) {
-					log.Error(err, fmt.Sprintf("Unable to fetch the created webhook %v, retrying", "el-"+component.Name))
-					return ctrl.Result{Requeue: true}, nil
-				} else {
-					return ctrl.Result{}, err
-				}
-			}
-
-			// Get the ingress url from the status of the route, if it exists
-			if len(createdWebhook.Status.Ingress) != 0 {
-				component.Status.Webhook = createdWebhook.Status.Ingress[0].Host
-				err := r.Client.Status().Update(ctx, &component)
-				if err != nil {
-					return ctrl.Result{}, err
-				}
-			}
 		}
 	}
 


### PR DESCRIPTION
Removing eventlistener route handling since tektontriggers and eventlisteners are not used anymore.

### What does this PR do?:
<!-- _Summarize the changes_ -->

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
