### PR TITLE
Do not reconcile after removing finalizers

### DIFF
--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -119,10 +119,13 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 			// remove the finalizer from the list and update it.
 			controllerutil.RemoveFinalizer(&application, appFinalizerName)
-			if err := r.Update(ctx, &application); err != nil {
-				return ctrl.Result{}, err
-			}
+			// Dont worry about the err on the Update call since the object is being deleted
+			r.Update(ctx, &application)
 		}
+
+		// once the Finalizer has been dealt with, return as there is no need
+		// to go through the reconcile logic on an object being deleted
+		return ctrl.Result{}, nil
 	}
 
 	log.Info(fmt.Sprintf("Starting reconcile loop for %v", req.NamespacedName))

--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -120,7 +120,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			// remove the finalizer from the list and update it.
 			controllerutil.RemoveFinalizer(&application, appFinalizerName)
 			// Dont worry about the err on the Update call since the object is being deleted
-			r.Update(ctx, &application)
+			_ = r.Update(ctx, &application)
 		}
 
 		// once the Finalizer has been dealt with, return as there is no need

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -165,7 +165,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			// remove the finalizer from the list and update it.
 			controllerutil.RemoveFinalizer(&component, compFinalizerName)
 			// Dont worry about the err on the Update call since the object is being deleted
-			r.Update(ctx, &component)
+			_ = r.Update(ctx, &component)
 		}
 
 		// once the Finalizer has been dealt with, return as there is no need

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -164,10 +164,13 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if containsString(component.GetFinalizers(), compFinalizerName) {
 			// remove the finalizer from the list and update it.
 			controllerutil.RemoveFinalizer(&component, compFinalizerName)
-			if err := r.Update(ctx, &component); err != nil {
-				return ctrl.Result{}, err
-			}
+			// Dont worry about the err on the Update call since the object is being deleted
+			r.Update(ctx, &component)
 		}
+
+		// once the Finalizer has been dealt with, return as there is no need
+		// to go through the reconcile logic on an object being deleted
+		return ctrl.Result{}, nil
 	}
 
 	log.Info(fmt.Sprintf("Starting reconcile loop for %v", req.NamespacedName))


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

### What does this PR do?:
<!-- _Summarize the changes_ -->
Returns after removing finalizers. There is no need to go through a reconcile logic on an object being deleted.

For instance, `Component` CR on delete

