### PR TITLE
[DEVHAS-226] Only override DockerfileURL if its path is local and not absolute

### DIFF
--- a/pkg/devfile/detect_mock.go
+++ b/pkg/devfile/detect_mock.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Red Hat, Inc.
+// Copyright 2022-2023 Red Hat, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/devfile/detect_mock.go
+++ b/pkg/devfile/detect_mock.go
@@ -43,6 +43,31 @@ func (a MockAlizerClient) DetectComponents(path string) ([]recognizer.Component,
 				},
 			},
 		}, nil
+	} else if strings.Contains(path, "nodejs-no-dockerfile") {
+		return []recognizer.Component{
+			{
+				Path: path,
+				Languages: []language.Language{
+					{
+						Name: "JavaScript",
+						Aliases: []string{
+							"js",
+							"node",
+							"nodejs",
+						},
+						Frameworks: []string{
+							"Express",
+						},
+						Tools: []string{
+							"NodeJs",
+							"Node.js",
+						},
+						UsageInPercentage: 100,
+						CanBeComponent:    true,
+					},
+				},
+			},
+		}, nil
 	} else if !strings.Contains(path, "springboot") && !strings.Contains(path, "python") {
 		return nil, nil
 	}
@@ -85,6 +110,17 @@ func (a MockAlizerClient) SelectDevFileFromTypes(path string, devFileTypes []rec
 	} else if strings.Contains(path, "python-basic") {
 		return recognizer.DevFileType{
 			Name: "python-basic",
+		}, nil
+	} else if strings.Contains(path, "nodejs-no-dockerfile") {
+		return recognizer.DevFileType{
+			Name:        "nodejs-basic",
+			Language:    "JavaScript",
+			ProjectType: "Node.js",
+			Tags: []string{
+				"Node.js",
+				"Express",
+				"ubi8",
+			},
 		}, nil
 	}
 


### PR DESCRIPTION
### What does this PR do?:
This PR updates the logic in the CDQ controller that sets DockerfileURL links, so that it only overrides the DockerfileURL link to the source repository if the given context/path is local. If the given path is absolute (i.e. a fully qualified address), then we no longer override it.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-226

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
