### PR TITLE
[DEVHAS-223 Redux] Ensure revision is set for Dockerfile-only components

### DIFF
--- a/controllers/componentdetectionquery_controller_test.go
+++ b/controllers/componentdetectionquery_controller_test.go
@@ -989,7 +989,8 @@ var _ = Describe("Component Detection Query controller", func() {
 					},
 					Spec: appstudiov1alpha1.ComponentDetectionQuerySpec{
 						GitSource: appstudiov1alpha1.GitSource{
-							URL: "https://github.com/maysunfaisal/python-src-docker",
+							URL:      "https://github.com/devfile-resources/python-src-docker",
+							Revision: "testbranch",
 						},
 					},
 				}
@@ -1014,6 +1015,7 @@ var _ = Describe("Component Detection Query controller", func() {
 					Expect(componentDesc.ComponentStub.Source.GitSource).ShouldNot(BeNil())
 					Expect(componentDesc.ComponentStub.Source.GitSource.DockerfileURL).ShouldNot(BeEmpty())
 					Expect(componentDesc.ComponentStub.Source.GitSource.DockerfileURL).Should(Equal("./Dockerfile"))
+					Expect(componentDesc.ComponentStub.Source.GitSource.Revision).Should(Equal("testbranch"))
 				}
 
 				// Delete the specified Detection Query resource

--- a/controllers/update.go
+++ b/controllers/update.go
@@ -492,6 +492,7 @@ func (r *ComponentDetectionQueryReconciler) updateComponentStub(req ctrl.Request
 		gitSource := &appstudiov1alpha1.GitSource{
 			Context:       context,
 			URL:           componentDetectionQuery.Spec.GitSource.URL,
+			Revision:      componentDetectionQuery.Spec.GitSource.Revision,
 			DockerfileURL: link,
 		}
 		componentName := getComponentName(gitSource)


### PR DESCRIPTION
### What does this PR do?:
In https://github.com/redhat-appstudio/application-service/pull/250, we addressed the bug where the source revision for Components was not being returned in the CDQ status. However, it seems that we were only setting the revision for Components with a Devfile present. For Dockerfile-only components, the revision was not being set, as the revision needed to be set in a different part of code.

This PR updates the CDQ logic so that the revision is also returned for Dockerfile components, and updates test cases to ensure this scenario is covered.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-223

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
