### PR TITLE
[RHTAPBUGS-111] Use SPI token for private repos in CDQs

### DIFF
--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -86,7 +86,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return reconcile.Result{}, err
 	}
 
-	ghClient, err := r.GitHubTokenClient.GetNewGitHubClient()
+	ghClient, err := r.GitHubTokenClient.GetNewGitHubClient("")
 	if err != nil {
 		log.Error(err, "Unable to create Go-GitHub client due to error")
 		return reconcile.Result{}, err

--- a/controllers/applicationsnapshotenvironmentbinding_controller.go
+++ b/controllers/applicationsnapshotenvironmentbinding_controller.go
@@ -96,7 +96,7 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 
 	log.Info(fmt.Sprintf("Starting reconcile loop for %v %v", appSnapshotEnvBinding.Name, req.NamespacedName))
 
-	ghClient, err := r.GitHubTokenClient.GetNewGitHubClient()
+	ghClient, err := r.GitHubTokenClient.GetNewGitHubClient("")
 	if err != nil {
 		log.Error(err, "Unable to create Go-GitHub client due to error")
 		return reconcile.Result{}, err

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -126,7 +126,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	setCounterAnnotation(applicationFailCounterAnnotation, &component, 0)
 
-	ghClient, err := r.GitHubTokenClient.GetNewGitHubClient()
+	ghClient, err := r.GitHubTokenClient.GetNewGitHubClient("")
 	if err != nil {
 		log.Error(err, "Unable to create Go-GitHub client due to error")
 		return reconcile.Result{}, err

--- a/pkg/github/token.go
+++ b/pkg/github/token.go
@@ -29,7 +29,7 @@ import (
 )
 
 type GitHubToken interface {
-	GetNewGitHubClient() (GitHubClient, error)
+	GetNewGitHubClient(token string) (GitHubClient, error)
 }
 
 type GitHubTokenClient struct {
@@ -101,13 +101,21 @@ func getRandomToken() (string, string, error) {
 	return token, tokenName, nil
 }
 
-// GetNewGitHubClient intializes a new Go-GitHub client from a randomly selected GitHub token available to HAS
-// It returns the GitHub client, and the name of the token used for the client
+// GetNewGitHubClient intializes a new Go-GitHub client
+// If a token is passed in (non-empty string) it will use that token for the GitHub client
+// If no token is passed in (empty string), a token will be randomly selected by HAS.
+// It returns the GitHub client, and (if a token was randomly selected) the name of the token used for the client
 // If an error is encountered retrieving the token, or initializing the client, an error is returned
-func (g GitHubTokenClient) GetNewGitHubClient() (GitHubClient, error) {
-	ghToken, ghTokenName, err := getRandomToken()
-	if err != nil {
-		return GitHubClient{}, err
+func (g GitHubTokenClient) GetNewGitHubClient(token string) (GitHubClient, error) {
+	var ghToken, ghTokenName string
+	var err error
+	if token == "" {
+		ghToken, ghTokenName, err = getRandomToken()
+		if err != nil {
+			return GitHubClient{}, err
+		}
+	} else {
+		ghToken = token
 	}
 
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: ghToken})

--- a/pkg/github/token_mock.go
+++ b/pkg/github/token_mock.go
@@ -19,8 +19,9 @@ type MockGitHubTokenClient struct {
 }
 
 // GetNewGitHubClient returns a mocked Go-GitHub client. No actual tokens are passed in or used when this function is called
-func (g MockGitHubTokenClient) GetNewGitHubClient() (GitHubClient, error) {
+func (g MockGitHubTokenClient) GetNewGitHubClient(token string) (GitHubClient, error) {
 	return GitHubClient{
+		Token:  token,
 		Client: GetMockedClient(),
 	}, nil
 }

--- a/pkg/github/token_test.go
+++ b/pkg/github/token_test.go
@@ -120,11 +120,15 @@ func TestParseGitHubTokens(t *testing.T) {
 
 func TestGetNewGitHubClient(t *testing.T) {
 	ghTokenClient := GitHubTokenClient{}
+
+	fakeToken := "ghp_faketoken"
+
 	tests := []struct {
 		name               string
 		client             GitHubToken
 		githubTokenEnv     string
 		githubTokenListEnv string
+		passedInToken      string
 		wantErr            bool
 	}{
 		{
@@ -153,6 +157,12 @@ func TestGetNewGitHubClient(t *testing.T) {
 			wantErr:            false,
 		},
 		{
+			name:          "One token set, should return client",
+			client:        ghTokenClient,
+			passedInToken: fakeToken,
+			wantErr:       false,
+		},
+		{
 			name:    "Mock client",
 			client:  MockGitHubTokenClient{},
 			wantErr: false,
@@ -172,7 +182,7 @@ func TestGetNewGitHubClient(t *testing.T) {
 			}
 
 			_ = ParseGitHubTokens()
-			ghClient, err := tt.client.GetNewGitHubClient()
+			ghClient, err := tt.client.GetNewGitHubClient(tt.passedInToken)
 			if tt.name != "Mock client" && !tt.wantErr {
 				if Tokens[ghClient.TokenName] == "" {
 					t.Errorf("TestGetNewGitHubClient() error: expected token value %v with key %v", Tokens[ghClient.TokenName], ghClient.TokenName)


### PR DESCRIPTION
### What does this PR do?:
This PR fixes branch detection in CDQs for private repositories. We were using the HAS-provided Git tokens to detect branches, and In order for branch detection to work against private repositories, we need to use the token provided by SPI.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/RHTAPBUGS-111

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
