### PR TITLE
[DEVHAS-355] rate limit improvements - switch to using GetCommitIDFromRepo

### DIFF
--- a/controllers/applicationsnapshotenvironmentbinding_controller_test.go
+++ b/controllers/applicationsnapshotenvironmentbinding_controller_test.go
@@ -1781,7 +1781,8 @@ var _ = Describe("SnapshotEnvironmentBinding controller", func() {
 			environmentName := "staging"
 
 			replicas := int32(3)
-			createAndFetchSimpleApp(applicationName, HASAppNamespace, DisplayName, Description)
+
+			createAndFetchSimpleAppWithRepo(applicationName, HASAppNamespace, DisplayName, Description, "https://github.com/fakeorg/test-error-response")
 			hasComp := createAndFetchSimpleComponent(componentName, HASAppNamespace, ComponentName, applicationName, SampleRepoLink, false)
 			// Make sure the devfile model was properly set in Component
 			Expect(hasComp.Status.Devfile).Should(Not(Equal("")))
@@ -1889,7 +1890,6 @@ var _ = Describe("SnapshotEnvironmentBinding controller", func() {
 			Expect(createdBinding.Status.GitOpsRepoConditions[0].Status).Should(Equal(metav1.ConditionFalse))
 			Expect(createdBinding.Status.GitOpsRepoConditions[0].Reason).Should(Equal("GenerateError"))
 			Expect(createdBinding.Status.GitOpsRepoConditions[0].Message).Should(ContainSubstring("failed to retrieve commit id for repository"))
-			//Expect(createdBinding.Status.GitOpsRepoConditions[0].Message).Should(ContainSubstring("unable to parse gitops repository"))
 
 			// Delete the specified Component resources
 			hasCompLookupKey := types.NamespacedName{Name: componentName, Namespace: HASAppNamespace}

--- a/gitops/generate_mock.go
+++ b/gitops/generate_mock.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Red Hat, Inc.
+// Copyright 2022-2023 Red Hat, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -105,7 +105,7 @@ func execute(baseDir string, cmd gitops.CommandType, args ...string) ([]byte, er
 	if cmd == gitops.GitCommand || cmd == gitops.RmCommand {
 		if len(args) > 0 && args[0] == "rev-parse" {
 			if strings.Contains(baseDir, "test-git-error") {
-				return []byte(""), fmt.Errorf("unable to retrive git commit id")
+				return []byte(""), fmt.Errorf("unable to retrieve git commit id")
 			} else {
 				return []byte("ca82a6dff817ec66f44342007202690a93763949"), errorStack.Pop()
 			}


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
Avoids using the `GetLatestCommitSHAFromRepository` since that can incur rate limiting penalties.  We'll use the gitops generator method, `GetCommitIDFromRepo` instead which makes the equivalent calls using the git cli

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->

https://issues.redhat.com/browse/DEVHAS-355
### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
