### PR TITLE
[DEVHAS-207] Detect ports in Component when running alizer

### DIFF
--- a/controllers/componentdetectionquery_controller_test.go
+++ b/controllers/componentdetectionquery_controller_test.go
@@ -1294,7 +1294,7 @@ var _ = Describe("Component Detection Query controller", func() {
 				Expect(len(createdHasCompDetectionQuery.Status.ComponentDetected)).Should(Equal(1))
 
 				for devfileName, devfileDesc := range createdHasCompDetectionQuery.Status.ComponentDetected {
-					Expect(devfileName).Should(ContainSubstring("nodejs"))
+					Expect(devfileName).Should(ContainSubstring("multi-component-port-detected"))
 					Expect(devfileDesc.ComponentStub.Source.GitSource.Context).Should(ContainSubstring("nodejs"))
 					Expect(devfileDesc.ComponentStub.Source.GitSource.Revision).Should(ContainSubstring("main"))
 					Expect(devfileDesc.ComponentStub.Source.GitSource.DevfileURL).Should(Equal("https://raw.githubusercontent.com/nodeshift-starters/devfile-sample/main/devfile.yaml"))

--- a/controllers/componentdetectionquery_controller_test.go
+++ b/controllers/componentdetectionquery_controller_test.go
@@ -1273,8 +1273,9 @@ var _ = Describe("Component Detection Query controller", func() {
 					},
 					Spec: appstudiov1alpha1.ComponentDetectionQuerySpec{
 						GitSource: appstudiov1alpha1.GitSource{
-							URL:      "https://github.com/devfile-resources/multi-component-port-detected",
+							URL:      "https://github.com/devfile-resources/single-component-port-detected",
 							Revision: "main",
+							Context:  "nodejs",
 						},
 					},
 				}
@@ -1294,7 +1295,7 @@ var _ = Describe("Component Detection Query controller", func() {
 				Expect(len(createdHasCompDetectionQuery.Status.ComponentDetected)).Should(Equal(1))
 
 				for devfileName, devfileDesc := range createdHasCompDetectionQuery.Status.ComponentDetected {
-					Expect(devfileName).Should(ContainSubstring("multi-component-port-detected"))
+					Expect(devfileName).Should(ContainSubstring("nodejs"))
 					Expect(devfileDesc.ComponentStub.Source.GitSource.Context).Should(ContainSubstring("nodejs"))
 					Expect(devfileDesc.ComponentStub.Source.GitSource.Revision).Should(ContainSubstring("main"))
 					Expect(devfileDesc.ComponentStub.Source.GitSource.DevfileURL).Should(Equal("https://raw.githubusercontent.com/nodeshift-starters/devfile-sample/main/devfile.yaml"))

--- a/controllers/componentdetectionquery_controller_test.go
+++ b/controllers/componentdetectionquery_controller_test.go
@@ -1260,7 +1260,7 @@ var _ = Describe("Component Detection Query controller", func() {
 			It("Should only return one component, with target port set", func() {
 				ctx := context.Background()
 
-				queryName := HASCompDetQuery + "26"
+				queryName := HASCompDetQuery + "devfile-sample-nodejs-basic" + "26"
 
 				hasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{
 					TypeMeta: metav1.TypeMeta{

--- a/controllers/update_test.go
+++ b/controllers/update_test.go
@@ -583,6 +583,25 @@ func TestUpdateComponentStub(t *testing.T) {
 		},
 	}
 
+	componentsValidWithPort := []devfileAPIV1.Component{
+		{
+			Name: "component1",
+			Attributes: envAttributes.PutInteger(devfilePkg.ReplicaKey, 1).PutString(devfilePkg.RouteKey, "route1").PutInteger(
+				devfilePkg.ContainerImagePortKey, 8080).PutString(devfilePkg.CpuLimitKey, "2").PutString(devfilePkg.CpuRequestKey, "700m").PutString(
+				devfilePkg.MemoryLimitKey, "500Mi").PutString(devfilePkg.MemoryRequestKey, "400Mi").PutString(
+				devfilePkg.StorageLimitKey, "400Mi").PutString(devfilePkg.StorageRequestKey, "200Mi"),
+			ComponentUnion: devfileAPIV1.ComponentUnion{
+				Kubernetes: &devfileAPIV1.KubernetesComponent{
+					K8sLikeComponent: devfileAPIV1.K8sLikeComponent{
+						K8sLikeComponentLocation: devfileAPIV1.K8sLikeComponentLocation{
+							Uri: "testLocation",
+						},
+					},
+				},
+			},
+		},
+	}
+
 	componentsReplicaErr := []devfileAPIV1.Component{
 		{
 			Name: "component1",
@@ -762,12 +781,13 @@ func TestUpdateComponentStub(t *testing.T) {
 	}
 
 	tests := []struct {
-		name             string
-		devfilesDataMap  map[string]*v2.DevfileV2
-		devfilesURLMap   map[string]string
-		dockerfileURLMap map[string]string
-		isNil            bool
-		wantErr          bool
+		name              string
+		devfilesDataMap   map[string]*v2.DevfileV2
+		devfilesURLMap    map[string]string
+		dockerfileURLMap  map[string]string
+		componentPortsMap map[string][]int
+		isNil             bool
+		wantErr           bool
 	}{
 		{
 			name: "Kubernetes Components present",
@@ -789,6 +809,31 @@ func TestUpdateComponentStub(t *testing.T) {
 						},
 					},
 				},
+			},
+		},
+		{
+			name: "Detected ports present",
+			devfilesDataMap: map[string]*v2.DevfileV2{
+				"./": {
+					Devfile: devfileAPIV1.Devfile{
+						DevfileHeader: devfile.DevfileHeader{
+							SchemaVersion: "2.2.0",
+							Metadata: devfile.DevfileMetadata{
+								Name:        "test-devfile",
+								Language:    "language",
+								ProjectType: "project",
+							},
+						},
+						DevWorkspaceTemplateSpec: devfileAPIV1.DevWorkspaceTemplateSpec{
+							DevWorkspaceTemplateSpecContent: devfileAPIV1.DevWorkspaceTemplateSpecContent{
+								Components: componentsValidWithPort,
+							},
+						},
+					},
+				},
+			},
+			componentPortsMap: map[string][]int{
+				"./": {8080},
 			},
 		},
 		{
@@ -1274,7 +1319,7 @@ func TestUpdateComponentStub(t *testing.T) {
 			if tt.isNil {
 				err = r.updateComponentStub(ctrl.Request{}, nil, devfilesMap, nil, nil, nil)
 			} else {
-				err = r.updateComponentStub(ctrl.Request{}, &componentDetectionQuery, devfilesMap, tt.devfilesURLMap, tt.dockerfileURLMap, nil)
+				err = r.updateComponentStub(ctrl.Request{}, &componentDetectionQuery, devfilesMap, tt.devfilesURLMap, tt.dockerfileURLMap, tt.componentPortsMap)
 			}
 
 			if tt.wantErr && (err == nil) {

--- a/controllers/update_test.go
+++ b/controllers/update_test.go
@@ -1272,9 +1272,9 @@ func TestUpdateComponentStub(t *testing.T) {
 			}
 			var err error
 			if tt.isNil {
-				err = r.updateComponentStub(ctrl.Request{}, nil, devfilesMap, nil, nil)
+				err = r.updateComponentStub(ctrl.Request{}, nil, devfilesMap, nil, nil, nil)
 			} else {
-				err = r.updateComponentStub(ctrl.Request{}, &componentDetectionQuery, devfilesMap, tt.devfilesURLMap, tt.dockerfileURLMap)
+				err = r.updateComponentStub(ctrl.Request{}, &componentDetectionQuery, devfilesMap, tt.devfilesURLMap, tt.dockerfileURLMap, nil)
 			}
 
 			if tt.wantErr && (err == nil) {

--- a/pkg/devfile/detect.go
+++ b/pkg/devfile/detect.go
@@ -45,6 +45,7 @@ type AlizerClient struct {
 // Map 1 returns a context to the devfile bytes if present.
 // Map 2 returns a context to the matched devfileURL from the github repository. If no devfile was present, then a link to a matching devfile in the devfile registry will be used instead.
 // Map 3 returns a context to the dockerfile uri or a matched dockerfileURL from the devfile registry if no dockerfile is present in the context
+// Map 4 returns a context to the list of ports that were detected by alizer in the source code, at that given context
 func search(log logr.Logger, a Alizer, localpath string, devfileRegistryURL string, source appstudiov1alpha1.GitSource) (map[string][]byte, map[string]string, map[string]string, map[string][]int, error) {
 
 	devfileMapFromRepo := make(map[string][]byte)
@@ -152,6 +153,11 @@ func search(log logr.Logger, a Alizer, localpath string, devfileRegistryURL stri
 }
 
 // AnalyzePath checks if a devfile or a dockerfile can be found in the localpath for the given context, this is a helper func used by the CDQ controller
+// In addition to returning an error, the following maps may be updated:
+// devfileMapFromRepo: a context to the devfile bytes if present
+// devfilesURLMapFromRepo: a context to the matched devfileURL from the github repository. If no devfile was present, then a link to a matching devfile in the devfile registry will be used instead.
+// dockerfileContextMapFromRepo: a context to the dockerfile uri or a matched dockerfileURL from the devfile registry if no dockerfile is present in the context
+// componentPortsMapFromRepo: a context to the list of ports that were detected by alizer in the source code, at that given context
 func AnalyzePath(a Alizer, localpath, context, devfileRegistryURL string, devfileMapFromRepo map[string][]byte, devfilesURLMapFromRepo, dockerfileContextMapFromRepo map[string]string, componentPortsMapFromRepo map[string][]int, isDevfilePresent, isDockerfilePresent bool) error {
 	if isDevfilePresent {
 		// If devfile is present, check to see if we can determine a Dockerfile from it
@@ -271,6 +277,11 @@ func (a AlizerClient) DetectComponents(path string) ([]model.Component, error) {
 }
 
 // AnalyzeAndDetectDevfile analyzes and attempts to detect a devfile from the devfile registry for a given local path
+// The following values are returned, in addition to an error
+// 1. the detected devfile, in bytes
+// 2. the detected endpoints in the devfile
+// 3. the detected type of the source code
+// 4. the detected ports found in the source code
 func AnalyzeAndDetectDevfile(a Alizer, path, devfileRegistryURL string) ([]byte, string, string, []int, error) {
 	var devfileBytes []byte
 	alizerDevfileTypes, err := getAlizerDevfileTypes(devfileRegistryURL)

--- a/pkg/devfile/detect_mock.go
+++ b/pkg/devfile/detect_mock.go
@@ -41,6 +41,7 @@ func (a MockAlizerClient) DetectComponents(path string) ([]model.Component, erro
 						CanBeComponent: true,
 					},
 				},
+				Ports: []int{8080},
 			},
 		}, nil
 	} else if strings.Contains(path, "nodejs-no-dockerfile") {

--- a/pkg/devfile/detect_test.go
+++ b/pkg/devfile/detect_test.go
@@ -99,7 +99,7 @@ func TestAnalyzeAndDetectDevfile(t *testing.T) {
 			if err != nil {
 				t.Errorf("got unexpected error %v", err)
 			} else {
-				devfileBytes, detectedDevfileEndpoint, _, err := AnalyzeAndDetectDevfile(mockClient, tt.clonePath, tt.registryURL)
+				devfileBytes, detectedDevfileEndpoint, _, _, err := AnalyzeAndDetectDevfile(mockClient, tt.clonePath, tt.registryURL)
 				if !tt.wantErr && err != nil {
 					t.Errorf("Unexpected err: %+v", err)
 				} else if tt.wantErr && err == nil {

--- a/pkg/devfile/detect_test.go
+++ b/pkg/devfile/detect_test.go
@@ -37,6 +37,7 @@ func TestAnalyzeAndDetectDevfile(t *testing.T) {
 		registryURL         string
 		wantDevfile         bool
 		wantDevfileEndpoint string
+		wantDetectedPorts   []int
 		wantErr             bool
 	}{
 		{
@@ -91,6 +92,15 @@ func TestAnalyzeAndDetectDevfile(t *testing.T) {
 			registryURL: DevfileStageRegistryEndpoint,
 			wantErr:     true,
 		},
+		{
+			name:                "Component detected successfully with Port(s) detected",
+			clonePath:           "/tmp/nodejsports-devfile-sample-nodejs-basic",
+			repo:                "https://github.com/devfile-resources/node-express-hello-no-devfile",
+			registryURL:         DevfileStageRegistryEndpoint,
+			wantDevfile:         true,
+			wantDevfileEndpoint: "https://raw.githubusercontent.com/nodeshift-starters/devfile-sample/main/devfile.yaml",
+			wantDetectedPorts:   []int{8080},
+		},
 	}
 
 	for _, tt := range tests {
@@ -99,7 +109,7 @@ func TestAnalyzeAndDetectDevfile(t *testing.T) {
 			if err != nil {
 				t.Errorf("got unexpected error %v", err)
 			} else {
-				devfileBytes, detectedDevfileEndpoint, _, _, err := AnalyzeAndDetectDevfile(mockClient, tt.clonePath, tt.registryURL)
+				devfileBytes, detectedDevfileEndpoint, _, detectedPorts, err := AnalyzeAndDetectDevfile(mockClient, tt.clonePath, tt.registryURL)
 				if !tt.wantErr && err != nil {
 					t.Errorf("Unexpected err: %+v", err)
 				} else if tt.wantErr && err == nil {
@@ -108,6 +118,8 @@ func TestAnalyzeAndDetectDevfile(t *testing.T) {
 					t.Errorf("Expected devfile: %+v, Got: %+v, devfile %+v", tt.wantDevfile, len(devfileBytes) > 0, string(devfileBytes))
 				} else if !reflect.DeepEqual(detectedDevfileEndpoint, tt.wantDevfileEndpoint) {
 					t.Errorf("Expected devfile endpoint: %+v, Got: %+v", tt.wantDevfileEndpoint, detectedDevfileEndpoint)
+				} else if !reflect.DeepEqual(detectedPorts, tt.wantDetectedPorts) {
+					t.Errorf("Expected detected ports: %+v, Got: %+v", tt.wantDetectedPorts, detectedPorts)
 				}
 			}
 			os.RemoveAll(tt.clonePath)

--- a/pkg/devfile/devfile.go
+++ b/pkg/devfile/devfile.go
@@ -707,7 +707,7 @@ func DownloadDevfileAndDockerfile(url string) ([]byte, string, []byte) {
 // Map 1 returns a context to the devfile bytes if present.
 // Map 2 returns a context to the matched devfileURL from the devfile registry if no devfile is present in the context.
 // Map 3 returns a context to the dockerfile uri or a matched dockerfileURL from the devfile registry if no dockerfile is present in the context
-func ScanRepo(log logr.Logger, a Alizer, localpath string, devfileRegistryURL string, source appstudiov1alpha1.GitSource) (map[string][]byte, map[string]string, map[string]string, error) {
+func ScanRepo(log logr.Logger, a Alizer, localpath string, devfileRegistryURL string, source appstudiov1alpha1.GitSource) (map[string][]byte, map[string]string, map[string]string, map[string][]int, error) {
 	return search(log, a, localpath, devfileRegistryURL, source)
 }
 

--- a/pkg/devfile/devfile.go
+++ b/pkg/devfile/devfile.go
@@ -707,6 +707,7 @@ func DownloadDevfileAndDockerfile(url string) ([]byte, string, []byte) {
 // Map 1 returns a context to the devfile bytes if present.
 // Map 2 returns a context to the matched devfileURL from the devfile registry if no devfile is present in the context.
 // Map 3 returns a context to the dockerfile uri or a matched dockerfileURL from the devfile registry if no dockerfile is present in the context
+// Map 4 returns a context to the list of ports that were detected by alizer in the source code, at that given context
 func ScanRepo(log logr.Logger, a Alizer, localpath string, devfileRegistryURL string, source appstudiov1alpha1.GitSource) (map[string][]byte, map[string]string, map[string]string, map[string][]int, error) {
 	return search(log, a, localpath, devfileRegistryURL, source)
 }

--- a/pkg/devfile/devfile_test.go
+++ b/pkg/devfile/devfile_test.go
@@ -465,52 +465,22 @@ func TestScanRepo(t *testing.T) {
 		expectedDevfileContext       []string
 		expectedDevfileURLContextMap map[string]string
 		expectedDockerfileContextMap map[string]string
+		expectedPortsMap             map[string][]int
 	}{
 		{
-			name:                   "Should return 2 devfile contexts, and 2 devfileURLs as this is a multi comp devfile",
-			clonePath:              "/tmp/testclone",
-			repo:                   "https://github.com/maysunfaisal/multi-components-deep",
-			expectedDevfileContext: []string{"python", "devfile-sample-java-springboot-basic"},
+			name:                   "Should return one context with one devfile, along with one port detected",
+			clonePath:              "/tmp/testclonenode-devfile-sample-nodejs-basic",
+			repo:                   "https://github.com/devfile-resources/multi-component-port-detected",
+			expectedDevfileContext: []string{"nodejs"},
 			expectedDevfileURLContextMap: map[string]string{
-				"devfile-sample-java-springboot-basic": "https://raw.githubusercontent.com/maysunfaisal/multi-components-deep/main/devfile-sample-java-springboot-basic/.devfile/.devfile.yaml",
-				"python":                               "https://raw.githubusercontent.com/devfile-samples/devfile-sample-python-basic/main/devfile.yaml",
+				"nodejs": "https://raw.githubusercontent.com/nodeshift-starters/devfile-sample/main/devfile.yaml",
 			},
 			expectedDockerfileContextMap: map[string]string{
-				"devfile-sample-java-springboot-basic": "devfile-sample-java-springboot-basic/docker/Dockerfile",
-				"python":                               "https://raw.githubusercontent.com/devfile-samples/devfile-sample-python-basic/main/docker/Dockerfile"},
-		},
-		{
-			name:                   "Should return 2 devfile contexts, and 2 devfileURLs as this is a multi comp devfile - with revision specified",
-			clonePath:              "/tmp/testclone",
-			repo:                   "https://github.com/maysunfaisal/multi-components-deep",
-			revision:               "2a7b64d94453746579ae0898e44bcdd3d8575167",
-			expectedDevfileContext: []string{"python", "devfile-sample-java-springboot-basic"},
-			expectedDevfileURLContextMap: map[string]string{
-				"devfile-sample-java-springboot-basic": "https://raw.githubusercontent.com/maysunfaisal/multi-components-deep/main/devfile-sample-java-springboot-basic/.devfile/.devfile.yaml",
-				"python":                               "https://raw.githubusercontent.com/devfile-samples/devfile-sample-python-basic/main/devfile.yaml",
+				"nodejs": "https://raw.githubusercontent.com/nodeshift-starters/devfile-sample/main/Dockerfile",
 			},
-			expectedDockerfileContextMap: map[string]string{
-				"devfile-sample-java-springboot-basic": "devfile-sample-java-springboot-basic/docker/Dockerfile",
-				"python":                               "https://raw.githubusercontent.com/devfile-samples/devfile-sample-python-basic/main/docker/Dockerfile"},
-		},
-		{
-			name:                   "Should return 4 devfiles, 5 devfile url and 5 dockerfile uri as this is a multi comp devfile",
-			clonePath:              "/tmp/testclone",
-			repo:                   "https://github.com/maysunfaisal/multi-components-dockerfile",
-			expectedDevfileContext: []string{"devfile-sample-java-springboot-basic", "devfile-sample-nodejs-basic", "devfile-sample-python-basic", "python-src-none"},
-			expectedDevfileURLContextMap: map[string]string{
-				"devfile-sample-java-springboot-basic": "https://raw.githubusercontent.com/maysunfaisal/multi-components-dockerfile/main/devfile-sample-java-springboot-basic/.devfile/.devfile.yaml",
-				"devfile-sample-nodejs-basic":          "https://raw.githubusercontent.com/maysunfaisal/multi-components-dockerfile/main/devfile-sample-nodejs-basic/devfile.yaml",
-				"devfile-sample-python-basic":          "https://raw.githubusercontent.com/maysunfaisal/multi-components-dockerfile/main/devfile-sample-python-basic/.devfile.yaml",
-				"python-src-none":                      "https://raw.githubusercontent.com/devfile-samples/devfile-sample-python-basic/main/devfile.yaml",
-				"python-src-docker":                    "https://raw.githubusercontent.com/devfile-samples/devfile-sample-python-basic/main/devfile.yaml",
+			expectedPortsMap: map[string][]int{
+				"nodejs": {8080},
 			},
-			expectedDockerfileContextMap: map[string]string{
-				"python-src-docker":                    "python-src-docker/Dockerfile",
-				"devfile-sample-nodejs-basic":          "https://raw.githubusercontent.com/nodeshift-starters/devfile-sample/main/Dockerfile",
-				"devfile-sample-java-springboot-basic": "devfile-sample-java-springboot-basic/docker/Dockerfile",
-				"python-src-none":                      "https://raw.githubusercontent.com/devfile-samples/devfile-sample-python-basic/main/docker/Dockerfile",
-				"devfile-sample-python-basic":          "https://raw.githubusercontent.com/maysunfaisal/multi-components-dockerfile/main/devfile-sample-python-basic/Dockerfile"},
 		},
 	}
 
@@ -524,7 +494,7 @@ func TestScanRepo(t *testing.T) {
 			if err != nil {
 				t.Errorf("got unexpected error %v", err)
 			} else {
-				devfileMap, devfileURLMap, dockerfileMap, _, err := ScanRepo(logger, alizerClient, tt.clonePath, DevfileStageRegistryEndpoint, source)
+				devfileMap, devfileURLMap, dockerfileMap, portsMap, err := ScanRepo(logger, alizerClient, tt.clonePath, DevfileStageRegistryEndpoint, source)
 				if tt.wantErr && (err == nil) {
 					t.Error("wanted error but got nil")
 				} else if !tt.wantErr && err != nil {
@@ -554,6 +524,12 @@ func TestScanRepo(t *testing.T) {
 					for actualContext := range dockerfileMap {
 						if tt.expectedDockerfileContextMap[actualContext] != dockerfileMap[actualContext] {
 							t.Errorf("found dockerfile uri at context %v:%v but expected %v", actualContext, dockerfileMap[actualContext], tt.expectedDockerfileContextMap[actualContext])
+						}
+					}
+
+					for actualContext := range portsMap {
+						if !reflect.DeepEqual(tt.expectedPortsMap[actualContext], portsMap[actualContext]) {
+							t.Errorf("found port(s) at context %v:%v but expected %v", actualContext, portsMap[actualContext], tt.expectedPortsMap[actualContext])
 						}
 					}
 				}

--- a/pkg/devfile/devfile_test.go
+++ b/pkg/devfile/devfile_test.go
@@ -524,7 +524,7 @@ func TestScanRepo(t *testing.T) {
 			if err != nil {
 				t.Errorf("got unexpected error %v", err)
 			} else {
-				devfileMap, devfileURLMap, dockerfileMap, err := ScanRepo(logger, alizerClient, tt.clonePath, DevfileStageRegistryEndpoint, source)
+				devfileMap, devfileURLMap, dockerfileMap, _, err := ScanRepo(logger, alizerClient, tt.clonePath, DevfileStageRegistryEndpoint, source)
 				if tt.wantErr && (err == nil) {
 					t.Error("wanted error but got nil")
 				} else if !tt.wantErr && err != nil {

--- a/pkg/devfile/devfile_test.go
+++ b/pkg/devfile/devfile_test.go
@@ -470,7 +470,7 @@ func TestScanRepo(t *testing.T) {
 		{
 			name:                   "Should return one context with one devfile, along with one port detected",
 			clonePath:              "/tmp/testclonenode-devfile-sample-nodejs-basic",
-			repo:                   "https://github.com/devfile-resources/multi-component-port-detected",
+			repo:                   "https://github.com/devfile-resources/single-component-port-detected",
 			expectedDevfileContext: []string{"nodejs"},
 			expectedDevfileURLContextMap: map[string]string{
 				"nodejs": "https://raw.githubusercontent.com/nodeshift-starters/devfile-sample/main/devfile.yaml",


### PR DESCRIPTION
### What does this PR do?:
Updates our code in CDQs to retrieve the ports when we use alizer to detect Components. If ports are present for the detected component(s) they will be set in the Component stub. If no ports are detected, we will fall back on the ports present in the devfile.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-207

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
