### PR TITLE
Don't allow secondary rate limit callback to panic

### DIFF
--- a/controllers/application_controller_finalizer.go
+++ b/controllers/application_controller_finalizer.go
@@ -48,7 +48,7 @@ func (r *ApplicationReconciler) AddFinalizer(ctx context.Context, application *a
 }
 
 // Finalize deletes the corresponding GitOps repo for the given Application CR.
-func (r *ApplicationReconciler) Finalize(application *appstudiov1alpha1.Application, ghClient *github.GitHubClient) error {
+func (r *ApplicationReconciler) Finalize(ctx context.Context, application *appstudiov1alpha1.Application, ghClient *github.GitHubClient) error {
 	// Get the GitOps repository URL
 	devfileSrc := devfile.DevfileSrc{
 		Data: application.Status.Devfile,
@@ -72,7 +72,7 @@ func (r *ApplicationReconciler) Finalize(application *appstudiov1alpha1.Applicat
 
 		metricsLabel := prometheus.Labels{"controller": applicationName, "tokenName": ghClient.TokenName, "operation": "DeleteRepository"}
 		metrics.ControllerGitRequest.With(metricsLabel).Inc()
-		err = ghClient.DeleteRepository(context.Background(), r.GitHubOrg, repoName)
+		err = ghClient.DeleteRepository(ctx, r.GitHubOrg, repoName)
 		metrics.HandleRateLimitMetrics(err, metricsLabel)
 		return err
 

--- a/controllers/applicationsnapshotenvironmentbinding_controller.go
+++ b/controllers/applicationsnapshotenvironmentbinding_controller.go
@@ -100,6 +100,9 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 		return reconcile.Result{}, err
 	}
 
+	// Add the Go-GitHub client name to the context
+	ctx = context.WithValue(ctx, github.GHClientKey, ghClient.TokenName)
+
 	applicationName := appSnapshotEnvBinding.Spec.Application
 	environmentName := appSnapshotEnvBinding.Spec.Environment
 	snapshotName := appSnapshotEnvBinding.Spec.Snapshot

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -130,6 +130,9 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return reconcile.Result{}, err
 	}
 
+	// Add the Go-GitHub client name to the context
+	ctx = context.WithValue(ctx, github.GHClientKey, ghClient.TokenName)
+
 	// Check if the Component CR is under deletion
 	// If so: Remove the project from the Application devfile, remove the component dir from the Gitops repo and remove the finalizer.
 	if component.ObjectMeta.DeletionTimestamp.IsZero() {

--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -123,6 +123,9 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 			return reconcile.Result{}, err
 		}
 
+		// Add the Go-GitHub client name to the context
+		ctx = context.WithValue(ctx, github.GHClientKey, ghClient.TokenName)
+
 		source := componentDetectionQuery.Spec.GitSource
 		var devfileBytes, dockerfileBytes []byte
 		var clonePath, componentPath, devfilePath, dockerfilePath string

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -67,8 +67,6 @@ func GenerateNewRepositoryName(displayName, uniqueHash string) string {
 }
 
 func (g *GitHubClient) GenerateNewRepository(ctx context.Context, orgName string, repoName string, description string) (string, error) {
-	// Add the client to the context
-	ctx = context.WithValue(ctx, GHClientKey, g.TokenName)
 	isPrivate := false
 	appStudioAppDataURL := "https://github.com/" + orgName + "/"
 	metrics.GitOpsRepoCreationTotalReqs.Inc()
@@ -127,9 +125,6 @@ func GetRepoAndOrgFromURL(repoURL string) (string, string, error) {
 
 // GetDefaultBranchFromURL returns the default branch of a given repoURL
 func (g *GitHubClient) GetDefaultBranchFromURL(repoURL string, ctx context.Context) (string, error) {
-	// Add the client to the context
-	ctx = context.WithValue(ctx, GHClientKey, g.TokenName)
-
 	repoName, orgName, err := GetRepoAndOrgFromURL(repoURL)
 	if err != nil {
 		return "", err
@@ -145,9 +140,6 @@ func (g *GitHubClient) GetDefaultBranchFromURL(repoURL string, ctx context.Conte
 
 // GetBranchFromURL returns the requested branch of a given repoURL
 func (g *GitHubClient) GetBranchFromURL(repoURL string, ctx context.Context, branchName string) (*github.Branch, error) {
-	// Add the client to the context
-	ctx = context.WithValue(ctx, GHClientKey, g.TokenName)
-
 	repoName, orgName, err := GetRepoAndOrgFromURL(repoURL)
 	if err != nil {
 		return nil, err
@@ -163,9 +155,6 @@ func (g *GitHubClient) GetBranchFromURL(repoURL string, ctx context.Context, bra
 
 // GetLatestCommitSHAFromRepository gets the latest Commit SHA from the repository
 func (g *GitHubClient) GetLatestCommitSHAFromRepository(ctx context.Context, repoName string, orgName string, branch string) (string, error) {
-	// Add the client to the context
-	ctx = context.WithValue(ctx, GHClientKey, g.TokenName)
-
 	commitSHA, _, err := g.Client.Repositories.GetCommitSHA1(ctx, orgName, repoName, branch, "")
 	if err != nil {
 		return "", err
@@ -175,9 +164,6 @@ func (g *GitHubClient) GetLatestCommitSHAFromRepository(ctx context.Context, rep
 
 // Delete Repository takes in the given repository URL and attempts to delete it
 func (g *GitHubClient) DeleteRepository(ctx context.Context, orgName string, repoName string) error {
-	// Add the client to the context
-	ctx = context.WithValue(ctx, GHClientKey, g.TokenName)
-
 	// Retrieve just the repository name from the URL
 	_, err := g.Client.Repositories.Delete(ctx, orgName, repoName)
 	if err != nil {

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -127,6 +127,9 @@ func GetRepoAndOrgFromURL(repoURL string) (string, string, error) {
 
 // GetDefaultBranchFromURL returns the default branch of a given repoURL
 func (g *GitHubClient) GetDefaultBranchFromURL(repoURL string, ctx context.Context) (string, error) {
+	// Add the client to the context
+	ctx = context.WithValue(ctx, GHClientKey, g.TokenName)
+
 	repoName, orgName, err := GetRepoAndOrgFromURL(repoURL)
 	if err != nil {
 		return "", err
@@ -142,6 +145,9 @@ func (g *GitHubClient) GetDefaultBranchFromURL(repoURL string, ctx context.Conte
 
 // GetBranchFromURL returns the requested branch of a given repoURL
 func (g *GitHubClient) GetBranchFromURL(repoURL string, ctx context.Context, branchName string) (*github.Branch, error) {
+	// Add the client to the context
+	ctx = context.WithValue(ctx, GHClientKey, g.TokenName)
+
 	repoName, orgName, err := GetRepoAndOrgFromURL(repoURL)
 	if err != nil {
 		return nil, err
@@ -157,6 +163,9 @@ func (g *GitHubClient) GetBranchFromURL(repoURL string, ctx context.Context, bra
 
 // GetLatestCommitSHAFromRepository gets the latest Commit SHA from the repository
 func (g *GitHubClient) GetLatestCommitSHAFromRepository(ctx context.Context, repoName string, orgName string, branch string) (string, error) {
+	// Add the client to the context
+	ctx = context.WithValue(ctx, GHClientKey, g.TokenName)
+
 	commitSHA, _, err := g.Client.Repositories.GetCommitSHA1(ctx, orgName, repoName, branch, "")
 	if err != nil {
 		return "", err
@@ -166,6 +175,9 @@ func (g *GitHubClient) GetLatestCommitSHAFromRepository(ctx context.Context, rep
 
 // Delete Repository takes in the given repository URL and attempts to delete it
 func (g *GitHubClient) DeleteRepository(ctx context.Context, orgName string, repoName string) error {
+	// Add the client to the context
+	ctx = context.WithValue(ctx, GHClientKey, g.TokenName)
+
 	// Retrieve just the repository name from the URL
 	_, err := g.Client.Repositories.Delete(ctx, orgName, repoName)
 	if err != nil {

--- a/pkg/github/token.go
+++ b/pkg/github/token.go
@@ -199,10 +199,6 @@ func rateLimitCallBackfunc(cbContext *github_ratelimit.CallbackContext) {
 	if ghClientNameObj == nil {
 		// The GitHub Client should never be nil - it must always be set before we access the GH API
 		// But if it is nil, returning prematurely is preferable to panicking
-		/*log := zap.New(zap.UseFlagOptions(&zap.Options{
-			Development: true,
-			TimeEncoder: zapcore.ISO8601TimeEncoder,
-		}))*/
 		log.Error(fmt.Errorf("a Go-GitHub client name was not set in GitHub API request, cannot execute secondary rate limit callback"), "")
 		return
 	}

--- a/pkg/github/token.go
+++ b/pkg/github/token.go
@@ -192,7 +192,13 @@ func rateLimitCallBackfunc(cbContext *github_ratelimit.CallbackContext) {
 	// Use the client name to lookup the client pointer
 	req := *cbContext.Request
 	reqCtx := req.Context()
-	ghClientName := reqCtx.Value(GHClientKey).(string)
+	ghClientNameObj := reqCtx.Value(GHClientKey)
+	if ghClientNameObj == nil {
+		// The GitHub Client should never be nil - it must always be set before we access the GH API
+		// But if it is nil, returning prematurely is preferable to panicking
+		return
+	}
+	ghClientName := ghClientNameObj.(string)
 	ghClient := Clients[ghClientName]
 
 	// Start a goroutine that marks the given client as rate limited and sleeps for 'TotalSleepTime'

--- a/pkg/github/token_test.go
+++ b/pkg/github/token_test.go
@@ -217,10 +217,7 @@ func TestGetNewGitHubClient(t *testing.T) {
 }
 
 func TestGetRandomClient(t *testing.T) {
-	//ghTokenClient := GitHubTokenClient{}
-
-	//fakeToken := "ghp_faketoken"
-
+	ctx := context.WithValue(context.Background(), GHClientKey, "mock")
 	tests := []struct {
 		name               string
 		client             GitHubToken
@@ -270,7 +267,7 @@ func TestGetRandomClient(t *testing.T) {
 				Clients = tt.clientPool
 				// Deliberately lock the secondary rate limit object until we need to test the related fields
 				client.SecondaryRateLimit.mu.Lock()
-				_, err := client.GenerateNewRepository(context.Background(), "test-org", "test-repo", "test description")
+				_, err := client.GenerateNewRepository(ctx, "test-org", "test-repo", "test description")
 				if err == nil {
 					t.Error("TestGetRandomClient() error: expected err not to be nil")
 				}


### PR DESCRIPTION
### What does this PR do?:
The secondary rate limit callback function we use can potentially panic if the Go-GitHub client name is not set in the context before the (rate limited) request is made. This PR takes the following steps to avoid that:
- The Go-GitHub client name is added to the context as soon as we initialize the Go-GitHub client
- nil pointer checks for when the Go-GitHub client is either unset or points to a non-existent client
   - There's nothing we can do when its nil, so logging and returning is preferable to panicking.
- Updated test cases to ensure that we don't panic in these scenarios