### PR TITLE
[DEVHAS-223] Set revision in componentStub if set in CDQ's spec

### DIFF
--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -173,7 +173,7 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 					return ctrl.Result{}, nil
 				}
 
-				err = util.CloneRepo(clonePath, source.URL, gitToken)
+				err = util.CloneRepo(clonePath, source.URL, source.Revision, gitToken)
 				if err != nil {
 					log.Error(err, fmt.Sprintf("Unable to clone repo %s to path %s, exiting reconcile loop %v", source.URL, clonePath, req.NamespacedName))
 					r.SetCompleteConditionAndUpdateCR(ctx, req, &componentDetectionQuery, copiedCDQ, err)

--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -145,7 +145,11 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 			} else {
 				// Use SPI to retrieve the devfile from the private repository
 				// TODO - maysunfaisal also search for Dockerfile
-				devfileBytes, err = spi.DownloadDevfileUsingSPI(r.SPIClient, ctx, componentDetectionQuery.Namespace, source.URL, source.Revision, context)
+				revision := source.Revision
+				if revision == "" {
+					revision = "main"
+				}
+				devfileBytes, err = spi.DownloadDevfileUsingSPI(r.SPIClient, ctx, componentDetectionQuery.Namespace, source.URL, revision, context)
 				if err != nil {
 					log.Error(err, fmt.Sprintf("Unable to curl for any known devfile locations from %s %v", source.URL, req.NamespacedName))
 				}

--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -145,7 +145,7 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 			} else {
 				// Use SPI to retrieve the devfile from the private repository
 				// TODO - maysunfaisal also search for Dockerfile
-				devfileBytes, err = spi.DownloadDevfileUsingSPI(r.SPIClient, ctx, componentDetectionQuery.Namespace, source.URL, "main", context)
+				devfileBytes, err = spi.DownloadDevfileUsingSPI(r.SPIClient, ctx, componentDetectionQuery.Namespace, source.URL, source.Revision, context)
 				if err != nil {
 					log.Error(err, fmt.Sprintf("Unable to curl for any known devfile locations from %s %v", source.URL, req.NamespacedName))
 				}

--- a/controllers/componentdetectionquery_controller_test.go
+++ b/controllers/componentdetectionquery_controller_test.go
@@ -61,7 +61,8 @@ var _ = Describe("Component Detection Query controller", func() {
 				},
 				Spec: appstudiov1alpha1.ComponentDetectionQuerySpec{
 					GitSource: appstudiov1alpha1.GitSource{
-						URL: SampleRepoLink,
+						URL:      SampleRepoLink,
+						Revision: "main",
 					},
 				},
 			}
@@ -83,6 +84,7 @@ var _ = Describe("Component Detection Query controller", func() {
 			for devfileName, devfileDesc := range createdHasCompDetectionQuery.Status.ComponentDetected {
 				Expect(devfileName).Should(ContainSubstring("spring"))
 				Expect(devfileDesc.ComponentStub.Source.GitSource.Context).Should(ContainSubstring("./"))
+				Expect(devfileDesc.ComponentStub.Source.GitSource.Context).Should(ContainSubstring("main"))
 				Expect(devfileDesc.ComponentStub.Source.GitSource.DevfileURL).Should(Equal("https://raw.githubusercontent.com/devfile-samples/devfile-sample-java-springboot-basic/main/devfile.yaml"))
 				Expect(devfileDesc.DevfileFound).Should(BeTrue())
 			}

--- a/controllers/componentdetectionquery_controller_test.go
+++ b/controllers/componentdetectionquery_controller_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Component Detection Query controller", func() {
 			for devfileName, devfileDesc := range createdHasCompDetectionQuery.Status.ComponentDetected {
 				Expect(devfileName).Should(ContainSubstring("spring"))
 				Expect(devfileDesc.ComponentStub.Source.GitSource.Context).Should(ContainSubstring("./"))
-				Expect(devfileDesc.ComponentStub.Source.GitSource.Context).Should(ContainSubstring("main"))
+				Expect(devfileDesc.ComponentStub.Source.GitSource.Revision).Should(ContainSubstring("main"))
 				Expect(devfileDesc.ComponentStub.Source.GitSource.DevfileURL).Should(Equal("https://raw.githubusercontent.com/devfile-samples/devfile-sample-java-springboot-basic/main/devfile.yaml"))
 				Expect(devfileDesc.DevfileFound).Should(BeTrue())
 			}

--- a/controllers/update.go
+++ b/controllers/update.go
@@ -311,6 +311,7 @@ func (r *ComponentDetectionQueryReconciler) updateComponentStub(req ctrl.Request
 		gitSource := &appstudiov1alpha1.GitSource{
 			Context:       context,
 			URL:           componentDetectionQuery.Spec.GitSource.URL,
+			Revision:      componentDetectionQuery.Spec.GitSource.Revision,
 			DevfileURL:    devfilesURLMap[context],
 			DockerfileURL: dockerfileContextMap[context],
 		}

--- a/pkg/devfile/detect_test.go
+++ b/pkg/devfile/detect_test.go
@@ -31,6 +31,7 @@ func TestAnalyzeAndDetectDevfile(t *testing.T) {
 		name                string
 		clonePath           string
 		repo                string
+		revision            string
 		token               string
 		registryURL         string
 		wantDevfile         bool
@@ -41,6 +42,15 @@ func TestAnalyzeAndDetectDevfile(t *testing.T) {
 			name:                "Successfully detect a devfile from the registry",
 			clonePath:           "/tmp/java-springboot-basic",
 			repo:                "https://github.com/maysunfaisal/devfile-sample-java-springboot-basic-1",
+			registryURL:         DevfileStageRegistryEndpoint,
+			wantDevfile:         true,
+			wantDevfileEndpoint: "https://registry.stage.devfile.io/devfiles/java-springboot-basic",
+		},
+		{
+			name:                "Successfully detect a devfile from the registry using an alternate branch",
+			clonePath:           "/tmp/java-springboot-basic",
+			repo:                "https://github.com/devfile-samples/devfile-sample-java-springboot-basic",
+			revision:            "testbranch",
 			registryURL:         DevfileStageRegistryEndpoint,
 			wantDevfile:         true,
 			wantDevfileEndpoint: "https://registry.stage.devfile.io/devfiles/java-springboot-basic",
@@ -84,7 +94,7 @@ func TestAnalyzeAndDetectDevfile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := util.CloneRepo(tt.clonePath, tt.repo, tt.token)
+			err := util.CloneRepo(tt.clonePath, tt.repo, tt.revision, tt.token)
 			if err != nil {
 				t.Errorf("got unexpected error %v", err)
 			} else {

--- a/pkg/devfile/devfile_test.go
+++ b/pkg/devfile/devfile_test.go
@@ -459,6 +459,7 @@ func TestScanRepo(t *testing.T) {
 		name                         string
 		clonePath                    string
 		repo                         string
+		revision                     string
 		token                        string
 		wantErr                      bool
 		expectedDevfileContext       []string
@@ -469,6 +470,20 @@ func TestScanRepo(t *testing.T) {
 			name:                   "Should return 2 devfile contexts, and 2 devfileURLs as this is a multi comp devfile",
 			clonePath:              "/tmp/testclone",
 			repo:                   "https://github.com/maysunfaisal/multi-components-deep",
+			expectedDevfileContext: []string{"python", "devfile-sample-java-springboot-basic"},
+			expectedDevfileURLContextMap: map[string]string{
+				"devfile-sample-java-springboot-basic": "https://raw.githubusercontent.com/maysunfaisal/multi-components-deep/main/devfile-sample-java-springboot-basic/.devfile/.devfile.yaml",
+				"python":                               "https://registry.stage.devfile.io/devfiles/python-basic",
+			},
+			expectedDockerfileContextMap: map[string]string{
+				"devfile-sample-java-springboot-basic": "devfile-sample-java-springboot-basic/docker/Dockerfile",
+				"python":                               "https://raw.githubusercontent.com/devfile-samples/devfile-sample-python-basic/main/docker/Dockerfile"},
+		},
+		{
+			name:                   "Should return 2 devfile contexts, and 2 devfileURLs as this is a multi comp devfile - with revision specified",
+			clonePath:              "/tmp/testclone",
+			repo:                   "https://github.com/maysunfaisal/multi-components-deep",
+			revision:               "2a7b64d94453746579ae0898e44bcdd3d8575167",
 			expectedDevfileContext: []string{"python", "devfile-sample-java-springboot-basic"},
 			expectedDevfileURLContextMap: map[string]string{
 				"devfile-sample-java-springboot-basic": "https://raw.githubusercontent.com/maysunfaisal/multi-components-deep/main/devfile-sample-java-springboot-basic/.devfile/.devfile.yaml",
@@ -502,7 +517,7 @@ func TestScanRepo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			logger = ctrl.Log.WithName("TestScanRepo")
-			err := util.CloneRepo(tt.clonePath, tt.repo, tt.token)
+			err := util.CloneRepo(tt.clonePath, tt.repo, tt.revision, tt.token)
 			source := appstudiov1alpha1.GitSource{
 				URL: tt.repo,
 			}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -150,7 +150,7 @@ func CurlEndpoint(endpoint string) ([]byte, error) {
 }
 
 // CloneRepo clones the repoURL to clonePath
-func CloneRepo(clonePath, repoURL string, token string) error {
+func CloneRepo(clonePath, repoURL string, revision string, token string) error {
 	exist, err := IsExist(clonePath)
 	if !exist || err != nil {
 		err = os.MkdirAll(clonePath, 0750)
@@ -177,6 +177,16 @@ func CloneRepo(clonePath, repoURL string, token string) error {
 	_, err = c.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to clone the repo: %v", err)
+	}
+
+	if revision != "" {
+		c = exec.Command("git", "checkout", revision)
+		c.Dir = clonePath
+
+		_, err = c.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to checkout the revision %q: %v", revision, err)
+		}
 	}
 
 	return nil

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -218,6 +218,7 @@ func TestCloneRepo(t *testing.T) {
 		name      string
 		clonePath string
 		repo      string
+		revision  string
 		token     string
 		wantErr   bool
 	}{
@@ -250,11 +251,30 @@ func TestCloneRepo(t *testing.T) {
 			token:     "fake-token",
 			wantErr:   true,
 		},
+		{
+			name:      "Clone Successfully - branch specified as revision",
+			clonePath: "/tmp/testspringboot",
+			repo:      "https://github.com/devfile-resources/node-express-hello-no-devfile",
+			revision:  "testbranch",
+		},
+		{
+			name:      "Clone Successfully - commit specified as revision",
+			clonePath: "/tmp/nodeexpressrevision",
+			repo:      "https://github.com/devfile-resources/node-express-hello-no-devfile",
+			revision:  "22d213a42091199bc1f85a8eac60a5ff82371df3",
+		},
+		{
+			name:      "Invalid revision, should err out",
+			clonePath: "/tmp/nodeexpressrevisioninvalidrevision",
+			repo:      "https://github.com/devfile-resources/node-express-hello-no-devfile",
+			revision:  "fasdfasdfasdfdsklafj2w23",
+			wantErr:   true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := CloneRepo(tt.clonePath, tt.repo, tt.token)
+			err := CloneRepo(tt.clonePath, tt.repo, tt.revision, tt.token)
 			if tt.wantErr && (err == nil) {
 				t.Error("wanted error but got nil")
 			} else if !tt.wantErr && err != nil {


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

### What does this PR do?:
Updates the componentStub returned by the CDQ to include the Git revision if `GitSource.revision` was set in the CDQ's spec. 

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-223

### PR acceptance criteria:
Tests pass and ComponentStub now includes the proper Git revision if set in the CDQ spec.

