### PR TITLE
[DEVHAS-274] Always return local Dockerfile URI if Dockerfile present in repository

### DIFF
--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"path"
-	"strings"
 
 	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
@@ -261,22 +260,6 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 				log.Error(err, fmt.Sprintf("Unable to remove the clonepath %s %v", clonePath, req.NamespacedName))
 				r.SetCompleteConditionAndUpdateCR(ctx, req, &componentDetectionQuery, copiedCDQ, err)
 				return ctrl.Result{}, nil
-			}
-		}
-
-		for context, link := range dockerfileContextMap {
-			// If the returned context/link is a local path, update the git link for the dockerfile accordingly
-			// Otherwise
-			if !strings.HasPrefix(link, "http") {
-				updatedContext := path.Join(context, link)
-
-				updatedLink, err := devfile.UpdateGitLink(source.URL, source.Revision, updatedContext)
-				if err != nil {
-					log.Error(err, fmt.Sprintf("Unable to update the dockerfile link %v", req.NamespacedName))
-					r.SetCompleteConditionAndUpdateCR(ctx, req, &componentDetectionQuery, copiedCDQ, err)
-					return ctrl.Result{}, nil
-				}
-				dockerfileContextMap[context] = updatedLink
 			}
 		}
 

--- a/controllers/componentdetectionquery_controller_test.go
+++ b/controllers/componentdetectionquery_controller_test.go
@@ -1013,7 +1013,7 @@ var _ = Describe("Component Detection Query controller", func() {
 				for _, componentDesc := range createdHasCompDetectionQuery.Status.ComponentDetected {
 					Expect(componentDesc.ComponentStub.Source.GitSource).ShouldNot(BeNil())
 					Expect(componentDesc.ComponentStub.Source.GitSource.DockerfileURL).ShouldNot(BeEmpty())
-					Expect(componentDesc.ComponentStub.Source.GitSource.DockerfileURL).Should(Equal("https://raw.githubusercontent.com/maysunfaisal/python-src-docker/main/Dockerfile"))
+					Expect(componentDesc.ComponentStub.Source.GitSource.DockerfileURL).Should(Equal("./Dockerfile"))
 				}
 
 				// Delete the specified Detection Query resource


### PR DESCRIPTION
### What does this PR do?:
Removes the code that would change the local dockerfile URI to be absolute for Dockerfile components. Since we no longer want to provide an absolute URI in this component, this can be removed, and we can fall back on returning a local URI.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-274

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.


- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
