### PR TITLE
[DEVHAS-275]trim leading and trailing spaces in repo URL

### DIFF
--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strings"
 
 	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
@@ -128,6 +129,8 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 		if context == "" {
 			context = "./"
 		}
+		// remove leading and trailing spaces of the repo URL
+		source.URL = strings.TrimSpace(source.URL)
 		sourceURL := source.URL
 		// If the repository URL ends in a forward slash, remove it to avoid issues with default branch lookup
 		if string(sourceURL[len(sourceURL)-1]) == "/" {

--- a/controllers/componentdetectionquery_controller_test.go
+++ b/controllers/componentdetectionquery_controller_test.go
@@ -782,7 +782,7 @@ var _ = Describe("Component Detection Query controller", func() {
 	})
 
 	Context("Create Component Detection Query with springboot repo that has devfile", func() {
-		It("Should return a correct devfile", func() {
+		It("Should return a correct devfile when repo URL has leading and trailing spaces", func() {
 			ctx := context.Background()
 
 			queryName := "springboot" + HASCompDetQuery + "16"
@@ -798,7 +798,7 @@ var _ = Describe("Component Detection Query controller", func() {
 				},
 				Spec: appstudiov1alpha1.ComponentDetectionQuerySpec{
 					GitSource: appstudiov1alpha1.GitSource{
-						URL: "https://github.com/maysunfaisal/devfile-sample-java-springboot-basic-1",
+						URL: "   https://github.com/maysunfaisal/devfile-sample-java-springboot-basic-1   ",
 					},
 				},
 			}


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
This PR trims leading and trailing spaces in repo URL to ensure the URL set in component spec is a valid one, and will bypass the web hook check. 

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
https://issues.redhat.com/browse/DEVHAS-275

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
