### PR TITLE
[DEVHAS-224] Provide default cpu/memory request and limits if unset in Component spec

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -29,6 +29,8 @@ import (
 
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	gitopsgenv1alpha1 "github.com/redhat-developer/gitops-generator/api/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/devfile/library/v2/pkg/devfile/parser"
 )
@@ -238,6 +240,20 @@ func GetMappedGitOpsComponent(component appstudiov1alpha1.Component, kubernetesR
 		}
 	} else {
 		gitopsMapComponent.GitSource = &gitopsgenv1alpha1.GitSource{}
+	}
+
+	// If the resource requests or limits were unset, set default values
+	if gitopsMapComponent.Resources.Requests == nil {
+		gitopsMapComponent.Resources.Requests = v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("10m"),
+			v1.ResourceMemory: resource.MustParse("50Mi"),
+		}
+	}
+	if gitopsMapComponent.Resources.Limits == nil {
+		gitopsMapComponent.Resources.Limits = v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("1"),
+			v1.ResourceMemory: resource.MustParse("512Mi"),
+		}
 	}
 
 	if !reflect.DeepEqual(kubernetesResources, parser.KubernetesResources{}) {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -26,7 +26,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -495,8 +494,8 @@ func TestGetMappedComponent(t *testing.T) {
 				Secret:      "Secret",
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						v1.ResourceCPU:    resource.MustParse("10m"),
-						v1.ResourceMemory: resource.MustParse("50Mi"),
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("50Mi"),
 					},
 					Limits: corev1.ResourceList{
 						corev1.ResourceLimitsCPU: resource.MustParse("1"),
@@ -537,12 +536,12 @@ func TestGetMappedComponent(t *testing.T) {
 				GitSource:   &gitopsgenv1alpha1.GitSource{},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						v1.ResourceCPU:    resource.MustParse("10m"),
-						v1.ResourceMemory: resource.MustParse("50Mi"),
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("50Mi"),
 					},
 					Limits: corev1.ResourceList{
-						v1.ResourceCPU:    resource.MustParse("1"),
-						v1.ResourceMemory: resource.MustParse("512Mi"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
 					},
 				},
 			},
@@ -565,12 +564,12 @@ func TestGetMappedComponent(t *testing.T) {
 				Application: "AppTest003",
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						v1.ResourceCPU:    resource.MustParse("10m"),
-						v1.ResourceMemory: resource.MustParse("50Mi"),
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("50Mi"),
 					},
 					Limits: corev1.ResourceList{
-						v1.ResourceCPU:    resource.MustParse("1"),
-						v1.ResourceMemory: resource.MustParse("512Mi"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
 					},
 				},
 			},
@@ -597,12 +596,12 @@ func TestGetMappedComponent(t *testing.T) {
 				GitSource:   &gitopsgenv1alpha1.GitSource{},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						v1.ResourceCPU:    resource.MustParse("10m"),
-						v1.ResourceMemory: resource.MustParse("50Mi"),
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("50Mi"),
 					},
 					Limits: corev1.ResourceList{
-						v1.ResourceCPU:    resource.MustParse("1"),
-						v1.ResourceMemory: resource.MustParse("512Mi"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
 					},
 				},
 			},
@@ -631,12 +630,12 @@ func TestGetMappedComponent(t *testing.T) {
 				GitSource:   &gitopsgenv1alpha1.GitSource{},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						v1.ResourceCPU:    resource.MustParse("10m"),
-						v1.ResourceMemory: resource.MustParse("50Mi"),
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("50Mi"),
 					},
 					Limits: corev1.ResourceList{
-						v1.ResourceCPU:    resource.MustParse("1"),
-						v1.ResourceMemory: resource.MustParse("512Mi"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
 					},
 				},
 			},
@@ -703,12 +702,12 @@ func TestGetMappedComponent(t *testing.T) {
 				},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						v1.ResourceCPU:    resource.MustParse("10m"),
-						v1.ResourceMemory: resource.MustParse("50Mi"),
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("50Mi"),
 					},
 					Limits: corev1.ResourceList{
-						v1.ResourceCPU:    resource.MustParse("1"),
-						v1.ResourceMemory: resource.MustParse("512Mi"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
 					},
 				},
 			},

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -26,6 +26,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -493,6 +494,10 @@ func TestGetMappedComponent(t *testing.T) {
 				Application: "AppTest001",
 				Secret:      "Secret",
 				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("10m"),
+						v1.ResourceMemory: resource.MustParse("50Mi"),
+					},
 					Limits: corev1.ResourceList{
 						corev1.ResourceLimitsCPU: resource.MustParse("1"),
 						corev1.ResourceMemory:    resource.MustParse("1Gi"),
@@ -530,6 +535,16 @@ func TestGetMappedComponent(t *testing.T) {
 				Namespace:   "testnamespace",
 				Application: "AppTest002",
 				GitSource:   &gitopsgenv1alpha1.GitSource{},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("10m"),
+						v1.ResourceMemory: resource.MustParse("50Mi"),
+					},
+					Limits: corev1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("1"),
+						v1.ResourceMemory: resource.MustParse("512Mi"),
+					},
+				},
 			},
 		},
 		{
@@ -548,6 +563,16 @@ func TestGetMappedComponent(t *testing.T) {
 				Name:        "testcomponent",
 				Namespace:   "testnamespace",
 				Application: "AppTest003",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("10m"),
+						v1.ResourceMemory: resource.MustParse("50Mi"),
+					},
+					Limits: corev1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("1"),
+						v1.ResourceMemory: resource.MustParse("512Mi"),
+					},
+				},
 			},
 		},
 		{
@@ -570,6 +595,16 @@ func TestGetMappedComponent(t *testing.T) {
 				Namespace:   "testnamespace",
 				Application: "AppTest004",
 				GitSource:   &gitopsgenv1alpha1.GitSource{},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("10m"),
+						v1.ResourceMemory: resource.MustParse("50Mi"),
+					},
+					Limits: corev1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("1"),
+						v1.ResourceMemory: resource.MustParse("512Mi"),
+					},
+				},
 			},
 		},
 		{
@@ -594,6 +629,16 @@ func TestGetMappedComponent(t *testing.T) {
 				Namespace:   "testnamespace",
 				Application: "AppTest005",
 				GitSource:   &gitopsgenv1alpha1.GitSource{},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("10m"),
+						v1.ResourceMemory: resource.MustParse("50Mi"),
+					},
+					Limits: corev1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("1"),
+						v1.ResourceMemory: resource.MustParse("512Mi"),
+					},
+				},
 			},
 		},
 		{
@@ -655,6 +700,16 @@ func TestGetMappedComponent(t *testing.T) {
 						},
 					},
 					Others: other,
+				},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("10m"),
+						v1.ResourceMemory: resource.MustParse("50Mi"),
+					},
+					Limits: corev1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("1"),
+						v1.ResourceMemory: resource.MustParse("512Mi"),
+					},
 				},
 			},
 		},


### PR DESCRIPTION
### What does this PR do?:
Updates the `GetMappedGitOpsComponent` function to set default values for the CPU & Memory requests/limits that we pass into the GItOps Generator, if those fields are unset in the Component spec.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-224

### PR acceptance criteria:
GitOps resources are generated with default values for CPU & Memory request/limits from now on.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
