### PR TITLE
[DEVHAS-290] Support multiple tokens & Initialize go-github during reconcile

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,17 +67,13 @@ Pipelines would use the credentials in the image pull secret `redhat-appstudio-r
 
 ### Creating a GitHub Secret for HAS
 
-Before deploying the operator, you must ensure that a secret, `has-github-token`, exists in the namespace where HAS will be deployed. This secret must contain a key-value pair, where the key is `token` and where the value points to a valid GitHub Personal Access Token.
+Before deploying the operator, you must ensure that a secret, `has-github-token`, exists in the namespace where HAS will be deployed. This secret must contain a key-value pair, where the key is `tokens` and where the value points to a comma separated list, without spaces, of valid (classic) GitHub Personal Access Token(s).
 
 The token that is used here must have the following permissions set:
 - `repo`
 - `delete_repo`
 
-You can also set an optional key-value pair for component detection query specifically, where the key is `cdq-token` and where the value points to a valid GitHub Personal Access Token. If the `cdq-token` does not exist, it will fall back to use `token` instead. 
-The token that is used here must have the following permissions set:
-- `repo`
-
-In addition to this, the GitHub token must be associated with an account that has write access to the GitHub organization you plan on using with HAS (see next section).
+In addition to this, each GitHub token must be associated with an account that has write access to the GitHub organization you plan on using with HAS (see next section).
 
 For example, on OpenShift:
 <img width="862" alt="Screen Shot 2021-12-14 at 1 08 43 AM" src="https://user-images.githubusercontent.com/6880023/145942734-63422532-6fad-4017-9d26-79436fe241b8.png">

--- a/README.md
+++ b/README.md
@@ -70,9 +70,11 @@ Pipelines would use the credentials in the image pull secret `redhat-appstudio-r
 Before deploying the operator, you must ensure that a secret, `has-github-token`, exists in the namespace where HAS will be deployed. This secret must contain a key, `tokens`, whose value points to a comma separated list, without spaces, of key-value pairs of token names and tokens, delimited by a colon. 
 
 For example, on OpenShift:
+
 <img width="801" alt="Screenshot 2023-03-22 at 3 53 11 PM" src="https://user-images.githubusercontent.com/6880023/227020767-30b3db08-e191-4ec1-81df-81ae2df55d79.png">
 
 Or via command-line:
+
 ```bash
 application-service % kubectl create secret generic has-github-token --from-literal=tokens=token1:ghp_faketoken,token2:ghp_anothertoken,token3:ghp_thirdtoken
 ```

