### PR TITLE
[DEVHAS-225] Set devfile repo context when scanning multi-component repos

### DIFF
--- a/pkg/devfile/devfile.go
+++ b/pkg/devfile/devfile.go
@@ -247,6 +247,6 @@ func DownloadDevfileAndDockerfile(url string) ([]byte, string, []byte) {
 // Map 1 returns a context to the devfile bytes if present.
 // Map 2 returns a context to the matched devfileURL from the devfile registry if no devfile is present in the context.
 // Map 3 returns a context to the dockerfile uri or a matched dockerfileURL from the devfile registry if no dockerfile is present in the context
-func ScanRepo(log logr.Logger, a Alizer, localpath string, devfileRegistryURL string) (map[string][]byte, map[string]string, map[string]string, error) {
+func ScanRepo(log logr.Logger, a Alizer, localpath string, devfileRegistryURL string) (map[string][]byte, map[string]string, map[string]string, map[string]string, error) {
 	return search(log, a, localpath, devfileRegistryURL)
 }

--- a/pkg/devfile/devfile_test.go
+++ b/pkg/devfile/devfile_test.go
@@ -418,7 +418,7 @@ func TestScanRepo(t *testing.T) {
 			if err != nil {
 				t.Errorf("got unexpected error %v", err)
 			} else {
-				devfileMap, devfileURLMap, dockerfileMap, err := ScanRepo(logger, alizerClient, tt.clonePath, DevfileStageRegistryEndpoint)
+				devfileMap, devfileURLMap, dockerfileMap, _, err := ScanRepo(logger, alizerClient, tt.clonePath, DevfileStageRegistryEndpoint)
 				if tt.wantErr && (err == nil) {
 					t.Error("wanted error but got nil")
 				} else if !tt.wantErr && err != nil {


### PR DESCRIPTION
### What does this PR do?:
This PR updates the `devfile.search()` function so that if a devfile is found locally within a git repository, its context is returned in a `devfileContextMapFromRepo` map. This map is then used by the CDQ controller to properly set any `source.devfileURL` fields that are returned for detected components.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-225

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
