### PR TITLE
[DEVHAS-255]update the attribute check to bypass 0 limit/request

### DIFF
--- a/pkg/devfile/devfile.go
+++ b/pkg/devfile/devfile.go
@@ -221,7 +221,7 @@ func GetResourceFromDevfile(log logr.Logger, devfileData data.DevfileData, deplo
 							containerLimits = make(corev1.ResourceList)
 						}
 
-						if cpuLimit != "" {
+						if cpuLimit != "" && cpuLimit != "0" {
 							cpuLimitQuantity, err := resource.ParseQuantity(cpuLimit)
 							if err != nil {
 								return parser.KubernetesResources{}, err
@@ -229,7 +229,7 @@ func GetResourceFromDevfile(log logr.Logger, devfileData data.DevfileData, deplo
 							containerLimits[corev1.ResourceCPU] = cpuLimitQuantity
 						}
 
-						if memoryLimit != "" {
+						if memoryLimit != "" && memoryLimit != "0" {
 							memoryLimitQuantity, err := resource.ParseQuantity(memoryLimit)
 							if err != nil {
 								return parser.KubernetesResources{}, err
@@ -237,7 +237,7 @@ func GetResourceFromDevfile(log logr.Logger, devfileData data.DevfileData, deplo
 							containerLimits[corev1.ResourceMemory] = memoryLimitQuantity
 						}
 
-						if storageLimit != "" {
+						if storageLimit != "" && storageLimit != "0" {
 							storageLimitQuantity, err := resource.ParseQuantity(storageLimit)
 							if err != nil {
 								return parser.KubernetesResources{}, err
@@ -274,7 +274,7 @@ func GetResourceFromDevfile(log logr.Logger, devfileData data.DevfileData, deplo
 							containerRequests = make(corev1.ResourceList)
 						}
 
-						if cpuRequest != "" {
+						if cpuRequest != "" && cpuRequest != "0" {
 							cpuRequestQuantity, err := resource.ParseQuantity(cpuRequest)
 							if err != nil {
 								return parser.KubernetesResources{}, err
@@ -282,7 +282,7 @@ func GetResourceFromDevfile(log logr.Logger, devfileData data.DevfileData, deplo
 							containerRequests[corev1.ResourceCPU] = cpuRequestQuantity
 						}
 
-						if memoryRequest != "" {
+						if memoryRequest != "" && memoryRequest != "0" {
 							memoryRequestQuantity, err := resource.ParseQuantity(memoryRequest)
 							if err != nil {
 								return parser.KubernetesResources{}, err
@@ -290,7 +290,7 @@ func GetResourceFromDevfile(log logr.Logger, devfileData data.DevfileData, deplo
 							containerRequests[corev1.ResourceMemory] = memoryRequestQuantity
 						}
 
-						if storageRequest != "" {
+						if storageRequest != "" && storageRequest != "0" {
 							storageRequestQuantity, err := resource.ParseQuantity(storageRequest)
 							if err != nil {
 								return parser.KubernetesResources{}, err

--- a/pkg/devfile/devfile_test.go
+++ b/pkg/devfile/devfile_test.go
@@ -655,8 +655,6 @@ components:
     deployment/memoryRequest: 401Mi
     deployment/replicas: 5
     deployment/route: route111222
-    deployment/storageLimit: 400Mi
-    deployment/storageRequest: 201Mi
   kubernetes:
     deployByDefault: false
     endpoints:
@@ -708,11 +706,9 @@ components:
                 limits:
                   cpu: "2"
                   memory: 500Mi
-                  storage: 400Mi
                 requests:
                   cpu: 700m
                   memory: 400Mi
-                  storage: 200Mi
       status: {}
       ---
       apiVersion: apps/v1
@@ -1703,14 +1699,12 @@ schemaVersion: 2.2.0`
 									},
 									Resources: corev1.ResourceRequirements{
 										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:     resource.MustParse("2"),
-											corev1.ResourceMemory:  resource.MustParse("500Mi"),
-											corev1.ResourceStorage: resource.MustParse("400Mi"),
+											corev1.ResourceCPU:    resource.MustParse("2"),
+											corev1.ResourceMemory: resource.MustParse("500Mi"),
 										},
 										Requests: corev1.ResourceList{
-											corev1.ResourceCPU:     resource.MustParse("701m"),
-											corev1.ResourceMemory:  resource.MustParse("401Mi"),
-											corev1.ResourceStorage: resource.MustParse("201Mi"),
+											corev1.ResourceCPU:    resource.MustParse("701m"),
+											corev1.ResourceMemory: resource.MustParse("401Mi"),
 										},
 									},
 								},


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

### What does this PR do?:
<!-- _Summarize the changes_ -->
This PR fix the issue that if the resource attribute is unset, the `attributes.GetString` returns "0" case. 
in the empty checks, ignore the `0` for all limits & requests, as setting to 0 does not make sense anyways. 


Tested the issue should have been fix: 


previously without the change: https://github.com/yangcao77/stephanie-app-yangcao-take-sit/blob/3ee8a35ad25cd670374784dc3764fe676b0e760b/components/devfile-sample-go-basic2/base/deployment.yaml#L41-L48

with the change:  https://github.com/yangcao77/stephanie-app-yangcao-take-sit/blob/main/components/devfile-sample-go-basic2/base/deployment.yaml#L42-L46

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
https://issues.redhat.com/browse/DEVHAS-255

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
