### PR TITLE
[DEVHAS-268] Fix path to HAS component in infra-deployments

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -20,7 +20,7 @@ spec:
       value: Dockerfile
     - name: infra-deployment-update-script
       value: |
-        sed -i -e 's|\(https://github.com/redhat-appstudio/application-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/has/kustomization.yaml
+        sed -i -e 's|\(https://github.com/redhat-appstudio/application-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/has/base/kustomization.yaml
         sed -i -e 's|\(https://github.com/redhat-appstudio/application-service/config/monitoring/?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/monitoring/grafana/base/has/kustomization.yaml
   pipelineRef:
     name: docker-build


### PR DESCRIPTION
### What does this PR do?:
Fixes the path in `.tekton/push.yaml` for the HAS component in infra-deployments from `components/has/kustomization.yaml` to `components/has/base/kustomization.yaml`

### Which issue(s)/story(ies) does this PR fixes:
[DEVHAS-268](https://issues.redhat.com/browse/DEVHAS-268)

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
