### PR TITLE
[DEVHAS-245] Prevent a panic from occurring when SelectDevfileFromTypes returns an error

### DIFF
--- a/pkg/devfile/detect.go
+++ b/pkg/devfile/detect.go
@@ -258,6 +258,9 @@ func (a AlizerClient) Analyze(path string) ([]model.Language, error) {
 // SelectDevFileFromTypes is a wrapper call to Alizer's SelectDevFileFromTypes()
 func (a AlizerClient) SelectDevFileFromTypes(path string, devFileTypes []model.DevFileType) (model.DevFileType, error) {
 	index, err := recognizer.SelectDevFileFromTypes(path, devFileTypes)
+	if err != nil {
+		return model.DevFileType{}, err
+	}
 	return devFileTypes[index], err
 }
 

--- a/pkg/devfile/detect_test.go
+++ b/pkg/devfile/detect_test.go
@@ -129,7 +129,7 @@ func TestSelectDevfileFromTypes(t *testing.T) {
 	}{
 		{
 			name:      "Successfully detect a devfile from the registry",
-			clonePath: "/tmp/java-springboot-basic",
+			clonePath: "/tmp/test-selected-devfile",
 			repo:      "https://github.com/maysunfaisal/devfile-sample-java-springboot-basic-1",
 			devfileTypes: []model.DevFileType{
 				{
@@ -158,8 +158,8 @@ func TestSelectDevfileFromTypes(t *testing.T) {
 		},
 		{
 			name:      "Unable to detect a devfile from the registry",
-			clonePath: "/tmp/test-console",
-			repo:      "https://github.com/devfile-resources/go-vendor-alizer-no-detection",
+			clonePath: "/tmp/test-no-devfiles-selected",
+			repo:      "https://github.com/maysunfaisal/devfile-sample-java-springboot-basic-1",
 			devfileTypes: []model.DevFileType{
 				{
 					Name: "python-basic", Language: "Python", ProjectType: "Python", Tags: []string{"Python", "Pip", "Flask"},

--- a/pkg/devfile/detect_test.go
+++ b/pkg/devfile/detect_test.go
@@ -172,7 +172,7 @@ func TestSelectDevfileFromTypes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			os.RemoveAll(tt.clonePath)
-			err := util.CloneRepo(tt.clonePath, tt.repo, "")
+			err := util.CloneRepo(tt.clonePath, tt.repo, "main", "")
 			if err != nil {
 				t.Errorf("got unexpected error %v", err)
 			}


### PR DESCRIPTION
### What does this PR do?:
When `recognizer.SelectDevFileFromTypes` returns an error, it also returns `-1` for its index return value, which is not a valid index. Since we not checking the error and just directly returning the index within the DevfileTypes array and error, this could lead to a panic when index == -1. 

This PR simply adds an err check and returns appropriately before we attempt to access the index within the DevfileTypes array.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-245

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
