### PR TITLE
[DEVHAS-225] Properly set devfileURL in CDQs for multi-component repos

### DIFF
--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Red Hat, Inc.
+Copyright 2021-2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strings"
 
 	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
@@ -246,7 +247,11 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 		}
 
 		for context, link := range dockerfileContextMap {
-			updatedLink, err := devfile.UpdateGitLink(source.URL, source.Revision, path.Join(context, link))
+			updatedContext := context
+			if !strings.HasPrefix(link, "http") {
+				updatedContext = path.Join(context, link)
+			}
+			updatedLink, err := devfile.UpdateGitLink(source.URL, source.Revision, updatedContext)
 			if err != nil {
 				log.Error(err, fmt.Sprintf("Unable to update the dockerfile link %v", req.NamespacedName))
 				r.SetCompleteConditionAndUpdateCR(ctx, req, &componentDetectionQuery, copiedCDQ, err)

--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -121,7 +121,6 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 		devfilesMap := make(map[string][]byte)
 		devfilesURLMap := make(map[string]string)
 		dockerfileContextMap := make(map[string]string)
-
 		context := source.Context
 		if context == "" {
 			context = "./"
@@ -207,7 +206,7 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 			if isMultiComponent {
 				log.Info(fmt.Sprintf("Since this is a multi-component, attempt will be made to read only level 1 dir for devfiles... %v", req.NamespacedName))
 
-				devfilesMap, devfilesURLMap, dockerfileContextMap, err = devfile.ScanRepo(log, r.AlizerClient, componentPath, r.DevfileRegistryURL)
+				devfilesMap, devfilesURLMap, dockerfileContextMap, err = devfile.ScanRepo(log, r.AlizerClient, componentPath, r.DevfileRegistryURL, source)
 				if err != nil {
 					if _, ok := err.(*devfile.NoDevfileFound); !ok {
 						log.Error(err, fmt.Sprintf("Unable to find devfile(s) in repo %s due to an error %s, exiting reconcile loop %v", source.URL, err.Error(), req.NamespacedName))
@@ -247,7 +246,7 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 		}
 
 		for context, link := range dockerfileContextMap {
-			updatedLink, err := devfile.UpdateGitLink(source.URL, source.Revision, link)
+			updatedLink, err := devfile.UpdateGitLink(source.URL, source.Revision, path.Join(context, link))
 			if err != nil {
 				log.Error(err, fmt.Sprintf("Unable to update the dockerfile link %v", req.NamespacedName))
 				r.SetCompleteConditionAndUpdateCR(ctx, req, &componentDetectionQuery, copiedCDQ, err)

--- a/controllers/componentdetectionquery_controller_test.go
+++ b/controllers/componentdetectionquery_controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Red Hat, Inc.
+Copyright 2021-2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/componentdetectionquery_controller_test.go
+++ b/controllers/componentdetectionquery_controller_test.go
@@ -999,7 +999,7 @@ var _ = Describe("Component Detection Query controller", func() {
 				for _, componentDesc := range createdHasCompDetectionQuery.Status.ComponentDetected {
 					Expect(componentDesc.ComponentStub.Source.GitSource).ShouldNot(BeNil())
 					Expect(componentDesc.ComponentStub.Source.GitSource.DockerfileURL).ShouldNot(BeEmpty())
-					Expect(componentDesc.ComponentStub.Source.GitSource.DockerfileURL).Should(Equal("https://raw.githubusercontent.com/maysunfaisal/python-src-docker/main/./Dockerfile"))
+					Expect(componentDesc.ComponentStub.Source.GitSource.DockerfileURL).Should(Equal("https://raw.githubusercontent.com/maysunfaisal/python-src-docker/main/Dockerfile"))
 				}
 
 				// Delete the specified Detection Query resource

--- a/pkg/devfile/detect.go
+++ b/pkg/devfile/detect.go
@@ -43,7 +43,7 @@ type AlizerClient struct {
 // If no devfile(s) or dockerfile(s) are found, then the Alizer tool is used to detect and match a devfile/dockerfile from the devfile registry
 // search returns 3 maps and an error:
 // Map 1 returns a context to the devfile bytes if present.
-// Map 2 returns a context to the matched devfileURL from the devfile registry if no devfile is present in the context.
+// Map 2 returns a context to the matched devfileURL from the github repository. If no devfile was present, then a link to a matching devfile in the devfile registry will be used instead.
 // Map 3 returns a context to the dockerfile uri or a matched dockerfileURL from the devfile registry if no dockerfile is present in the context
 func search(log logr.Logger, a Alizer, localpath string, devfileRegistryURL string, source appstudiov1alpha1.GitSource) (map[string][]byte, map[string]string, map[string]string, error) {
 

--- a/pkg/devfile/detect.go
+++ b/pkg/devfile/detect.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Red Hat, Inc.
+// Copyright 2022-2023 Red Hat, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -133,7 +133,6 @@ func search(log logr.Logger, a Alizer, localpath string, devfileRegistryURL stri
 				isDockerfilePresent = false
 			}
 
-			// If the devfile is present locally, add its local path to the devfile repo context map
 			if (!isDevfilePresent && !isDockerfilePresent) || (isDevfilePresent && !isDockerfilePresent) {
 				err := AnalyzePath(a, curPath, context, devfileRegistryURL, devfileMapFromRepo, devfilesURLMapFromRepo, dockerfileContextMapFromRepo, isDevfilePresent, isDockerfilePresent)
 				if err != nil {

--- a/pkg/devfile/devfile.go
+++ b/pkg/devfile/devfile.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Red Hat, Inc.
+// Copyright 2021-2023 Red Hat, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/devfile/devfile.go
+++ b/pkg/devfile/devfile.go
@@ -247,6 +247,6 @@ func DownloadDevfileAndDockerfile(url string) ([]byte, string, []byte) {
 // Map 1 returns a context to the devfile bytes if present.
 // Map 2 returns a context to the matched devfileURL from the devfile registry if no devfile is present in the context.
 // Map 3 returns a context to the dockerfile uri or a matched dockerfileURL from the devfile registry if no dockerfile is present in the context
-func ScanRepo(log logr.Logger, a Alizer, localpath string, devfileRegistryURL string) (map[string][]byte, map[string]string, map[string]string, error) {
-	return search(log, a, localpath, devfileRegistryURL)
+func ScanRepo(log logr.Logger, a Alizer, localpath string, devfileRegistryURL string, source appstudiov1alpha1.GitSource) (map[string][]byte, map[string]string, map[string]string, error) {
+	return search(log, a, localpath, devfileRegistryURL, source)
 }

--- a/pkg/devfile/devfile_test.go
+++ b/pkg/devfile/devfile_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Red Hat, Inc.
+// Copyright 2021-2023 Red Hat, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/devfile/devfile_test.go
+++ b/pkg/devfile/devfile_test.go
@@ -387,10 +387,10 @@ func TestScanRepo(t *testing.T) {
 		expectedDockerfileContextMap map[string]string
 	}{
 		{
-			name:                   "Should return 1 devfiles as this is a multi comp devfile",
+			name:                   "Should return 2 devfile contexts, and 2 devfileURLs as this is a multi comp devfile",
 			clonePath:              "/tmp/testclone",
 			repo:                   "https://github.com/maysunfaisal/multi-components-deep",
-			expectedDevfileContext: []string{"devfile-sample-java-springboot-basic", "python"},
+			expectedDevfileContext: []string{"python", "devfile-sample-java-springboot-basic"},
 			expectedDevfileURLContextMap: map[string]string{
 				"devfile-sample-java-springboot-basic": "https://raw.githubusercontent.com/maysunfaisal/multi-components-deep/main/devfile-sample-java-springboot-basic/.devfile/.devfile.yaml",
 				"python":                               "https://registry.stage.devfile.io/devfiles/python-basic",
@@ -450,7 +450,7 @@ func TestScanRepo(t *testing.T) {
 						}
 					}
 
-					for actualContext := range devfileMap {
+					for actualContext := range devfileURLMap {
 						if devfileURLMap[actualContext] != tt.expectedDevfileURLContextMap[actualContext] {
 							t.Errorf("expected devfile URL %v but got %v", tt.expectedDevfileURLContextMap[actualContext], devfileURLMap[actualContext])
 						}

--- a/pkg/devfile/devfile_test.go
+++ b/pkg/devfile/devfile_test.go
@@ -383,25 +383,34 @@ func TestScanRepo(t *testing.T) {
 		token                        string
 		wantErr                      bool
 		expectedDevfileContext       []string
-		expectedDevfileURLContext    []string
+		expectedDevfileURLContextMap map[string]string
 		expectedDockerfileContextMap map[string]string
 	}{
 		{
-			name:                      "Should return 1 devfiles as this is a multi comp devfile",
-			clonePath:                 "/tmp/testclone",
-			repo:                      "https://github.com/maysunfaisal/multi-components-deep",
-			expectedDevfileContext:    []string{"devfile-sample-java-springboot-basic", "python"},
-			expectedDevfileURLContext: []string{"python"},
+			name:                   "Should return 1 devfiles as this is a multi comp devfile",
+			clonePath:              "/tmp/testclone",
+			repo:                   "https://github.com/maysunfaisal/multi-components-deep",
+			expectedDevfileContext: []string{"devfile-sample-java-springboot-basic", "python"},
+			expectedDevfileURLContextMap: map[string]string{
+				"devfile-sample-java-springboot-basic": "https://raw.githubusercontent.com/maysunfaisal/multi-components-deep/main/devfile-sample-java-springboot-basic/.devfile/.devfile.yaml",
+				"python":                               "https://registry.stage.devfile.io/devfiles/python-basic",
+			},
 			expectedDockerfileContextMap: map[string]string{
 				"devfile-sample-java-springboot-basic": "devfile-sample-java-springboot-basic/docker/Dockerfile",
 				"python":                               "https://raw.githubusercontent.com/devfile-samples/devfile-sample-python-basic/main/docker/Dockerfile"},
 		},
 		{
-			name:                      "Should return 4 devfiles, 1 devfile url and 5 dockerfile uri as this is a multi comp devfile",
-			clonePath:                 "/tmp/testclone",
-			repo:                      "https://github.com/maysunfaisal/multi-components-dockerfile",
-			expectedDevfileContext:    []string{"devfile-sample-java-springboot-basic", "devfile-sample-nodejs-basic", "devfile-sample-python-basic", "python-src-none"},
-			expectedDevfileURLContext: []string{"python-src-none"},
+			name:                   "Should return 4 devfiles, 5 devfile url and 5 dockerfile uri as this is a multi comp devfile",
+			clonePath:              "/tmp/testclone",
+			repo:                   "https://github.com/maysunfaisal/multi-components-dockerfile",
+			expectedDevfileContext: []string{"devfile-sample-java-springboot-basic", "devfile-sample-nodejs-basic", "devfile-sample-python-basic", "python-src-none"},
+			expectedDevfileURLContextMap: map[string]string{
+				"devfile-sample-java-springboot-basic": "https://raw.githubusercontent.com/maysunfaisal/multi-components-dockerfile/main/devfile-sample-java-springboot-basic/.devfile/.devfile.yaml",
+				"devfile-sample-nodejs-basic":          "https://raw.githubusercontent.com/maysunfaisal/multi-components-dockerfile/main/devfile-sample-nodejs-basic/devfile.yaml",
+				"devfile-sample-python-basic":          "https://raw.githubusercontent.com/maysunfaisal/multi-components-dockerfile/main/devfile-sample-python-basic/.devfile.yaml",
+				"python-src-none":                      "https://registry.stage.devfile.io/devfiles/python-basic",
+				"python-src-docker":                    "https://registry.stage.devfile.io/devfiles/python-basic",
+			},
 			expectedDockerfileContextMap: map[string]string{
 				"python-src-docker":                    "python-src-docker/Dockerfile",
 				"devfile-sample-nodejs-basic":          "https://raw.githubusercontent.com/nodeshift-starters/devfile-sample/main/Dockerfile",
@@ -441,18 +450,11 @@ func TestScanRepo(t *testing.T) {
 						}
 					}
 
-					for actualContext := range devfileURLMap {
-						matched := false
-						for _, expectedContext := range tt.expectedDevfileURLContext {
-							if expectedContext == actualContext {
-								matched = true
-								break
-							}
+					for actualContext := range devfileMap {
+						if devfileURLMap[actualContext] != tt.expectedDevfileURLContextMap[actualContext] {
+							t.Errorf("expected devfile URL %v but got %v", tt.expectedDevfileURLContextMap[actualContext], devfileURLMap[actualContext])
 						}
 
-						if !matched {
-							t.Errorf("found devfile URL at context %v:%v but expected none", actualContext, devfileURLMap[actualContext])
-						}
 					}
 
 					for actualContext := range dockerfileMap {

--- a/pkg/devfile/devfile_test.go
+++ b/pkg/devfile/devfile_test.go
@@ -415,10 +415,13 @@ func TestScanRepo(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			logger = ctrl.Log.WithName("TestScanRepo")
 			err := util.CloneRepo(tt.clonePath, tt.repo, tt.token)
+			source := appstudiov1alpha1.GitSource{
+				URL: tt.repo,
+			}
 			if err != nil {
 				t.Errorf("got unexpected error %v", err)
 			} else {
-				devfileMap, devfileURLMap, dockerfileMap, err := ScanRepo(logger, alizerClient, tt.clonePath, DevfileStageRegistryEndpoint)
+				devfileMap, devfileURLMap, dockerfileMap, err := ScanRepo(logger, alizerClient, tt.clonePath, DevfileStageRegistryEndpoint, source)
 				if tt.wantErr && (err == nil) {
 					t.Error("wanted error but got nil")
 				} else if !tt.wantErr && err != nil {


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

### What does this PR do?:
Alternative to https://github.com/redhat-appstudio/application-service/pull/239. Instead of creating a new map to store the context/local path of the devfile, this PR updates `devfile.search()` to properly set the `devfilesURLMap` when devfiles are detected locally in a multi-component repository. 

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-225

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