--- a/README.md
+++ b/README.md
@@ -67,16 +67,22 @@ Pipelines would use the credentials in the image pull secret `redhat-appstudio-r
 
 ### Creating a GitHub Secret for HAS
 
-Before deploying the operator, you must ensure that a secret, `has-github-token`, exists in the namespace where HAS will be deployed. This secret must contain a key-value pair, where the key is `tokens` and where the value points to a comma separated list, without spaces, of valid (classic) GitHub Personal Access Token(s).
+Before deploying the operator, you must ensure that a secret, `has-github-token`, exists in the namespace where HAS will be deployed. This secret must contain a key, `tokens`, whose value points to a comma separated list, without spaces, of key-value pairs of token names and tokens, delimited by a colon. 
 
-The token that is used here must have the following permissions set:
+For example, on OpenShift:
+<img width="801" alt="Screenshot 2023-03-22 at 3 53 11 PM" src="https://user-images.githubusercontent.com/6880023/227020767-30b3db08-e191-4ec1-81df-81ae2df55d79.png">
+
+Or via command-line:
+```bash
+application-service % kubectl create secret generic has-github-token --from-literal=tokens=token1:ghp_faketoken,token2:ghp_anothertoken,token3:ghp_thirdtoken
+```
+
+Any token that is used here must have the following permissions set:
 - `repo`
 - `delete_repo`
 
 In addition to this, each GitHub token must be associated with an account that has write access to the GitHub organization you plan on using with HAS (see next section).
 
-For example, on OpenShift:
-<img width="862" alt="Screen Shot 2021-12-14 at 1 08 43 AM" src="https://user-images.githubusercontent.com/6880023/145942734-63422532-6fad-4017-9d26-79436fe241b8.png">
 
 ### Using Private Git Repos
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -66,6 +66,12 @@ spec:
               name: has-github-token
               key: token
               optional: true
+        - name: GITHUB_TOKEN_LIST
+          valueFrom:
+            secretKeyRef:
+              name: has-github-token
+              key: tokens
+              optional: true
         - name: CDQ_GITHUB_TOKEN
           valueFrom:
             secretKeyRef:

--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -24,7 +24,6 @@ import (
 	"github.com/go-logr/logr"
 	"go.uber.org/zap/zapcore"
 
-	gh "github.com/google/go-github/v41/github"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -48,10 +47,10 @@ import (
 // ApplicationReconciler reconciles a Application object
 type ApplicationReconciler struct {
 	client.Client
-	Scheme       *runtime.Scheme
-	Log          logr.Logger
-	GitHubClient *gh.Client
-	GitHubOrg    string
+	Scheme            *runtime.Scheme
+	Log               logr.Logger
+	GitHubTokenClient github.GitHubToken
+	GitHubOrg         string
 }
 
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications,verbs=get;list;watch;create;update;patch;delete
@@ -89,6 +88,11 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return reconcile.Result{}, err
 	}
 
+	ghClient, err := r.GitHubTokenClient.GetNewGitHubClient()
+	if err != nil {
+		log.Error(err, "Unable to create Go-GitHub client due to error")
+	}
+
 	// Check if the Application CR is under deletion
 	// If so: Remove the GitOps repo (if generated) and remove the finalizer.
 	if application.ObjectMeta.DeletionTimestamp.IsZero() {
@@ -100,7 +104,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	} else {
 		if containsString(application.GetFinalizers(), appFinalizerName) {
 			// A finalizer is present for the Application CR, so make sure we do the necessary cleanup steps
-			if err := r.Finalize(&application); err != nil {
+			if err := r.Finalize(&application, ghClient); err != nil {
 				finalizeCounter, err := getCounterAnnotation(finalizeCount, &application)
 				if err == nil && finalizeCounter < 5 {
 					// The Finalize function failed, so increment the finalize count and return
@@ -139,7 +143,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			repoName := github.GenerateNewRepositoryName(application.Name, uniqueHash)
 
 			// Generate the git repo in the redhat-appstudio-appdata org
-			repoUrl, err := github.GenerateNewRepository(r.GitHubClient, ctx, r.GitHubOrg, repoName, "GitOps Repository")
+			repoUrl, err := github.GenerateNewRepository(ghClient, ctx, r.GitHubOrg, repoName, "GitOps Repository")
 			if err != nil {
 				log.Error(err, fmt.Sprintf("Unable to create repository %v", repoUrl))
 				r.SetCreateConditionAndUpdateCR(ctx, req, &application, err)

--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -88,7 +88,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return reconcile.Result{}, err
 	}
 
-	ghClient, err := r.GitHubTokenClient.GetNewGitHubClient()
+	ghClient, _, err := r.GitHubTokenClient.GetNewGitHubClient()
 	if err != nil {
 		log.Error(err, "Unable to create Go-GitHub client due to error")
 		return reconcile.Result{}, err

--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -88,7 +88,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return reconcile.Result{}, err
 	}
 
-	ghClient, _, err := r.GitHubTokenClient.GetNewGitHubClient()
+	ghClient, err := r.GitHubTokenClient.GetNewGitHubClient()
 	if err != nil {
 		log.Error(err, "Unable to create Go-GitHub client due to error")
 		return reconcile.Result{}, err
@@ -144,7 +144,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			repoName := github.GenerateNewRepositoryName(application.Name, uniqueHash)
 
 			// Generate the git repo in the redhat-appstudio-appdata org
-			repoUrl, err := github.GenerateNewRepository(ghClient, ctx, r.GitHubOrg, repoName, "GitOps Repository")
+			repoUrl, err := ghClient.GenerateNewRepository(ctx, r.GitHubOrg, repoName, "GitOps Repository")
 			if err != nil {
 				log.Error(err, fmt.Sprintf("Unable to create repository %v", repoUrl))
 				r.SetCreateConditionAndUpdateCR(ctx, req, &application, err)

--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -91,6 +91,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	ghClient, err := r.GitHubTokenClient.GetNewGitHubClient()
 	if err != nil {
 		log.Error(err, "Unable to create Go-GitHub client due to error")
+		return reconcile.Result{}, err
 	}
 
 	// Check if the Application CR is under deletion

--- a/controllers/application_controller_finalizer.go
+++ b/controllers/application_controller_finalizer.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 
+	gh "github.com/google/go-github/v41/github"
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	devfile "github.com/redhat-appstudio/application-service/pkg/devfile"
 	github "github.com/redhat-appstudio/application-service/pkg/github"
@@ -46,7 +47,7 @@ func (r *ApplicationReconciler) AddFinalizer(ctx context.Context, application *a
 }
 
 // Finalize deletes the corresponding GitOps repo for the given Application CR.
-func (r *ApplicationReconciler) Finalize(application *appstudiov1alpha1.Application) error {
+func (r *ApplicationReconciler) Finalize(application *appstudiov1alpha1.Application, client *gh.Client) error {
 	// Get the GitOps repository URL
 	devfileSrc := devfile.DevfileSrc{
 		Data: application.Status.Devfile,
@@ -67,7 +68,7 @@ func (r *ApplicationReconciler) Finalize(application *appstudiov1alpha1.Applicat
 		if err != nil {
 			return err
 		}
-		return github.DeleteRepository(r.GitHubClient, context.Background(), r.GitHubOrg, repoName)
+		return github.DeleteRepository(client, context.Background(), r.GitHubOrg, repoName)
 	}
 	return nil
 }

--- a/controllers/application_controller_finalizer.go
+++ b/controllers/application_controller_finalizer.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 	"strings"
 
-	gh "github.com/google/go-github/v41/github"
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	devfile "github.com/redhat-appstudio/application-service/pkg/devfile"
 	github "github.com/redhat-appstudio/application-service/pkg/github"
@@ -47,7 +46,7 @@ func (r *ApplicationReconciler) AddFinalizer(ctx context.Context, application *a
 }
 
 // Finalize deletes the corresponding GitOps repo for the given Application CR.
-func (r *ApplicationReconciler) Finalize(application *appstudiov1alpha1.Application, client *gh.Client) error {
+func (r *ApplicationReconciler) Finalize(application *appstudiov1alpha1.Application, ghClient github.GitHubClient) error {
 	// Get the GitOps repository URL
 	devfileSrc := devfile.DevfileSrc{
 		Data: application.Status.Devfile,
@@ -68,7 +67,7 @@ func (r *ApplicationReconciler) Finalize(application *appstudiov1alpha1.Applicat
 		if err != nil {
 			return err
 		}
-		return github.DeleteRepository(client, context.Background(), r.GitHubOrg, repoName)
+		return ghClient.DeleteRepository(context.Background(), r.GitHubOrg, repoName)
 	}
 	return nil
 }

--- a/controllers/applicationsnapshotenvironmentbinding_controller.go
+++ b/controllers/applicationsnapshotenvironmentbinding_controller.go
@@ -197,7 +197,7 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 			return ctrl.Result{}, err
 		}
 
-		gitOpsRemoteURL, gitOpsBranch, gitOpsContext, err := util.ProcessGitOpsStatus(hasComponent.Status.GitOps, r.GitToken)
+		gitOpsRemoteURL, gitOpsBranch, gitOpsContext, err := util.ProcessGitOpsStatus(hasComponent.Status.GitOps, ghClient.Token)
 		if err != nil {
 			r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, err)
 			return ctrl.Result{}, err

--- a/controllers/applicationsnapshotenvironmentbinding_controller.go
+++ b/controllers/applicationsnapshotenvironmentbinding_controller.go
@@ -99,7 +99,7 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 
 	log.Info(fmt.Sprintf("Starting reconcile loop for %v %v", appSnapshotEnvBinding.Name, req.NamespacedName))
 
-	ghClient, _, err := r.GitHubTokenClient.GetNewGitHubClient()
+	ghClient, err := r.GitHubTokenClient.GetNewGitHubClient()
 	if err != nil {
 		log.Error(err, "Unable to create Go-GitHub client due to error")
 		return reconcile.Result{}, err
@@ -274,7 +274,7 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 			r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, gitOpsErr)
 			return ctrl.Result{}, gitOpsErr
 		}
-		commitID, err = github.GetLatestCommitSHAFromRepository(ghClient, ctx, repoName, orgName, gitOpsBranch)
+		commitID, err = ghClient.GetLatestCommitSHAFromRepository(ctx, repoName, orgName, gitOpsBranch)
 		if err != nil {
 			gitOpsErr := &GitOpsCommitIdError{err}
 			log.Error(gitOpsErr, "")

--- a/controllers/applicationsnapshotenvironmentbinding_controller.go
+++ b/controllers/applicationsnapshotenvironmentbinding_controller.go
@@ -45,6 +45,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
@@ -101,6 +102,7 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 	ghClient, err := r.GitHubTokenClient.GetNewGitHubClient()
 	if err != nil {
 		log.Error(err, "Unable to create Go-GitHub client due to error")
+		return reconcile.Result{}, err
 	}
 
 	applicationName := appSnapshotEnvBinding.Spec.Application

--- a/controllers/applicationsnapshotenvironmentbinding_controller.go
+++ b/controllers/applicationsnapshotenvironmentbinding_controller.go
@@ -99,7 +99,7 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 
 	log.Info(fmt.Sprintf("Starting reconcile loop for %v %v", appSnapshotEnvBinding.Name, req.NamespacedName))
 
-	ghClient, err := r.GitHubTokenClient.GetNewGitHubClient()
+	ghClient, _, err := r.GitHubTokenClient.GetNewGitHubClient()
 	if err != nil {
 		log.Error(err, "Unable to create Go-GitHub client due to error")
 		return reconcile.Result{}, err

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -161,7 +161,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if hasApplication.Status.Devfile != "" && len(component.Status.Conditions) > 0 && component.Status.Conditions[len(component.Status.Conditions)-1].Status == metav1.ConditionTrue && containsString(component.GetFinalizers(), compFinalizerName) {
 			// only attempt to finalize and update the gitops repo if an Application is present & the previous Component status is good
 			// A finalizer is present for the Component CR, so make sure we do the necessary cleanup steps
-			if err := r.Finalize(ctx, &component, &hasApplication); err != nil {
+			if err := r.Finalize(ctx, &component, &hasApplication, ghClient); err != nil {
 				// if fail to delete the external dependency here, log the error, but don't return error
 				// Don't want to get stuck in a cycle of repeatedly trying to update the repository and failing
 				log.Error(err, "Unable to update GitOps repository for component %v in namespace %v", component.GetName(), component.GetNamespace())
@@ -522,7 +522,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 func (r *ComponentReconciler) generateGitops(ctx context.Context, ghClient github.GitHubClient, req ctrl.Request, component *appstudiov1alpha1.Component, compDevfileData data.DevfileData) error {
 	log := r.Log.WithValues("Component", req.NamespacedName).WithValues("clusterName", req.ClusterName)
 
-	gitOpsURL, gitOpsBranch, gitOpsContext, err := util.ProcessGitOpsStatus(component.Status.GitOps, r.GitToken)
+	gitOpsURL, gitOpsBranch, gitOpsContext, err := util.ProcessGitOpsStatus(component.Status.GitOps, ghClient.Token)
 	if err != nil {
 		return err
 	}

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -133,7 +133,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	setCounterAnnotation(applicationFailCounterAnnotation, &component, 0)
 
-	ghClient, err := r.GitHubTokenClient.GetNewGitHubClient()
+	ghClient, _, err := r.GitHubTokenClient.GetNewGitHubClient()
 	if err != nil {
 		log.Error(err, "Unable to create Go-GitHub client due to error")
 		return reconcile.Result{}, err

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/yaml"
 
 	"github.com/devfile/api/v2/pkg/attributes"
@@ -135,6 +136,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	ghClient, err := r.GitHubTokenClient.GetNewGitHubClient()
 	if err != nil {
 		log.Error(err, "Unable to create Go-GitHub client due to error")
+		return reconcile.Result{}, err
 	}
 
 	// Check if the Component CR is under deletion

--- a/controllers/component_controller_finalizer.go
+++ b/controllers/component_controller_finalizer.go
@@ -22,6 +22,7 @@ import (
 
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	devfile "github.com/redhat-appstudio/application-service/pkg/devfile"
+	github "github.com/redhat-appstudio/application-service/pkg/github"
 	"github.com/redhat-appstudio/application-service/pkg/util"
 	"github.com/redhat-appstudio/application-service/pkg/util/ioutils"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -38,7 +39,7 @@ func (r *ComponentReconciler) AddFinalizer(ctx context.Context, component *appst
 
 // Finalize deletes the corresponding devfile project or the devfile attribute entry from the Application CR and also deletes the corresponding GitOps repo's Component dir
 // & updates the parent kustomize for the given Component CR.
-func (r *ComponentReconciler) Finalize(ctx context.Context, component *appstudiov1alpha1.Component, application *appstudiov1alpha1.Application) error {
+func (r *ComponentReconciler) Finalize(ctx context.Context, component *appstudiov1alpha1.Component, application *appstudiov1alpha1.Application, ghClient github.GitHubClient) error {
 	// Get the Application CR devfile
 	devfileSrc := devfile.DevfileSrc{
 		Data: application.Status.Devfile,
@@ -71,7 +72,7 @@ func (r *ComponentReconciler) Finalize(ctx context.Context, component *appstudio
 
 	application.Status.Devfile = string(yamldevfileObj)
 
-	gitOpsURL, gitOpsBranch, gitOpsContext, err := util.ProcessGitOpsStatus(component.Status.GitOps, r.GitToken)
+	gitOpsURL, gitOpsBranch, gitOpsContext, err := util.ProcessGitOpsStatus(component.Status.GitOps, ghClient.Token)
 	if err != nil {
 		return err
 	}

--- a/controllers/component_controller_unit_test.go
+++ b/controllers/component_controller_unit_test.go
@@ -161,24 +161,24 @@ func TestGenerateGitops(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().Build()
 
 	r := &ComponentReconciler{
-		Log:          ctrl.Log.WithName("controllers").WithName("Component"),
-		GitHubOrg:    github.AppStudioAppDataOrg,
-		GitToken:     "fake-token",
-		Generator:    gitops.NewMockGenerator(),
-		Client:       fakeClient,
-		GitHubClient: github.GetMockedClient(),
+		Log:               ctrl.Log.WithName("controllers").WithName("Component"),
+		GitHubOrg:         github.AppStudioAppDataOrg,
+		GitToken:          "fake-token",
+		Generator:         gitops.NewMockGenerator(),
+		Client:            fakeClient,
+		GitHubTokenClient: github.MockGitHubTokenClient{},
 	}
 
 	// Create a second reconciler for testing error scenarios
 	errGen := gitops.NewMockGenerator()
 	errGen.Errors.Push(errors.New("Fatal error"))
 	errReconciler := &ComponentReconciler{
-		Log:          ctrl.Log.WithName("controllers").WithName("Component"),
-		GitHubOrg:    github.AppStudioAppDataOrg,
-		GitToken:     "fake-token",
-		Generator:    errGen,
-		Client:       fakeClient,
-		GitHubClient: github.GetMockedClient(),
+		Log:               ctrl.Log.WithName("controllers").WithName("Component"),
+		GitHubOrg:         github.AppStudioAppDataOrg,
+		GitToken:          "fake-token",
+		Generator:         errGen,
+		Client:            fakeClient,
+		GitHubTokenClient: github.MockGitHubTokenClient{},
 	}
 
 	componentSpec := appstudiov1alpha1.ComponentSpec{
@@ -557,7 +557,7 @@ func TestGenerateGitops(t *testing.T) {
 			mockKubernetesComponents := mockDevfileData.EXPECT().GetComponents(kubernetesComponentFilter)
 			mockKubernetesComponents.Return(kubernetesComponents, nil).AnyTimes()
 
-			err := tt.reconciler.generateGitops(ctx, ctrl.Request{}, tt.component, mockDevfileData)
+			err := tt.reconciler.generateGitops(ctx, github.GetMockedClient(), ctrl.Request{}, tt.component, mockDevfileData)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("TestGenerateGitops() unexpected error: %v", err)
 			}

--- a/controllers/component_controller_unit_test.go
+++ b/controllers/component_controller_unit_test.go
@@ -556,8 +556,10 @@ func TestGenerateGitops(t *testing.T) {
 			}
 			mockKubernetesComponents := mockDevfileData.EXPECT().GetComponents(kubernetesComponentFilter)
 			mockKubernetesComponents.Return(kubernetesComponents, nil).AnyTimes()
-
-			err := tt.reconciler.generateGitops(ctx, github.GetMockedClient(), ctrl.Request{}, tt.component, mockDevfileData)
+			mockedClient := github.GitHubClient{
+				Client: github.GetMockedClient(),
+			}
+			err := tt.reconciler.generateGitops(ctx, mockedClient, ctrl.Request{}, tt.component, mockDevfileData)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("TestGenerateGitops() unexpected error: %v", err)
 			}

--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -135,17 +135,17 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 		}
 		if source.Revision == "" {
 			// Create a Go-GitHub client for checking the default branch
-			ghClient, _, err := r.GitHubTokenClient.GetNewGitHubClient()
+			ghClient, err := r.GitHubTokenClient.GetNewGitHubClient()
 			if err != nil {
 				log.Error(err, "Unable to create Go-GitHub client due to error")
 				return reconcile.Result{}, err
 			}
 
 			log.Info(fmt.Sprintf("Look for default branch of repo %s... %v", source.URL, req.NamespacedName))
-			source.Revision, err = github.GetDefaultBranchFromURL(sourceURL, ghClient, ctx)
+			source.Revision, err = ghClient.GetDefaultBranchFromURL(sourceURL, ctx)
 			if err != nil {
 				log.Error(err, fmt.Sprintf("Unable to get default branch of Github Repo %v, try to fall back to main branch... %v", source.URL, req.NamespacedName))
-				_, err := github.GetBranchFromURL(sourceURL, ghClient, ctx, "main")
+				_, err := ghClient.GetBranchFromURL(sourceURL, ctx, "main")
 				if err != nil {
 					log.Error(err, fmt.Sprintf("Unable to get main branch of Github Repo %v ... %v", source.URL, req.NamespacedName))
 					retErr := fmt.Errorf("unable to get default branch of Github Repo %v, try to fall back to main branch, failed to get main branch... %v", source.URL, req.NamespacedName)

--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -135,7 +135,7 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 		}
 		if source.Revision == "" {
 			// Create a Go-GitHub client for checking the default branch
-			ghClient, err := r.GitHubTokenClient.GetNewGitHubClient()
+			ghClient, _, err := r.GitHubTokenClient.GetNewGitHubClient()
 			if err != nil {
 				log.Error(err, "Unable to create Go-GitHub client due to error")
 				return reconcile.Result{}, err

--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/go-logr/logr"
 	logicalcluster "github.com/kcp-dev/logicalcluster/v2"
@@ -132,6 +133,7 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 			ghClient, err := r.GitHubTokenClient.GetNewGitHubClient()
 			if err != nil {
 				log.Error(err, "Unable to create Go-GitHub client due to error")
+				return reconcile.Result{}, err
 			}
 
 			log.Info(fmt.Sprintf("Look for default branch of repo %s... %v", source.URL, req.NamespacedName))

--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -34,7 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/go-logr/logr"
-	gh "github.com/google/go-github/v41/github"
 	logicalcluster "github.com/kcp-dev/logicalcluster/v2"
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	devfile "github.com/redhat-appstudio/application-service/pkg/devfile"
@@ -53,7 +52,7 @@ type ComponentDetectionQueryReconciler struct {
 	SPIClient          spi.SPI
 	AlizerClient       devfile.Alizer
 	Log                logr.Logger
-	GitHubClient       *gh.Client
+	GitHubTokenClient  github.GitHubToken
 	DevfileRegistryURL string
 	AppFS              afero.Afero
 }
@@ -129,11 +128,17 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 			context = "./"
 		}
 		if source.Revision == "" {
+			// Create a Go-GitHub client for checking the default branch
+			ghClient, err := r.GitHubTokenClient.GetNewGitHubClient()
+			if err != nil {
+				log.Error(err, "Unable to create Go-GitHub client due to error")
+			}
+
 			log.Info(fmt.Sprintf("Look for default branch of repo %s... %v", source.URL, req.NamespacedName))
-			source.Revision, err = github.GetDefaultBranchFromURL(source.URL, r.GitHubClient, ctx)
+			source.Revision, err = github.GetDefaultBranchFromURL(source.URL, ghClient, ctx)
 			if err != nil {
 				log.Error(err, fmt.Sprintf("Unable to get default branch of Github Repo %v, try to fall back to main branch... %v", source.URL, req.NamespacedName))
-				_, err := github.GetBranchFromURL(source.URL, r.GitHubClient, ctx, "main")
+				_, err := github.GetBranchFromURL(source.URL, ghClient, ctx, "main")
 				if err != nil {
 					log.Error(err, fmt.Sprintf("Unable to get main branch of Github Repo %v ... %v", source.URL, req.NamespacedName))
 					retErr := fmt.Errorf("unable to get default branch of Github Repo %v, try to fall back to main branch, failed to get main branch... %v", source.URL, req.NamespacedName)

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -100,25 +100,26 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
+	mockGhTokenClient := github.MockGitHubTokenClient{}
 	// To Do: Set up reconcilers for the other controllers
 	err = (&ApplicationReconciler{
-		Client:       k8sManager.GetClient(),
-		Scheme:       k8sManager.GetScheme(),
-		Log:          ctrl.Log.WithName("controllers").WithName("Application"),
-		GitHubClient: github.GetMockedClient(),
-		GitHubOrg:    github.AppStudioAppDataOrg,
+		Client:            k8sManager.GetClient(),
+		Scheme:            k8sManager.GetScheme(),
+		Log:               ctrl.Log.WithName("controllers").WithName("Application"),
+		GitHubTokenClient: mockGhTokenClient,
+		GitHubOrg:         github.AppStudioAppDataOrg,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&ComponentReconciler{
-		Client:          k8sManager.GetClient(),
-		Scheme:          k8sManager.GetScheme(),
-		Log:             ctrl.Log.WithName("controllers").WithName("Component"),
-		Generator:       gitops.NewMockGenerator(),
-		AppFS:           ioutils.NewMemoryFilesystem(),
-		ImageRepository: "docker.io/foo/customized",
-		SPIClient:       spi.MockSPIClient{},
-		GitHubClient:    github.GetMockedClient(),
+		Client:            k8sManager.GetClient(),
+		Scheme:            k8sManager.GetScheme(),
+		Log:               ctrl.Log.WithName("controllers").WithName("Component"),
+		Generator:         gitops.NewMockGenerator(),
+		AppFS:             ioutils.NewMemoryFilesystem(),
+		ImageRepository:   "docker.io/foo/customized",
+		SPIClient:         spi.MockSPIClient{},
+		GitHubTokenClient: mockGhTokenClient,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -128,19 +129,19 @@ var _ = BeforeSuite(func() {
 		Log:                ctrl.Log.WithName("controllers").WithName("ComponentDetectionQuery"),
 		SPIClient:          spi.MockSPIClient{},
 		AlizerClient:       devfile.MockAlizerClient{},
-		GitHubClient:       github.GetMockedClient(),
+		GitHubTokenClient:  mockGhTokenClient,
 		DevfileRegistryURL: devfile.DevfileStageRegistryEndpoint, // Use the staging devfile registry for tests
 		AppFS:              ioutils.NewMemoryFilesystem(),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&SnapshotEnvironmentBindingReconciler{
-		Client:       k8sManager.GetClient(),
-		Scheme:       k8sManager.GetScheme(),
-		Log:          ctrl.Log.WithName("controllers").WithName("SnapshotEnvironmentBinding"),
-		Generator:    gitops.NewMockGenerator(),
-		AppFS:        ioutils.NewMemoryFilesystem(),
-		GitHubClient: github.GetMockedClient(),
+		Client:            k8sManager.GetClient(),
+		Scheme:            k8sManager.GetScheme(),
+		Log:               ctrl.Log.WithName("controllers").WithName("SnapshotEnvironmentBinding"),
+		Generator:         gitops.NewMockGenerator(),
+		AppFS:             ioutils.NewMemoryFilesystem(),
+		GitHubTokenClient: mockGhTokenClient,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/main.go
+++ b/main.go
@@ -23,14 +23,12 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"time"
 
 	gitopsgen "github.com/redhat-developer/gitops-generator/pkg"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	"go.uber.org/zap/zapcore"
-	"golang.org/x/oauth2"
 	"k8s.io/client-go/discovery"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
@@ -47,13 +45,11 @@ import (
 
 	routev1 "github.com/openshift/api/route/v1"
 
-	"github.com/gofri/go-github-ratelimit/github_ratelimit"
-	"github.com/google/go-github/v41/github"
-
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/application-service/controllers"
 	appservicegitops "github.com/redhat-appstudio/application-service/gitops"
 	"github.com/redhat-appstudio/application-service/pkg/devfile"
+	"github.com/redhat-appstudio/application-service/pkg/github"
 	"github.com/redhat-appstudio/application-service/pkg/spi"
 	"github.com/redhat-appstudio/application-service/pkg/util/ioutils"
 
@@ -151,16 +147,6 @@ func main() {
 		setupLog.Error(err, "unable to add triggers api to the scheme")
 		os.Exit(1)
 	}
-	// Retrieve the GitHub Auth Token to use, error out if not found
-	ghToken := os.Getenv("GITHUB_AUTH_TOKEN")
-	if ghToken == "" {
-		log.Fatal("Unauthorized: No GitHub token present")
-	}
-
-	cdqToken := os.Getenv("CDQ_GITHUB_TOKEN")
-	if cdqToken == "" {
-		cdqToken = ghToken
-	}
 
 	// Retrieve the name of the GitHub org to use
 	ghOrg := os.Getenv("GITHUB_ORG")
@@ -181,44 +167,33 @@ func main() {
 		devfileRegistryURL = devfile.DevfileRegistryEndpoint
 	}
 
-	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: ghToken})
-	tc := oauth2.NewClient(ctx, ts)
-	rateLimiter, err := github_ratelimit.NewRateLimitWaiterClient(tc.Transport, github_ratelimit.WithSingleSleepLimit(time.Minute, nil))
+	// Parse any passed in tokens and set up a client for handling the github tokens
+	err = github.ParseGitHubTokens()
 	if err != nil {
-		setupLog.Error(err, "unable to add triggers api to the scheme")
+		setupLog.Error(err, "unable to set up github tokens")
 		os.Exit(1)
 	}
-	client := github.NewClient(rateLimiter)
-
-	cdqts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: cdqToken})
-	cdqtc := oauth2.NewClient(ctx, cdqts)
-	cdqRateLimiter, err := github_ratelimit.NewRateLimitWaiterClient(cdqtc.Transport, github_ratelimit.WithSingleSleepLimit(time.Minute, nil))
-	if err != nil {
-		setupLog.Error(err, "unable to add triggers api to the scheme")
-		os.Exit(1)
-	}
-	cdqClient := github.NewClient(cdqRateLimiter)
+	ghTokenClient := github.GitHubTokenClient{}
 
 	if err = (&controllers.ApplicationReconciler{
-		Client:       mgr.GetClient(),
-		Scheme:       mgr.GetScheme(),
-		Log:          ctrl.Log.WithName("controllers").WithName("Application").WithValues("appstudio-component", "HAS"),
-		GitHubClient: client,
-		GitHubOrg:    ghOrg,
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		Log:               ctrl.Log.WithName("controllers").WithName("Application").WithValues("appstudio-component", "HAS"),
+		GitHubTokenClient: ghTokenClient,
+		GitHubOrg:         ghOrg,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Application")
 		os.Exit(1)
 	}
 	if err = (&controllers.ComponentReconciler{
-		Client:          mgr.GetClient(),
-		Scheme:          mgr.GetScheme(),
-		Log:             ctrl.Log.WithName("controllers").WithName("Component").WithValues("appstudio-component", "HAS"),
-		Generator:       gitopsgen.NewGitopsGen(),
-		AppFS:           ioutils.NewFilesystem(),
-		GitToken:        ghToken,
-		ImageRepository: imageRepository,
-		SPIClient:       spi.SPIClient{},
-		GitHubClient:    client,
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		Log:               ctrl.Log.WithName("controllers").WithName("Component").WithValues("appstudio-component", "HAS"),
+		Generator:         gitopsgen.NewGitopsGen(),
+		AppFS:             ioutils.NewFilesystem(),
+		GitHubTokenClient: ghTokenClient,
+		ImageRepository:   imageRepository,
+		SPIClient:         spi.SPIClient{},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Component")
 		os.Exit(1)
@@ -229,7 +204,7 @@ func main() {
 		Log:                ctrl.Log.WithName("controllers").WithName("ComponentDetectionQuery").WithValues("appstudio-component", "HAS"),
 		SPIClient:          spi.SPIClient{},
 		AlizerClient:       devfile.AlizerClient{},
-		GitHubClient:       cdqClient,
+		GitHubTokenClient:  ghTokenClient,
 		DevfileRegistryURL: devfileRegistryURL,
 		AppFS:              ioutils.NewFilesystem(),
 	}).SetupWithManager(mgr); err != nil {
@@ -250,13 +225,12 @@ func main() {
 	}
 
 	if err = (&controllers.SnapshotEnvironmentBindingReconciler{
-		Client:       mgr.GetClient(),
-		Scheme:       mgr.GetScheme(),
-		Log:          ctrl.Log.WithName("controllers").WithName("SnapshotEnvironmentBinding").WithValues("appstudio-component", "HAS"),
-		Generator:    gitopsgen.NewGitopsGen(),
-		AppFS:        ioutils.NewFilesystem(),
-		GitToken:     ghToken,
-		GitHubClient: client,
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		Log:               ctrl.Log.WithName("controllers").WithName("SnapshotEnvironmentBinding").WithValues("appstudio-component", "HAS"),
+		Generator:         gitopsgen.NewGitopsGen(),
+		AppFS:             ioutils.NewFilesystem(),
+		GitHubTokenClient: ghTokenClient,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SnapshotEnvironmentBinding")
 		os.Exit(1)

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -32,6 +32,7 @@ const AppStudioAppDataOrg = "redhat-appstudio-appdata"
 // GitHubClient represents a Go-GitHub client, along with the name of the GitHub token that was used to initialize it
 type GitHubClient struct {
 	TokenName string
+	Token     string
 	Client    *github.Client
 }
 

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -29,6 +29,11 @@ import (
 
 const AppStudioAppDataOrg = "redhat-appstudio-appdata"
 
+type GitHubClient struct {
+	TokenName string
+	Client    *github.Client
+}
+
 // ServerError is used to identify gitops repo creation failures caused by server errors
 type ServerError struct {
 	err error
@@ -46,12 +51,12 @@ func GenerateNewRepositoryName(displayName, uniqueHash string) string {
 	return repoName
 }
 
-func GenerateNewRepository(client *github.Client, ctx context.Context, orgName string, repoName string, description string) (string, error) {
+func (g GitHubClient) GenerateNewRepository(ctx context.Context, orgName string, repoName string, description string) (string, error) {
 	isPrivate := false
 	appStudioAppDataURL := "https://github.com/" + orgName + "/"
 	metrics.GitOpsRepoCreationTotalReqs.Inc()
 	r := &github.Repository{Name: &repoName, Private: &isPrivate, Description: &description}
-	_, resp, err := client.Repositories.Create(ctx, orgName, r)
+	_, resp, err := g.Client.Repositories.Create(ctx, orgName, r)
 
 	if 500 <= resp.StatusCode && resp.StatusCode <= 599 {
 		// return custom error
@@ -104,13 +109,13 @@ func GetRepoAndOrgFromURL(repoURL string) (string, string, error) {
 }
 
 // GetDefaultBranchFromURL returns the default branch of a given repoURL
-func GetDefaultBranchFromURL(repoURL string, client *github.Client, ctx context.Context) (string, error) {
+func (g GitHubClient) GetDefaultBranchFromURL(repoURL string, ctx context.Context) (string, error) {
 	repoName, orgName, err := GetRepoAndOrgFromURL(repoURL)
 	if err != nil {
 		return "", err
 	}
 
-	repo, _, err := client.Repositories.Get(ctx, orgName, repoName)
+	repo, _, err := g.Client.Repositories.Get(ctx, orgName, repoName)
 	if err != nil || repo == nil {
 		return "", fmt.Errorf("failed to get repo %s under %s, error: %v", repoName, orgName, err)
 	}
@@ -119,13 +124,13 @@ func GetDefaultBranchFromURL(repoURL string, client *github.Client, ctx context.
 }
 
 // GetBranchFromURL returns the requested branch of a given repoURL
-func GetBranchFromURL(repoURL string, client *github.Client, ctx context.Context, branchName string) (*github.Branch, error) {
+func (g GitHubClient) GetBranchFromURL(repoURL string, ctx context.Context, branchName string) (*github.Branch, error) {
 	repoName, orgName, err := GetRepoAndOrgFromURL(repoURL)
 	if err != nil {
 		return nil, err
 	}
 
-	branch, _, err := client.Repositories.GetBranch(ctx, orgName, repoName, branchName, false)
+	branch, _, err := g.Client.Repositories.GetBranch(ctx, orgName, repoName, branchName, false)
 	if err != nil || branch == nil {
 		return nil, fmt.Errorf("failed to get branch %s from repo %s under %s, error: %v", branchName, repoName, orgName, err)
 	}
@@ -134,8 +139,8 @@ func GetBranchFromURL(repoURL string, client *github.Client, ctx context.Context
 }
 
 // GetLatestCommitSHAFromRepository gets the latest Commit SHA from the repository
-func GetLatestCommitSHAFromRepository(client *github.Client, ctx context.Context, repoName string, orgName string, branch string) (string, error) {
-	commitSHA, _, err := client.Repositories.GetCommitSHA1(ctx, orgName, repoName, branch, "")
+func (g GitHubClient) GetLatestCommitSHAFromRepository(ctx context.Context, repoName string, orgName string, branch string) (string, error) {
+	commitSHA, _, err := g.Client.Repositories.GetCommitSHA1(ctx, orgName, repoName, branch, "")
 	if err != nil {
 		return "", err
 	}
@@ -143,9 +148,9 @@ func GetLatestCommitSHAFromRepository(client *github.Client, ctx context.Context
 }
 
 // Delete Repository takes in the given repository URL and attempts to delete it
-func DeleteRepository(client *github.Client, ctx context.Context, orgName string, repoName string) error {
+func (g GitHubClient) DeleteRepository(ctx context.Context, orgName string, repoName string) error {
 	// Retrieve just the repository name from the URL
-	_, err := client.Repositories.Delete(ctx, orgName, repoName)
+	_, err := g.Client.Repositories.Delete(ctx, orgName, repoName)
 	if err != nil {
 		return err
 	}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -29,6 +29,7 @@ import (
 
 const AppStudioAppDataOrg = "redhat-appstudio-appdata"
 
+// GitHubClient represents a Go-GitHub client, along with the name of the GitHub token that was used to initialize it
 type GitHubClient struct {
 	TokenName string
 	Client    *github.Client

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -109,10 +109,12 @@ func TestGenerateNewRepository(t *testing.T) {
 
 	numTests := len(tests)
 	for _, tt := range tests {
-		mockedClient := GetMockedClient()
+		mockedClient := GitHubClient{
+			Client: GetMockedClient(),
+		}
 
 		t.Run(tt.name, func(t *testing.T) {
-			repoURL, err := GenerateNewRepository(mockedClient, context.Background(), tt.orgName, tt.repoName, "")
+			repoURL, err := mockedClient.GenerateNewRepository(context.Background(), tt.orgName, tt.repoName, "")
 
 			if err != nil && tt.wantErr {
 				if _, ok := err.(*ServerError); ok {
@@ -169,10 +171,12 @@ func TestDeleteRepository(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		mockedClient := GetMockedClient()
+		mockedClient := GitHubClient{
+			Client: GetMockedClient(),
+		}
 
 		t.Run(tt.name, func(t *testing.T) {
-			err := DeleteRepository(mockedClient, context.Background(), tt.orgName, tt.repoName)
+			err := mockedClient.DeleteRepository(context.Background(), tt.orgName, tt.repoName)
 
 			if tt.wantErr != (err != nil) {
 				t.Errorf("TestDeleteRepository() error: expected %v, got %v", err, tt.wantErr)
@@ -338,10 +342,12 @@ func TestGetLatestCommitSHAFromRepository(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		mockedClient := GetMockedClient()
+		mockedClient := GitHubClient{
+			Client: GetMockedClient(),
+		}
 
 		t.Run(tt.name, func(t *testing.T) {
-			commitSHA, err := GetLatestCommitSHAFromRepository(mockedClient, context.Background(), tt.orgName, tt.repoName, "main")
+			commitSHA, err := mockedClient.GetLatestCommitSHAFromRepository(context.Background(), tt.orgName, tt.repoName, "main")
 
 			if tt.wantErr != (err != nil) {
 				t.Errorf("TestGetLatestCommitSHAFromRepository() unexpected error value: %v", err)
@@ -377,13 +383,20 @@ func TestGetDefaultBranchFromURL(t *testing.T) {
 			repoURL: "https://github.com/some-org/test-error-response",
 			wantErr: true,
 		},
+		{
+			name:    "Unparseable URL",
+			repoURL: "http://github.com/?org\nrepo",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
-		mockedClient := GetMockedClient()
+		mockedClient := GitHubClient{
+			Client: GetMockedClient(),
+		}
 
 		t.Run(tt.name, func(t *testing.T) {
-			defaultBranch, err := GetDefaultBranchFromURL(tt.repoURL, mockedClient, context.Background())
+			defaultBranch, err := mockedClient.GetDefaultBranchFromURL(tt.repoURL, context.Background())
 
 			if tt.wantErr != (err != nil) {
 				t.Errorf("TestGetDefaultBranchFromURL() unexpected error value: %v", err)
@@ -420,13 +433,20 @@ func TestGetBranchFromURL(t *testing.T) {
 			branchName: "main",
 			wantErr:    true,
 		},
+		{
+			name:    "Unparseable URL",
+			repoURL: "http://github.com/?org\nrepo",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
-		mockedClient := GetMockedClient()
+		mockedClient := GitHubClient{
+			Client: GetMockedClient(),
+		}
 
 		t.Run(tt.name, func(t *testing.T) {
-			branch, err := GetBranchFromURL(tt.repoURL, mockedClient, context.Background(), tt.branchName)
+			branch, err := mockedClient.GetBranchFromURL(tt.repoURL, context.Background(), tt.branchName)
 
 			if tt.wantErr != (err != nil) {
 				t.Errorf("TestGetBranchFromURL() unexpected error value: %v, branch %v", err, branch)

--- a/pkg/github/token.go
+++ b/pkg/github/token.go
@@ -1,0 +1,91 @@
+//
+// Copyright 2023 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gofri/go-github-ratelimit/github_ratelimit"
+	"github.com/google/go-github/v41/github"
+	"golang.org/x/oauth2"
+)
+
+type GitHubToken interface {
+	GetNewGitHubClient() (*github.Client, error)
+}
+
+type GitHubTokenClient struct {
+}
+
+var Tokens []string
+
+// ParseGitHubTokens parses all of the possible GitHub tokens available to HAS and makes them available within the "github" package
+// This function should *only* be called once: at operator startup.
+func ParseGitHubTokens() error {
+	githubToken := os.Getenv("GITHUB_AUTH_TOKEN")
+	githubTokenList := os.Getenv("GITHUB_TOKEN_LIST")
+	if githubToken == "" && githubTokenList == "" {
+		return fmt.Errorf("no GitHub tokens were provided. Either GITHUB_TOKENS or GITHUB_AUTH_TOKEN (legacy) must be set")
+	}
+
+	var tokenList []string
+	if githubToken != "" {
+		tokenList = append(tokenList, githubToken)
+	}
+	if githubTokenList != "" {
+		splitTokenList := strings.Split(githubTokenList, ",")
+		tokenList = append(tokenList, splitTokenList...)
+	}
+
+	Tokens = tokenList
+
+	return nil
+}
+
+// getRandomToken randomly retrieves
+func getRandomToken() (string, error) {
+	if len(Tokens) == 0 {
+		return "", fmt.Errorf("no GitHub tokens initialized")
+	}
+	if len(Tokens) == 1 {
+		return Tokens[0], nil
+	}
+	return Tokens[rand.Intn(len(Tokens)-1)], nil
+}
+
+// GetNewGitHubClient intializes a new Go-GitHub client from a randomly selecte GitHub token available to HAS
+// If an error is encountered retrieveing the token, or initializing the client, an error is returned
+func (g GitHubTokenClient) GetNewGitHubClient() (*github.Client, error) {
+	ghToken, err := getRandomToken()
+	if err != nil {
+		return nil, err
+	}
+
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: ghToken})
+	tc := oauth2.NewClient(context.Background(), ts)
+	rateLimiter, err := github_ratelimit.NewRateLimitWaiterClient(tc.Transport, github_ratelimit.WithSingleSleepLimit(time.Minute, nil))
+	if err != nil {
+		return nil, err
+	}
+	client := github.NewClient(rateLimiter)
+
+	return client, nil
+}

--- a/pkg/github/token.go
+++ b/pkg/github/token.go
@@ -119,6 +119,7 @@ func (g GitHubTokenClient) GetNewGitHubClient() (GitHubClient, error) {
 	client := github.NewClient(rateLimiter)
 	githubClient := GitHubClient{
 		TokenName: ghTokenName,
+		Token:     ghToken,
 		Client:    client,
 	}
 

--- a/pkg/github/token_mock.go
+++ b/pkg/github/token_mock.go
@@ -1,0 +1,29 @@
+//
+// Copyright 2023 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"github.com/google/go-github/v41/github"
+)
+
+type MockGitHubTokenClient struct {
+}
+
+// GetNewGitHubClient intializes a new Go-GitHub client from a randomly selecte GitHub token available to HAS
+// If an error is encountered retrieveing the token, or initializing the client, an error is returned
+func (g MockGitHubTokenClient) GetNewGitHubClient() (*github.Client, error) {
+	return GetMockedClient(), nil
+}

--- a/pkg/github/token_mock.go
+++ b/pkg/github/token_mock.go
@@ -23,6 +23,6 @@ type MockGitHubTokenClient struct {
 }
 
 // GetNewGitHubClient returns a mocked Go-GitHub client. No actual tokens are passed in or used when this function is called
-func (g MockGitHubTokenClient) GetNewGitHubClient() (*github.Client, error) {
-	return GetMockedClient(), nil
+func (g MockGitHubTokenClient) GetNewGitHubClient() (*github.Client, string, error) {
+	return GetMockedClient(), "", nil
 }

--- a/pkg/github/token_mock.go
+++ b/pkg/github/token_mock.go
@@ -15,14 +15,12 @@
 
 package github
 
-import (
-	"github.com/google/go-github/v41/github"
-)
-
 type MockGitHubTokenClient struct {
 }
 
 // GetNewGitHubClient returns a mocked Go-GitHub client. No actual tokens are passed in or used when this function is called
-func (g MockGitHubTokenClient) GetNewGitHubClient() (*github.Client, string, error) {
-	return GetMockedClient(), "", nil
+func (g MockGitHubTokenClient) GetNewGitHubClient() (GitHubClient, error) {
+	return GitHubClient{
+		Client: GetMockedClient(),
+	}, nil
 }

--- a/pkg/github/token_mock.go
+++ b/pkg/github/token_mock.go
@@ -22,8 +22,7 @@ import (
 type MockGitHubTokenClient struct {
 }
 
-// GetNewGitHubClient intializes a new Go-GitHub client from a randomly selecte GitHub token available to HAS
-// If an error is encountered retrieveing the token, or initializing the client, an error is returned
+// GetNewGitHubClient returns a mocked Go-GitHub client. No actual tokens are passed in or used when this function is called
 func (g MockGitHubTokenClient) GetNewGitHubClient() (*github.Client, error) {
 	return GetMockedClient(), nil
 }

--- a/pkg/github/token_test.go
+++ b/pkg/github/token_test.go
@@ -172,7 +172,12 @@ func TestGetNewGitHubClient(t *testing.T) {
 			}
 
 			_ = ParseGitHubTokens()
-			_, err := tt.client.GetNewGitHubClient()
+			_, tokenName, err := tt.client.GetNewGitHubClient()
+			if tt.name != "Mock client" && !tt.wantErr {
+				if Tokens[tokenName] == "" {
+					t.Errorf("TestGetNewGitHubClient() error: expected token value %v with key %v", Tokens[tokenName], tokenName)
+				}
+			}
 			if tt.wantErr != (err != nil) {
 				t.Errorf("TestGetNewGitHubClient() error: unexpected error value %v", err)
 			}

--- a/pkg/github/token_test.go
+++ b/pkg/github/token_test.go
@@ -1,0 +1,148 @@
+//
+// Copyright 2021-2023 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestParseGitHubTokens(t *testing.T) {
+	tests := []struct {
+		name               string
+		githubTokenEnv     string
+		githubTokenListEnv string
+		want               []string
+		wantErr            bool
+	}{
+		{
+			name:    "No tokens set",
+			wantErr: true,
+		},
+		{
+			name:           "Only one token, stored in GITHUB_AUTH_TOKEN",
+			githubTokenEnv: "some_token",
+			want:           []string{"some_token"},
+		},
+		{
+			name:               "Only one token, stored in GITHUB_TOKEN_LIST",
+			githubTokenListEnv: "list_token",
+			want:               []string{"list_token"},
+		},
+		{
+			name:               "Two tokens, one each stored in GITHUB_AUTH_TOKEN and GITHUB_TOKEN_LIST",
+			githubTokenEnv:     "some_token",
+			githubTokenListEnv: "list_token",
+			want:               []string{"some_token", "list_token"},
+		},
+		{
+			name:               "Multiple tokens",
+			githubTokenEnv:     "some_token",
+			githubTokenListEnv: "list_token,another_token,third_token",
+			want:               []string{"some_token", "list_token", "another_token", "third_token"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Unsetenv("GITHUB_AUTH_TOKEN")
+			os.Unsetenv("GITHUB_TOKEN_LIST")
+			if tt.githubTokenEnv != "" {
+				os.Setenv("GITHUB_AUTH_TOKEN", tt.githubTokenEnv)
+			}
+			if tt.githubTokenListEnv != "" {
+				os.Setenv("GITHUB_TOKEN_LIST", tt.githubTokenListEnv)
+			}
+
+			err := ParseGitHubTokens()
+			if tt.wantErr != (err != nil) {
+				t.Errorf("TestParseGitHubTokens() error: unexpected error value %v", err)
+			}
+			if !tt.wantErr {
+				if !reflect.DeepEqual(Tokens, tt.want) {
+					t.Errorf("TestParseGitHubTokens() error: expected %v got %v", tt.want, Tokens)
+				}
+			}
+
+		})
+	}
+}
+
+func TestGetNewGitHubClient(t *testing.T) {
+	ghTokenClient := GitHubTokenClient{}
+	tests := []struct {
+		name               string
+		client             GitHubToken
+		githubTokenEnv     string
+		githubTokenListEnv string
+		wantErr            bool
+	}{
+		{
+			name:    "No tokens initialized, error should be returned",
+			client:  ghTokenClient,
+			wantErr: true,
+		},
+		{
+			name:           "One token set, should return client",
+			client:         ghTokenClient,
+			githubTokenEnv: "some_token",
+			wantErr:        false,
+		},
+		{
+			name:               "Multiple tokens, should return client",
+			client:             ghTokenClient,
+			githubTokenEnv:     "some_token",
+			githubTokenListEnv: "another_token,third_token",
+			wantErr:            false,
+		},
+		{
+			name:               "Multiple tokens, should return client",
+			client:             ghTokenClient,
+			githubTokenEnv:     "some_token",
+			githubTokenListEnv: "another_token,third_token",
+			wantErr:            false,
+		},
+		{
+			name:    "Mock client",
+			client:  MockGitHubTokenClient{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Tokens = nil
+			os.Unsetenv("GITHUB_AUTH_TOKEN")
+			os.Unsetenv("GITHUB_TOKEN_LIST")
+			if tt.githubTokenEnv != "" {
+				os.Setenv("GITHUB_AUTH_TOKEN", tt.githubTokenEnv)
+			}
+			if tt.githubTokenListEnv != "" {
+				os.Setenv("GITHUB_TOKEN_LIST", tt.githubTokenListEnv)
+			}
+
+			if !tt.wantErr {
+				_ = ParseGitHubTokens()
+			}
+			_, err := tt.client.GetNewGitHubClient()
+			if tt.wantErr != (err != nil) {
+				t.Errorf("TestGetNewGitHubClient() error: unexpected error value %v", err)
+			}
+
+		})
+	}
+}

--- a/pkg/github/token_test.go
+++ b/pkg/github/token_test.go
@@ -172,10 +172,10 @@ func TestGetNewGitHubClient(t *testing.T) {
 			}
 
 			_ = ParseGitHubTokens()
-			_, tokenName, err := tt.client.GetNewGitHubClient()
+			ghClient, err := tt.client.GetNewGitHubClient()
 			if tt.name != "Mock client" && !tt.wantErr {
-				if Tokens[tokenName] == "" {
-					t.Errorf("TestGetNewGitHubClient() error: expected token value %v with key %v", Tokens[tokenName], tokenName)
+				if Tokens[ghClient.TokenName] == "" {
+					t.Errorf("TestGetNewGitHubClient() error: expected token value %v with key %v", Tokens[ghClient.TokenName], ghClient.TokenName)
 				}
 			}
 			if tt.wantErr != (err != nil) {


### PR DESCRIPTION
### What does this PR do?:
- Allow HAS to support using an arbitrary number of GitHub tokens for its Git operations.
    - A new environment variable, `GITHUB_TOKEN_LIST`, has been created for this. It can be set to a comma separated list of GitHub tokens. E.g. `GITHUB_TOKEN_LIST=some_token1,some_token2,some_token3`
    - `GITHUB_AUTH_TOKEN` remains in place in HAS, but I've removed its mention from the readme
- Moves Go-GitHub client initialization from `main.go` to each controller's `Reconcile()` function. When a client is initialized, a GitHub token will be randomly chosen, from the ones available to HAS.
    - the `GitHubToken` interface (which both `GitHubTokenClient` and `MockGitHubTokenClient` implement) provides a function for handling this.
    - Each controller's reconciler struct will have access to this



### Which issue(s)/story(ies) does this PR fixes:
[<!-- _Link to issue(s)/story(ies)_ -->](https://issues.redhat.com/browse/DEVHAS-290)

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [x] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
