### PR TITLE
[DEVHAS-264] Don't immediately display Application not ready error

### DIFF
--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -101,10 +101,10 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		if containsString(application.GetFinalizers(), appFinalizerName) {
 			// A finalizer is present for the Application CR, so make sure we do the necessary cleanup steps
 			if err := r.Finalize(&application); err != nil {
-				finalizeCount, err := getFinalizeCount(&application)
-				if err == nil && finalizeCount < 5 {
+				finalizeCounter, err := getCounterAnnotation(finalizeCount, &application)
+				if err == nil && finalizeCounter < 5 {
 					// The Finalize function failed, so increment the finalize count and return
-					setFinalizeCount(&application, finalizeCount+1)
+					setCounterAnnotation(finalizeCount, &application, finalizeCounter+1)
 					err := r.Update(ctx, &application)
 					if err != nil {
 						log.Error(err, "Error incrementing finalizer count on resource")

--- a/controllers/application_controller_finalizer.go
+++ b/controllers/application_controller_finalizer.go
@@ -24,6 +24,7 @@ import (
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	devfile "github.com/redhat-appstudio/application-service/pkg/devfile"
 	github "github.com/redhat-appstudio/application-service/pkg/github"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -81,22 +82,22 @@ func containsString(slice []string, s string) bool {
 	return false
 }
 
-// getFinalizeCount gets the finalize count for the Application CR
-func getFinalizeCount(application *appstudiov1alpha1.Application) (int, error) {
-	applicationAnnotations := application.GetAnnotations()
-	if applicationAnnotations == nil {
-		applicationAnnotations = make(map[string]string)
-		applicationAnnotations[finalizeCount] = "0"
+// getApplicationFailCount gets the given counter annotation on the resource (defaults to 0 if unset)
+func getCounterAnnotation(annotation string, obj client.Object) (int, error) {
+	objAnnotations := obj.GetAnnotations()
+	if objAnnotations == nil {
+		objAnnotations = make(map[string]string)
+		objAnnotations[annotation] = "0"
 	}
-	finalizeCountAnnotation := applicationAnnotations[finalizeCount]
-	return strconv.Atoi(finalizeCountAnnotation)
+	applicationFailCountAnnotation := objAnnotations[annotation]
+	return strconv.Atoi(applicationFailCountAnnotation)
 }
 
-// setCompFinalizeCount sets the finalize count for the Application CR
-func setFinalizeCount(application *appstudiov1alpha1.Application, count int) {
-	applicationAnnotations := application.GetAnnotations()
-	if applicationAnnotations == nil {
-		applicationAnnotations = make(map[string]string)
+// setApplicationFailCount sets the given counter annotation on the resource to the specified value
+func setCounterAnnotation(annotation string, obj client.Object, count int) {
+	objAnnotations := obj.GetAnnotations()
+	if objAnnotations == nil {
+		objAnnotations = make(map[string]string)
 	}
-	applicationAnnotations[finalizeCount] = strconv.Itoa(count)
+	objAnnotations[applicationFailCounterAnnotation] = strconv.Itoa(count)
 }

--- a/controllers/application_controller_finalizer.go
+++ b/controllers/application_controller_finalizer.go
@@ -99,5 +99,5 @@ func setCounterAnnotation(annotation string, obj client.Object, count int) {
 	if objAnnotations == nil {
 		objAnnotations = make(map[string]string)
 	}
-	objAnnotations[applicationFailCounterAnnotation] = strconv.Itoa(count)
+	objAnnotations[annotation] = strconv.Itoa(count)
 }

--- a/controllers/application_controller_finalizer.go
+++ b/controllers/application_controller_finalizer.go
@@ -85,12 +85,12 @@ func containsString(slice []string, s string) bool {
 // getApplicationFailCount gets the given counter annotation on the resource (defaults to 0 if unset)
 func getCounterAnnotation(annotation string, obj client.Object) (int, error) {
 	objAnnotations := obj.GetAnnotations()
-	if objAnnotations == nil {
+	if objAnnotations == nil || objAnnotations[annotation] == "" {
 		objAnnotations = make(map[string]string)
 		objAnnotations[annotation] = "0"
 	}
-	applicationFailCountAnnotation := objAnnotations[annotation]
-	return strconv.Atoi(applicationFailCountAnnotation)
+	counterAnnotation := objAnnotations[annotation]
+	return strconv.Atoi(counterAnnotation)
 }
 
 // setApplicationFailCount sets the given counter annotation on the resource to the specified value

--- a/controllers/application_controller_finalizer_test.go
+++ b/controllers/application_controller_finalizer_test.go
@@ -205,7 +205,7 @@ func createAndFetchSimpleAppWithRepo(name string, namespace string, display stri
 	return fetchedHasApp
 }
 
-func TestGetFinalizeCount(t *testing.T) {
+func TestGetCounterAnnotation(t *testing.T) {
 	tests := []struct {
 		name        string
 		application appstudiov1alpha1.Application
@@ -231,19 +231,19 @@ func TestGetFinalizeCount(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			count, err := getFinalizeCount(&tt.application)
+			count, err := getCounterAnnotation(finalizeCount, &tt.application)
 			if err != nil {
-				t.Errorf("TestGetFinalizeCount() unexpected error: %v", err)
+				t.Errorf("TestGetCounterAnnotation() unexpected error: %v", err)
 			}
 			if count != tt.want {
-				t.Errorf("TestGetFinalizeCount() error: expected %v got %v", tt.want, count)
+				t.Errorf("TestGetCounterAnnotation() error: expected %v got %v", tt.want, count)
 			}
 		})
 	}
 
 }
 
-func TestSetFinalizeCount(t *testing.T) {
+func TestSetCounterAnnotation(t *testing.T) {
 	tests := []struct {
 		name        string
 		application appstudiov1alpha1.Application
@@ -272,13 +272,13 @@ func TestSetFinalizeCount(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			setFinalizeCount(&tt.application, tt.count)
-			count, err := getFinalizeCount(&tt.application)
+			setCounterAnnotation(finalizeCount, &tt.application, tt.count)
+			count, err := getCounterAnnotation(finalizeCount, &tt.application)
 			if err != nil {
-				t.Errorf("TestGetFinalizeCount() unexpected error: %v", err)
+				t.Errorf("TestSetCounterAnnotation() unexpected error: %v", err)
 			}
 			if count != tt.want {
-				t.Errorf("TestGetFinalizeCount() error: expected %v got %v", tt.want, count)
+				t.Errorf("TestSetCounterAnnotation() error: expected %v got %v", tt.want, count)
 			}
 		})
 	}

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -633,7 +633,7 @@ func (r *ComponentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appstudiov1alpha1.Component{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		WithOptions(controller.Options{
-			RateLimiter: workqueue.NewItemExponentialFailureRateLimiter(time.Duration(500*time.Millisecond), time.Duration(60*time.Second)),
+			RateLimiter: workqueue.NewItemExponentialFailureRateLimiter(time.Duration(500*time.Millisecond), time.Duration(1000*time.Second)),
 		}).WithEventFilter(predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			log := log.WithValues("Namespace", e.Object.GetNamespace()).WithValues("clusterName", logicalcluster.From(e.Object).String())
@@ -673,6 +673,6 @@ func (r *ComponentReconciler) incrementCounterAndRequeue(log logr.Logger, ctx co
 		if err != nil {
 			log.Error(err, "error updating component's counter annotation")
 		}
-		return ctrl.Result{RequeueAfter: 500 * time.Millisecond}, componentErr
+		return ctrl.Result{}, componentErr
 	}
 }

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -654,6 +654,10 @@ func (r *ComponentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
+// incrementCounterAndRequeue will increment the "application error counter" on the Component resource and requeue
+// If the counter is less than 3, the Component will be requeued (with a half second delay) without any error message returned
+// If the counter is greater than or equal to 3, an error message will be set on the Component's status and it will be requeud
+// 3 attemps were chosen along with the half second requeue delay to allow certain transient errors when the application CR isn't ready, to resolve themself.
 func (r *ComponentReconciler) incrementCounterAndRequeue(log logr.Logger, ctx context.Context, req ctrl.Request, component *appstudiov1alpha1.Component, componentErr error) (ctrl.Result, error) {
 	if component.GetAnnotations() == nil {
 		component.ObjectMeta.Annotations = make(map[string]string)

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -366,6 +366,10 @@ var _ = Describe("Component controller", func() {
 			Expect(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Reason).Should(Equal("Error"))
 			Expect(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message).Should(ContainSubstring(fmt.Sprintf("%q not found", hasComp.Spec.Application)))
 
+			compAnnotations := createdHasComp.GetAnnotations()
+			Expect(compAnnotations).ShouldNot(BeNil())
+			Expect(compAnnotations[applicationFailCounterAnnotation]).Should(Not(Equal("")))
+
 			// Now create the application resource that it references
 			createAndFetchSimpleApp(applicationName, HASAppNamespace, DisplayName, Description)
 

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -359,12 +359,12 @@ var _ = Describe("Component controller", func() {
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompLookupKey, createdHasComp)
 				return len(createdHasComp.Status.Conditions) > 0
-			}, timeout, interval).Should(BeTrue())
+			}, 5*timeout, interval).Should(BeTrue())
 
 			// Make sure the err was set
 			Expect(createdHasComp.Status.Devfile).Should(Equal(""))
 			Expect(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Reason).Should(Equal("Error"))
-			Expect(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message).Should(ContainSubstring(fmt.Sprintf("%q not found", hasComp.Spec.Application)))
+			Expect(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message).Should(ContainSubstring(fmt.Sprintf("unable to get the Application %s", hasComp.Spec.Application)))
 
 			compAnnotations := createdHasComp.GetAnnotations()
 			Expect(compAnnotations).ShouldNot(BeNil())
@@ -377,7 +377,7 @@ var _ = Describe("Component controller", func() {
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompLookupKey, createdHasComp)
 				return len(createdHasComp.Status.Conditions) > 0 && createdHasComp.Status.Conditions[0].Reason == "OK"
-			}, timeout, interval).Should(BeTrue())
+			}, 4*timeout, interval).Should(BeTrue())
 
 			// Delete the specified HASComp resource
 			deleteHASAppCR(types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace})

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -359,7 +359,7 @@ var _ = Describe("Component controller", func() {
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompLookupKey, createdHasComp)
 				return len(createdHasComp.Status.Conditions) > 0
-			}, 5*timeout, interval).Should(BeTrue())
+			}, timeout40s, interval).Should(BeTrue())
 
 			// Make sure the err was set
 			Expect(createdHasComp.Status.Devfile).Should(Equal(""))
@@ -377,7 +377,7 @@ var _ = Describe("Component controller", func() {
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompLookupKey, createdHasComp)
 				return len(createdHasComp.Status.Conditions) > 0 && createdHasComp.Status.Conditions[0].Reason == "OK"
-			}, 4*timeout, interval).Should(BeTrue())
+			}, timeout40s, interval).Should(BeTrue())
 
 			// Delete the specified HASComp resource
 			deleteHASAppCR(types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace})


### PR DESCRIPTION
### What does this PR do?:
This PR updates the logic in the Component controller for handling scenarios where the Application isn't reconciled before the Component is.

Previously, if a Component's associated Application resource was not finished reconciling, or had an error state associated with it, we would return an error message in the Component. However, in scenarios where the the Component and Application are created together, it's not ideal to immediately display that error message.

With this PR, when the Component controller encounters that error, we instead add a counter annotation to the Component. If the error occurs 5 consecutive times, we then return the original error in the Component status. Otherwise, if the error goes away, we don't display it.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-264

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
