### PR TITLE
chore: Regenerate dashboard CM name

### DIFF
--- a/config/monitoring/kustomization.yaml
+++ b/config/monitoring/kustomization.yaml
@@ -3,11 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 
 namespace: grafana-operator-system
 
-
-generatorOptions:
-  disableNameSuffixHash: true
-
-
 configMapGenerator:
   - name: grafana-dashboard-has-gitops-repo-metrics
     files:


### PR DESCRIPTION
This will cause an update to the Dashboard CR that will get reconciled by the Grafana operator.