### PR TITLE
[DEVHAS-272] updating monitor to  fix kustomize error

### DIFF
--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -1,27 +1,17 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: application-service-metrics-reader
+  name: metrics-reader
   namespace: application-service # deployment namespace from https://github.com/redhat-appstudio/infra-deployments/blob/main/components/has/base/kustomization.yaml#L20
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: application-service-metrics-reader
+  name: metrics-reader
   namespace: application-service
   annotations:
     kubernetes.io/service-account.name: metrics-reader
 type: kubernetes.io/service-account-token
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: application-service-metrics-reader
-rules:
-  - nonResourceURLs:
-      - /metrics
-    verbs:
-      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -30,16 +20,16 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: application-service-metrics-reader
+  name: metrics-reader
 subjects:
   - kind: ServiceAccount
-    name: application-service-metrics-reader
+    name: metrics-reader
     namespace: application-service
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: application-service
+  name: service-monitor
   namespace: application-service
 spec:
   endpoints:


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

Infra deployments PR is failing due to kustomize error: https://github.com/redhat-appstudio/infra-deployments/pull/1733
The problem is due to a cluster role being defined twice; once in the rbac/auth_proxy_client_clusterrole.yaml and another in the monitor.yaml.  Fix was to remove the one in the monitor.yaml. and clean up the names for other CRs.  Ran kustomize on the local changes and was able to get past the errors

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
https://issues.redhat.com/browse/DEVHAS-272

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
