### PR TITLE
[STONEBUGS-108] Trim route names from the devfile parser

### DIFF
--- a/pkg/devfile/devfile.go
+++ b/pkg/devfile/devfile.go
@@ -358,7 +358,13 @@ func GetResourceFromDevfile(log logr.Logger, devfileData data.DevfileData, deplo
 				}
 				if len(resources.Routes) > 0 {
 					// replace the route metadata.name to use the component name
-					resources.Routes[0].ObjectMeta.Name = compName
+					// Trim the route name if needed
+					routeName := compName
+					if len(routeName) >= 30 {
+						routeName = routeName[0:25] + util.GetRandomString(4, true)
+					}
+
+					resources.Routes[0].ObjectMeta.Name = routeName
 					resources.Routes[0].ObjectMeta.Namespace = namespace
 
 					// generate and append the route labels with the hc & ha information

--- a/pkg/devfile/devfile_test.go
+++ b/pkg/devfile/devfile_test.go
@@ -2369,8 +2369,8 @@ schemaVersion: 2.2.0`
 
 				if len(actualResources.Routes) > 0 {
 					if tt.name == "Devfile with long component name - route name should be trimmed" {
-						if len(actualResources.Routes[0].Name) <= 30 {
-							t.Errorf("Expected trimmed route name with length 30, but got %v", len(actualResources.Routes[0].Name))
+						if len(actualResources.Routes[0].Name) > 30 {
+							t.Errorf("Expected trimmed route name with length < 30, but got %v", len(actualResources.Routes[0].Name))
 						}
 						if !strings.Contains(actualResources.Routes[0].Name, "component-sample-comp") {
 							t.Errorf("Expected route name to contain %v, but got %v", "component-sample-comp", actualResources.Routes[0].Name)


### PR DESCRIPTION
### What does this PR do?:
This PR updates the `GetResourceFromDevfile()` function to trim the names of the route that retrieve from endpoints in a Component's devfile. Previously we were only trimming the route name when we generate resources _not_ from a devfile (e.g. from scratch). 

As recommended earlier, the route name should be less than 30 characters, and we reserve the last 4 characters to append 4 random characters for uniqueness.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/STONEBUGS-108

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
