### PR TITLE
Use Patch() to update SEB status

### DIFF
--- a/controllers/applicationsnapshotenvironmentbinding_controller.go
+++ b/controllers/applicationsnapshotenvironmentbinding_controller.go
@@ -98,8 +98,6 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 
 	log.Info(fmt.Sprintf("Starting reconcile loop for %v %v", appSnapshotEnvBinding.Name, req.NamespacedName))
 
-	patch := client.MergeFrom(appSnapshotEnvBinding.DeepCopy())
-
 	applicationName := appSnapshotEnvBinding.Spec.Application
 	environmentName := appSnapshotEnvBinding.Spec.Environment
 	snapshotName := appSnapshotEnvBinding.Spec.Snapshot
@@ -123,7 +121,7 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 	err = r.Get(ctx, types.NamespacedName{Name: environmentName, Namespace: appSnapshotEnvBinding.Namespace}, &environment)
 	if err != nil {
 		log.Error(err, fmt.Sprintf("unable to get the Environment %s %v", environmentName, req.NamespacedName))
-		r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, patch, err)
+		r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, err)
 		return ctrl.Result{}, err
 	}
 
@@ -132,14 +130,14 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 	err = r.Get(ctx, types.NamespacedName{Name: snapshotName, Namespace: appSnapshotEnvBinding.Namespace}, &appSnapshot)
 	if err != nil {
 		log.Error(err, fmt.Sprintf("unable to get the Application Snapshot %s %v", snapshotName, req.NamespacedName))
-		r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, patch, err)
+		r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, err)
 		return ctrl.Result{}, err
 	}
 
 	if appSnapshot.Spec.Application != applicationName {
 		err := fmt.Errorf("application snapshot %s does not belong to the application %s", snapshotName, applicationName)
 		log.Error(err, "")
-		r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, patch, err)
+		r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, err)
 		return ctrl.Result{}, err
 	}
 
@@ -155,7 +153,7 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 		err = r.Get(ctx, types.NamespacedName{Name: componentName, Namespace: appSnapshotEnvBinding.Namespace}, &hasComponent)
 		if err != nil {
 			log.Error(err, fmt.Sprintf("unable to get the Component %s %v", componentName, req.NamespacedName))
-			r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, patch, err)
+			r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, err)
 			return ctrl.Result{}, err
 		}
 
@@ -167,7 +165,7 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 		if hasComponent.Spec.Application != applicationName {
 			err := fmt.Errorf("component %s does not belong to the application %s", componentName, applicationName)
 			log.Error(err, "")
-			r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, patch, err)
+			r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, err)
 			return ctrl.Result{}, err
 		}
 
@@ -183,13 +181,13 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 		if imageName == "" {
 			err := fmt.Errorf("application snapshot %s did not reference component %s", snapshotName, componentName)
 			log.Error(err, "")
-			r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, patch, err)
+			r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, err)
 			return ctrl.Result{}, err
 		}
 
 		gitOpsRemoteURL, gitOpsBranch, gitOpsContext, err := util.ProcessGitOpsStatus(hasComponent.Status.GitOps, r.GitToken)
 		if err != nil {
-			r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, patch, err)
+			r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, err)
 			return ctrl.Result{}, err
 		}
 
@@ -206,7 +204,7 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 			tempDir, err = ioutils.CreateTempPath(appSnapshotEnvBinding.Name, r.AppFS)
 			if err != nil {
 				log.Error(err, "unable to create temp directory for gitops resources due to error")
-				r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, patch, err)
+				r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, err)
 				return ctrl.Result{}, fmt.Errorf("unable to create temp directory for gitops resources due to error: %v", err)
 			}
 		}
@@ -251,7 +249,7 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 		if err != nil {
 			log.Error(err, fmt.Sprintf("unable to get generate gitops resources for %s %v", componentName, req.NamespacedName))
 			_ = r.AppFS.RemoveAll(tempDir) // not worried with an err, its a best case attempt to delete the temp clone dir
-			r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, patch, err)
+			r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, err)
 			return ctrl.Result{}, err
 		}
 
