### PR TITLE
[DEVHAS-231] Use metadata.Name for GitOps repository

### DIFF
--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -134,7 +134,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		appModelRepo := application.Spec.AppModelRepository.URL
 		if gitOpsRepo == "" {
 			// If both repositories are blank, just generate a single shared repository
-			repoName := github.GenerateNewRepositoryName(application.Spec.DisplayName, application.Namespace, req.ClusterName)
+			repoName := github.GenerateNewRepositoryName(application.Name, application.Namespace, req.ClusterName)
 
 			// Generate the git repo in the redhat-appstudio-appdata org
 			repoUrl, err := github.GenerateNewRepository(r.GitHubClient, ctx, r.GitHubOrg, repoName, "GitOps Repository")

--- a/controllers/application_controller_test.go
+++ b/controllers/application_controller_test.go
@@ -321,7 +321,7 @@ var _ = Describe("Application controller", func() {
 		It("Should update successfully with updated description", func() {
 			ctx := context.Background()
 
-			applicationName := HASAppName + "5"
+			applicationName := "test-error-response" + "5"
 
 			hasApp := &appstudiov1alpha1.Application{
 				TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

### What does this PR do?:
This PR updates the GitOps repository name generation to use the Application's`metadata.name` instead of `spec.displayName`. Existing Applications with gitops repositories based on display names will not be affected.

### Which issue(s)/story(ies) does this PR fixes:
Fixes https://issues.redhat.com/browse/DEVHAS-231

### PR acceptance criteria:
GitOps repo names include the metadata.name field

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
