### PR TITLE
[DEVHAS-272] Add ServiceMonitor to HAS repo and update grafana dashboard 

### DIFF
--- a/config/monitoring/grafana-dashboards/has-gitops-repo-metrics.json
+++ b/config/monitoring/grafana-dashboards/has-gitops-repo-metrics.json
@@ -30,10 +30,6 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PF224BEF3374A25F8"
-      },
       "description": "The rate of gitops repo creation requests",
       "fieldConfig": {
         "defaults": {
@@ -111,10 +107,6 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "editorMode": "code",
           "expr": "sum(rate(has_gitops_repo_creation_total[5m]))",
           "legendFormat": "__auto",
@@ -126,10 +118,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PF224BEF3374A25F8"
-      },
       "description": "Percentage of successful gitops repo creation requests",
       "fieldConfig": {
         "defaults": {
@@ -178,10 +166,6 @@
       "pluginVersion": "9.1.6",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "editorMode": "code",
           "expr": "1-sum(increase(has_gitops_failed_repo_creation_total[$__range]))/sum(increase(has_gitops_repo_creation_total[$__range]))",
           "legendFormat": "__auto",
@@ -193,10 +177,6 @@
       "type": "gauge"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PF224BEF3374A25F8"
-      },
       "description": "Percentage of failed gitops repo creation requests",
       "fieldConfig": {
         "defaults": {
@@ -244,10 +224,6 @@
       "pluginVersion": "9.1.6",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "editorMode": "code",
           "expr": "sum(increase(has_gitops_failed_repo_creation_total[$__range]))/sum(increase(has_gitops_repo_creation_total[$__range]))",
           "legendFormat": "__auto",
@@ -262,28 +238,7 @@
   "schemaVersion": 37,
   "style": "dark",
   "tags": [],
-  "templating": {
-    "list": [
-      {
-        "current": {
-          "selected": true,
-          "text": "prometheus-appstudio-ds",
-          "value": "prometheus-appstudio-ds"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "multi": false,
-        "name": "datasource",
-        "options": [],
-        "query": "prometheus",
-        "queryValue": "",
-        "refresh": 1,
-        "regex": ".*-(appstudio)-.*",
-        "skipUrlSync": false,
-        "type": "datasource"
-      }
-    ]
-  },
+  "templating": {},
   "time": {
     "from": "now-24h",
     "to": "now"

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -1,18 +1,54 @@
-
-# Prometheus Monitor Service (Metrics)
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: application-service-metrics-reader
+  namespace: application-service # deployment namespace from https://github.com/redhat-appstudio/infra-deployments/blob/main/components/has/base/kustomization.yaml#L20
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: application-service-metrics-reader
+  namespace: application-service
+  annotations:
+    kubernetes.io/service-account.name: metrics-reader
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: application-service-metrics-reader
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-application-service-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: application-service-metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: application-service-metrics-reader
+    namespace: application-service
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  labels:
-    control-plane: controller-manager
-  name: controller-manager-metrics-monitor
-  namespace: system
+  name: application-service
+  namespace: application-service
 spec:
   endpoints:
     - path: /metrics
       port: https
       scheme: https
-      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      bearerTokenSecret:
+        name: "metrics-reader"
+        key: token
       tlsConfig:
         insecureSkipVerify: true
   selector:


### PR DESCRIPTION

### What does this PR do?:
<!-- _Summarize the changes_ -->

- With the recent changes in the monitoring stack, components now have to store Service Monitors in their own repo based on this [dummy template](https://github.com/redhat-appstudio/infra-deployments/blob/main/components/monitoring/prometheus/development/dummy-service-service-monitor.yaml).

- Changes were also made in the grafana dashboard to remove an invalid DS


### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
https://issues.redhat.com/browse/DEVHAS-272

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