@@ -261,14 +259,14 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 		if err != nil {
 			gitOpsErr := &GitOpsParseRepoError{gitOpsRemoteURL, err}
 			log.Error(gitOpsErr, "")
-			r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, patch, gitOpsErr)
+			r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, gitOpsErr)
 			return ctrl.Result{}, gitOpsErr
 		}
 		commitID, err = github.GetLatestCommitSHAFromRepository(r.GitHubClient, ctx, repoName, orgName, gitOpsBranch)
 		if err != nil {
 			gitOpsErr := &GitOpsCommitIdError{err}
 			log.Error(gitOpsErr, "")
-			r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, patch, gitOpsErr)
+			r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, gitOpsErr)
 			return ctrl.Result{}, gitOpsErr
 		}
 
@@ -304,11 +302,11 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 	err = r.Client.Status().Update(ctx, &appSnapshotEnvBinding)
 	if err != nil {
 		log.Error(err, "Unable to update App Snapshot Env Binding")
-		r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, patch, err)
+		r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, err)
 		return ctrl.Result{}, err
 	}
 
-	r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, patch, nil)
+	r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, nil)
 
 	log.Info(fmt.Sprintf("Finished reconcile loop for %v", req.NamespacedName))
 	return ctrl.Result{}, nil

--- a/controllers/applicationsnapshotenvironmentbinding_controller_conditions.go
+++ b/controllers/applicationsnapshotenvironmentbinding_controller_conditions.go
@@ -24,30 +24,35 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (r *SnapshotEnvironmentBindingReconciler) SetConditionAndUpdateCR(ctx context.Context, req ctrl.Request, appSnapshotEnvBinding *appstudiov1alpha1.SnapshotEnvironmentBinding, createError error) {
+func (r *SnapshotEnvironmentBindingReconciler) SetConditionAndUpdateCR(ctx context.Context, req ctrl.Request, appSnapshotEnvBinding *appstudiov1alpha1.SnapshotEnvironmentBinding, patch client.Patch, createError error) {
 	log := r.Log.WithValues("SnapshotEnvironmentBinding", req.NamespacedName).WithValues("clusterName", req.ClusterName)
 
+	condition := metav1.Condition{}
 	if createError == nil {
-		meta.SetStatusCondition(&appSnapshotEnvBinding.Status.GitOpsRepoConditions, metav1.Condition{
+		condition = metav1.Condition{
 			Type:    "GitOpsResourcesGenerated",
 			Status:  metav1.ConditionTrue,
 			Reason:  "OK",
 			Message: "GitOps repository sync successful",
-		})
+		}
 	} else {
-		meta.SetStatusCondition(&appSnapshotEnvBinding.Status.GitOpsRepoConditions, metav1.Condition{
+		condition = metav1.Condition{
 			Type:    "GitOpsResourcesGenerated",
 			Status:  metav1.ConditionFalse,
 			Reason:  "GenerateError",
 			Message: fmt.Sprintf("GitOps repository sync failed: %v", createError),
-		})
-		logutil.LogAPIResourceChangeEvent(log, appSnapshotEnvBinding.Name, "SnapshotEnvironmentBinding", logutil.ResourceCreate, createError)
-	}
+		}
 
-	err := r.Client.Status().Update(ctx, appSnapshotEnvBinding)
+	}
+	meta.SetStatusCondition(&appSnapshotEnvBinding.Status.GitOpsRepoConditions, condition)
+	logutil.LogAPIResourceChangeEvent(log, appSnapshotEnvBinding.Name, "SnapshotEnvironmentBinding", logutil.ResourceCreate, createError)
+
+	err := r.Client.Status().Patch(ctx, appSnapshotEnvBinding, patch)
 	if err != nil {
 		log.Error(err, "Unable to update application snapshot environment binding")
+
 	}
 }


### PR DESCRIPTION
Changes the logic to update the SEB status from `Status().Update()` to `Status().Patch()`