### PR TITLE
Pass in Target Port to Gitops Generator Library for SEB controller

### DIFF
--- a/controllers/applicationsnapshotenvironmentbinding_controller.go
+++ b/controllers/applicationsnapshotenvironmentbinding_controller.go
@@ -307,6 +307,7 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 			OverlayEnvVar:       environmentConfigEnvVars,
 			K8sLabels:           kubeLabels,
 			IsKubernetesCluster: isKubernetesCluster,
+			TargetPort:          hasComponent.Spec.TargetPort, // pass the target port to the gitops gen library as they may generate a route/ingress based on the target port if the devfile does not have an ingress/route or an endpoint
 		}
 
 		if !reflect.DeepEqual(kubernetesResources, devfileParser.KubernetesResources{}) {


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
When a component repo like https://github.com/psturc-org/hacbs-test-project has a devfile that does not have a devfile endpoint nor does it have an ingress/route resource in the outerloop YAML file, then the gitops generator library should generate an ingress/route based on the component.spec.targetport property..

Since the generation of ingress/route has moved from base to overlays, we need to pass the target port in the SEB controller to the Gitops generator library during resource generation.

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
https://issues.redhat.com/browse/DEVHAS-329

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
