### PR TITLE
[DEVHAS-278] fix the cdq default name generation rule

### DIFF
--- a/controllers/update.go
+++ b/controllers/update.go
@@ -19,8 +19,8 @@ package controllers
 import (
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/brianvoe/gofakeit/v6"
 	devfileAPIV1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
@@ -535,7 +535,7 @@ func getComponentName(gitSource *appstudiov1alpha1.GitSource) string {
 // sanitizeComponentName sanitizes component name with the following requirements:
 // - Contain at most 63 characters
 // - Contain only lowercase alphanumeric characters or ‘-’
-// - Start with an alphanumeric character
+// - Start with an alphabet character
 // - End with an alphanumeric character
 // - Must not contain all numeric values
 func sanitizeComponentName(name string) string {
@@ -546,14 +546,11 @@ func sanitizeComponentName(name string) string {
 	if name == "" {
 		name = gofakeit.Noun()
 	}
-	_, err := strconv.ParseFloat(name, 64)
-	if err != nil {
-		// convert all Uppercase chars to lowercase
-		name = strings.ToLower(name)
-	} else {
-		// contains only numeric values, prefix a character
+	if unicode.IsDigit(rune(name[0])) {
+		// starts with numeric values, prefix a character
 		name = fmt.Sprintf("comp-%s", name)
 	}
+	name = strings.ToLower(name)
 	if len(name) > 58 {
 		name = name[0:58]
 	}

--- a/controllers/update_test.go
+++ b/controllers/update_test.go
@@ -1418,7 +1418,7 @@ func TestGetComponentName(t *testing.T) {
 			gitSource: &appstudiov1alpha1.GitSource{
 				URL: "https://github.com/devfile-samples/123-testdevfilego--ImportRepository--withaverylongreporitoryname-test-validation-and-generation",
 			},
-			expectedName: "123-testdevfilego--importrepository--withaverylongreporito",
+			expectedName: "comp-123-testdevfilego--importrepository--withaverylongrep",
 		},
 		{
 			name: "numeric repo name",

--- a/controllers/update_test.go
+++ b/controllers/update_test.go
@@ -1497,6 +1497,11 @@ func TestSanitizeComponentName(t *testing.T) {
 			want:          "comp-123412341234",
 		},
 		{
+			name:          "simple component name, start with a number",
+			componentName: "123-testcomp",
+			want:          "comp-123-testcomp",
+		},
+		{
 			name:          "Empty string, should have a name generated for it",
 			componentName: "",
 		},


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
This PR fixes the cdq default name generation rule. now starting with a numeric character is not accepted. 
The `sanitizeComponentName` will add a `comp-` prefix if the component name starts with a number. 

```
Spec:
  Git:
    URL:  https://github.com/hacbs-release/fbc-test
Status:
  Component Detected:
    comp-413-fbc-test-8iki:
      Component Stub:
        Application:     insert-application-name
        Component Name:  comp-413-fbc-test-8iki
        Replicas:        1

```

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
https://issues.redhat.com/browse/DEVHAS-278

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
