### PR TITLE
STONEBLD-687: repository without ending '/'

### DIFF
--- a/gitops/generate_build.go
+++ b/gitops/generate_build.go
@@ -133,7 +133,7 @@ func GeneratePACRepository(component appstudiov1alpha1.Component, config map[str
 			Annotations: getBuildCommonLabelsForComponent(&component),
 		},
 		Spec: pacv1alpha1.RepositorySpec{
-			URL:         strings.TrimSuffix(component.Spec.Source.GitSource.URL, ".git"),
+			URL:         strings.TrimSuffix(strings.TrimSuffix(component.Spec.Source.GitSource.URL, ".git"), "/"),
 			GitProvider: gitProviderConfig,
 		},
 	}

--- a/gitops/generate_build_test.go
+++ b/gitops/generate_build_test.go
@@ -179,7 +179,7 @@ func TestGeneratePACRepository(t *testing.T) {
 		},
 		{
 			name:    "should create PaC repository for GitLab webhook",
-			repoUrl: "https://gitlab.com/user/test-component-repository",
+			repoUrl: "https://gitlab.com/user/test-component-repository/",
 			pacConfig: map[string][]byte{
 				"github.token": []byte("ghp_token"),
 				"gitlab.token": []byte("glpat-token"),
@@ -191,7 +191,7 @@ func TestGeneratePACRepository(t *testing.T) {
 				},
 				WebhookSecret: &pacv1alpha1.Secret{
 					Name: PipelinesAsCodeWebhooksSecretName,
-					Key:  GetWebhookSecretKeyForComponent(getComponent("https://gitlab.com/user/test-component-repository")),
+					Key:  GetWebhookSecretKeyForComponent(getComponent("https://gitlab.com/user/test-component-repository/")),
 				},
 				URL: "https://gitlab.com",
 			},
@@ -240,9 +240,9 @@ func TestGeneratePACRepository(t *testing.T) {
 			if pacRepo.Annotations["appstudio.openshift.io/component"] != component.Name {
 				t.Errorf("Generated PaC repository must have component annotation")
 			}
-
-			if pacRepo.Spec.URL != strings.TrimRight(tt.repoUrl, ".git") {
-				t.Errorf("Wrong git repository URL in PaC repository: %s, want %s", pacRepo.Spec.URL, tt.repoUrl)
+			expectedRepo := strings.TrimSuffix(strings.TrimSuffix(tt.repoUrl, ".git"), "/")
+			if pacRepo.Spec.URL != expectedRepo {
+				t.Errorf("Wrong git repository URL in PaC repository: %s, want %s", pacRepo.Spec.URL, expectedRepo)
 			}
 			if !reflect.DeepEqual(pacRepo.Spec.GitProvider, tt.expectedGitProviderConfig) {
 				t.Errorf("Wrong git provider config in PaC repository: %#v, want %#v", pacRepo.Spec.GitProvider, tt.expectedGitProviderConfig)


### PR DESCRIPTION
Ending slash is causing issue in Pipelines-as-code, reported as SRVKP-2808.

### What does this PR do?:
<!-- _Summarize the changes_ -->

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
