### PR TITLE
[STONEBLD-818] Do not set default component image repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,10 @@ The following section outlines the steps to deploy HAS on a physical Kubernetes 
 
 As a user, upon creation of Component, Tekton resources would be created by the controller.
 
-If you wish to get 'working' PipelineRuns,
-* Create an image pull secret named `redhat-appstudio-registry-pull-secret`. See [Kubernetes docs](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#registry-secret-existing-credentials) for more information on how to create
-`Secrets` containing registry credentials.
-* Configure the default image repository to which Pipelines would push images to by defining the environment variable `IMAGE_REPOSITORY` for the operator deployment.
-Defaults to `quay.io/redhat-appstudio/user-workload`.
+To use auto generated image repository for the Component's image add `image.redhat.com/generate: "true"` annotation to the Component.
 
-Pipelines would use the credentials in the image pull secret `redhat-appstudio-registry-pull-secret` to push to $IMAGE_REPOSITORY.
+If you wish to get 'working' PipelineRuns with user provided image repository, create an image pull secret and link it to the `pipeline` Service Account in the Component's namespace (in both `secrets` and `imagePullSecrets` sections).
+See [Kubernetes docs](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#registry-secret-existing-credentials) for more information on how to create `Secrets` containing registry credentials.
 
 
 

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -65,7 +65,6 @@ type ComponentReconciler struct {
 	Log               logr.Logger
 	GitToken          string
 	GitHubOrg         string
-	ImageRepository   string
 	Generator         gitopsgen.Generator
 	AppFS             afero.Afero
 	SPIClient         spi.SPI
@@ -179,17 +178,6 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	log.Info(fmt.Sprintf("Starting reconcile loop for %v", req.NamespacedName))
-
-	if component.Spec.ContainerImage == "" {
-		uniqueHash := util.GenerateUniqueHashForWorkloadImageTag(req.ClusterName, component.Namespace)
-		component.Spec.ContainerImage = r.ImageRepository + ":" + uniqueHash + "-" + component.Name
-		if err := r.Client.Update(ctx, &component); err != nil {
-			log.Error(err, fmt.Sprintf("Failed to set default component image: %s", component.Spec.ContainerImage))
-			return ctrl.Result{}, err
-		}
-		log.Info(fmt.Sprintf("Set component image to default value: %s", component.Spec.ContainerImage))
-		return ctrl.Result{Requeue: true}, nil
-	}
 
 	// Check if GitOps generation has failed on a reconcile
 	// Attempt to generate GitOps and set appropriate conditions accordingly

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -117,7 +117,6 @@ var _ = BeforeSuite(func() {
 		Log:               ctrl.Log.WithName("controllers").WithName("Component"),
 		Generator:         gitops.NewMockGenerator(),
 		AppFS:             ioutils.NewMemoryFilesystem(),
-		ImageRepository:   "docker.io/foo/customized",
 		SPIClient:         spi.MockSPIClient{},
 		GitHubTokenClient: mockGhTokenClient,
 	}).SetupWithManager(k8sManager)

--- a/gitops/generate_build.go
+++ b/gitops/generate_build.go
@@ -38,26 +38,12 @@ const (
 	buildWebhookRouteFileName    = "build-webhook-route.yaml"
 	buildRepositoryFileName      = "pac-repository.yaml"
 
-	DefaultImageRepo = "quay.io/redhat-appstudio/user-workload"
-
 	PaCAnnotation                     = "pipelinesascode"
 	GitProviderAnnotationName         = "git-provider"
 	PipelinesAsCodeWebhooksSecretName = "pipelines-as-code-webhooks-secret"
 	PipelinesAsCode_githubAppIdKey    = "github-application-id"
 	PipelinesAsCode_githubPrivateKey  = "github-private-key"
 )
-
-var (
-	imageRegistry = DefaultImageRepo
-)
-
-func GetDefaultImageRepo() string {
-	return imageRegistry
-}
-
-func SetDefaultImageRepo(repo string) {
-	imageRegistry = repo
-}
 
 func GenerateBuild(fs afero.Fs, outputFolder string, component appstudiov1alpha1.Component, gitopsConfig gitopsprepare.GitopsConfig) error {
 	repository, err := GeneratePACRepository(component, gitopsConfig.PipelinesAsCodeCredentials)

--- a/gitops/generate_test.go
+++ b/gitops/generate_test.go
@@ -122,34 +122,3 @@ func TestGenerateTektonBuild(t *testing.T) {
 		})
 	}
 }
-
-func TestGetAndSetDefaultImageRepo(t *testing.T) {
-
-	tests := []struct {
-		name      string
-		imageRepo string
-		want      string
-	}{
-		{
-			name: "Get default image repo",
-			want: "quay.io/redhat-appstudio/user-workload",
-		},
-		{
-			name:      "Override default image repo",
-			imageRepo: "quay.io/myuser/myrepo",
-			want:      "quay.io/myuser/myrepo",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.imageRepo != "" {
-				SetDefaultImageRepo(tt.imageRepo)
-			}
-			imageRepo := GetDefaultImageRepo()
-			if imageRepo != tt.want {
-				t.Errorf("TestGetAndSetDefaultImageRepo(): want %v, got %v", tt.want, imageRepo)
-			}
-		})
-	}
-}

--- a/main.go
+++ b/main.go
@@ -47,7 +47,6 @@ import (
 
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/application-service/controllers"
-	appservicegitops "github.com/redhat-appstudio/application-service/gitops"
 	"github.com/redhat-appstudio/application-service/pkg/devfile"
 	"github.com/redhat-appstudio/application-service/pkg/github"
 	"github.com/redhat-appstudio/application-service/pkg/spi"
@@ -154,13 +153,6 @@ func main() {
 		ghOrg = "redhat-appstudio-appdata"
 	}
 
-	// Retrieve the name of the default repository to use
-	imageRepository := os.Getenv("IMAGE_REPOSITORY")
-	if imageRepository == "" {
-		imageRepository = appservicegitops.DefaultImageRepo
-	}
-	appservicegitops.SetDefaultImageRepo(imageRepository)
-
 	// Retrieve the option to specify a custom devfile registry
 	devfileRegistryURL := os.Getenv("DEVFILE_REGISTRY_URL")
 	if devfileRegistryURL == "" {
@@ -192,7 +184,6 @@ func main() {
 		Generator:         gitopsgen.NewGitopsGen(),
 		AppFS:             ioutils.NewFilesystem(),
 		GitHubTokenClient: ghTokenClient,
-		ImageRepository:   imageRepository,
 		SPIClient:         spi.SPIClient{},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Component")


### PR DESCRIPTION
### What does this PR do?:
Removes code that sets default value into `ContainerImage` field.
It should be done by user or image controller should provide annotation with the created image repository

### Which issue(s)/story(ies) does this PR fixes:
[STONEBLD-818](https://issues.redhat.com/browse/STONEBLD-818)

### Blocked by:
[HAC-3275](https://issues.redhat.com/browse/HAC-3275)