#### Before
```
2023-02-03T14:42:04.858-0500	INFO	controllers.Component	API Resource changed: Update	{"appstudio-component": "HAS", "Namespace": "maysun", "clusterName": "", "audit": "true", "name": "component-sample", "resource": "Component", "action": "Update"}
2023-02-03T14:42:06.489-0500	INFO	controllers.Application	API Resource changed: Update	{"appstudio-component": "HAS", "Namespace": "maysun", "clusterName": "", "audit": "true", "name": "application-sample", "resource": "Application", "action": "Update"}
2023-02-03T14:42:06.490-0500	INFO	controllers.Application	Starting reconcile loop for maysun/application-sample	{"appstudio-component": "HAS", "Application": "maysun/application-sample", "clusterName": ""}
2023-02-03T14:42:06.492-0500	INFO	controllers.Application	Finished reconcile loop for maysun/application-sample	{"appstudio-component": "HAS", "Application": "maysun/application-sample", "clusterName": ""}
2023-02-03T14:42:06.531-0500	INFO	controllers.Component	Starting reconcile loop for maysun/component-sample	{"appstudio-component": "HAS", "Component": "maysun/component-sample", "clusterName": ""}
2023-02-03T14:42:06.531-0500	INFO	controllers.Component	Checking if the Component has been updated maysun/component-sample	{"appstudio-component": "HAS", "Component": "maysun/component-sample", "clusterName": ""}
2023-02-03T14:42:06.535-0500	INFO	controllers.Component	setting devfile component kubernetes-deploy attribute component.Spec.Route route111	{"appstudio-component": "HAS", "Component": "maysun/component-sample", "clusterName": ""}
2023-02-03T14:42:06.535-0500	INFO	controllers.Component	setting devfileComponent kubernetes-deploy env FOO value to foo1	{"appstudio-component": "HAS", "Component": "maysun/component-sample", "clusterName": ""}
2023-02-03T14:42:06.535-0500	INFO	controllers.Component	setting devfileComponent kubernetes-deploy env BAR value to bar1	{"appstudio-component": "HAS", "Component": "maysun/component-sample", "clusterName": ""}
2023-02-03T14:42:06.535-0500	INFO	controllers.Component	setting devfile component kubernetes-deploy attribute cpu limit to 2	{"appstudio-component": "HAS", "Component": "maysun/component-sample", "clusterName": ""}
2023-02-03T14:42:06.535-0500	INFO	controllers.Component	setting devfile component kubernetes-deploy attribute memory limit to 500Mi	{"appstudio-component": "HAS", "Component": "maysun/component-sample", "clusterName": ""}
2023-02-03T14:42:06.535-0500	INFO	controllers.Component	setting devfile component kubernetes-deploy attribute storage limit to 400Mi	{"appstudio-component": "HAS", "Component": "maysun/component-sample", "clusterName": ""}
2023-02-03T14:42:06.535-0500	INFO	controllers.Component	updating devfile component kubernetes-deploy attribute cpu request to 700m	{"appstudio-component": "HAS", "Component": "maysun/component-sample", "clusterName": ""}
2023-02-03T14:42:06.535-0500	INFO	controllers.Component	updating devfile component kubernetes-deploy attribute memory request to 400Mi	{"appstudio-component": "HAS", "Component": "maysun/component-sample", "clusterName": ""}
2023-02-03T14:42:06.535-0500	INFO	controllers.Component	updating devfile component kubernetes-deploy attribute storage request to 200Mi	{"appstudio-component": "HAS", "Component": "maysun/component-sample", "clusterName": ""}
2023-02-03T14:42:06.535-0500	INFO	controllers.Component	updating devfile component name kubernetes-deploy ...	{"appstudio-component": "HAS", "Component": "maysun/component-sample", "clusterName": ""}
2023-02-03T14:42:06.536-0500	INFO	controllers.Component	API Resource changed: Delete	{"appstudio-component": "HAS", "Namespace": "maysun", "clusterName": "", "audit": "true", "name": "component-sample", "resource": "Component", "action": "Delete"}
2023-02-03T14:42:06.538-0500	INFO	controllers.Component	The Component devfile data was not updated maysun/component-sample	{"appstudio-component": "HAS", "Component": "maysun/component-sample", "clusterName": ""}
2023-02-03T14:42:06.538-0500	INFO	controllers.Component	Finished reconcile loop for maysun/component-sample	{"appstudio-component": "HAS", "Component": "maysun/component-sample", "clusterName": ""}
```

#### After
```
2023-02-03T14:50:51.833-0500	INFO	controllers.Component	API Resource changed: Update	{"appstudio-component": "HAS", "Namespace": "maysun", "clusterName": "", "audit": "true", "name": "component-sample", "resource": "Component", "action": "Update"}
2023-02-03T14:50:53.474-0500	INFO	controllers.Application	API Resource changed: Update	{"appstudio-component": "HAS", "Namespace": "maysun", "clusterName": "", "audit": "true", "name": "application-sample", "resource": "Application", "action": "Update"}
2023-02-03T14:50:53.474-0500	INFO	controllers.Application	Starting reconcile loop for maysun/application-sample	{"appstudio-component": "HAS", "Application": "maysun/application-sample", "clusterName": ""}
2023-02-03T14:50:53.476-0500	INFO	controllers.Application	Finished reconcile loop for maysun/application-sample	{"appstudio-component": "HAS", "Application": "maysun/application-sample", "clusterName": ""}
2023-02-03T14:50:53.535-0500	INFO	controllers.Component	API Resource changed: Delete	{"appstudio-component": "HAS", "Namespace": "maysun", "clusterName": "", "audit": "true", "name": "component-sample", "resource": "Component", "action": "Delete"}
```

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
N/A

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
- tests should pass
- manually test and check logs