### PR TITLE
PLNSRVCE-1019: build - remove registry-secret

### DIFF
--- a/gitops/prepare/prepare.go
+++ b/gitops/prepare/prepare.go
@@ -26,8 +26,6 @@ import (
 )
 
 const (
-	// default secret for app studio registry
-	RegistrySecret = "redhat-appstudio-registry-pull-secret"
 	// Pipelines as Code global configuration secret name
 	PipelinesAsCodeSecretName = "pipelines-as-code-secret"
 	// Pipelines as Code global configuration secret namespace
@@ -37,8 +35,6 @@ const (
 // Holds data that needs to be queried from the cluster in order for the gitops generation function to work
 // This struct is left here so more data can be added as needed
 type GitopsConfig struct {
-	AppStudioRegistrySecretPresent bool
-
 	// Contains data from Pipelies as Code configuration k8s secret
 	PipelinesAsCodeCredentials map[string][]byte
 }
@@ -46,18 +42,9 @@ type GitopsConfig struct {
 func PrepareGitopsConfig(ctx context.Context, cli client.Client, component appstudiov1alpha1.Component) GitopsConfig {
 	data := GitopsConfig{}
 
-	data.AppStudioRegistrySecretPresent = resolveRegistrySecretPresence(ctx, cli, component)
 	data.PipelinesAsCodeCredentials = getPipelinesAsCodeConfigurationSecretData(ctx, cli, component)
 
 	return data
-}
-
-// Determines whether the 'redhat-appstudio-registry-pull-secret' Secret exists, so that the Generate* functions
-// can avoid declaring a secret volume workspace for the Secret when the Secret is not available.
-func resolveRegistrySecretPresence(ctx context.Context, cli client.Client, component appstudiov1alpha1.Component) bool {
-	registrySecret := &corev1.Secret{}
-	err := cli.Get(ctx, types.NamespacedName{Name: RegistrySecret, Namespace: component.Namespace}, registrySecret)
-	return err == nil
 }
 
 func getPipelinesAsCodeConfigurationSecretData(ctx context.Context, cli client.Client, component appstudiov1alpha1.Component) map[string][]byte {

--- a/gitops/prepare/prepare_test.go
+++ b/gitops/prepare/prepare_test.go
@@ -78,57 +78,6 @@ func TestPrepareGitopsConfig(t *testing.T) {
 
 }
 
-func TestResolveRegistrySecretPresence(t *testing.T) {
-	ctx := context.TODO()
-
-	component := appstudiov1alpha1.Component{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "appstudio.redhat.com/v1alpha1",
-			Kind:       "Component",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "myName",
-			Namespace: "myNamespace",
-		},
-	}
-
-	tests := []struct {
-		name string
-		data *corev1.Secret
-		want bool
-	}{
-		{
-			name: "secret exists",
-			data: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: component.Namespace,
-					Name:      RegistrySecret,
-				},
-				Data: map[string][]byte{},
-			},
-			want: true,
-		},
-		{
-			name: "secret does not exist",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var client crclient.WithWatch
-			client = fake.NewClientBuilder().Build()
-			if tt.data != nil {
-				client = fake.NewClientBuilder().WithRuntimeObjects(tt.data).Build()
-			}
-
-			if got := resolveRegistrySecretPresence(ctx, client, component); got != tt.want {
-				t.Errorf("ResolveBuildBundle() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-
-}
-
 func TestGetPipelinesAsCodeConfigurationSecretData(t *testing.T) {
 	ctx := context.TODO()
 


### PR DESCRIPTION
Remove code for registrysecret which is not used anymore. Registry secrets should be linked to serviceaccount instead.

### What does this PR do?:
<!-- _Summarize the changes_ -->

### Which issue(s)/story(ies) does this PR fixes:
[PLNSRVCE-1019](https://issues.redhat.com//browse/PLNSRVCE-1019)

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
