### PR TITLE
[RHTAPBUGS-267] use retry  on conflict to update the status

### DIFF
--- a/controllers/component_controller_conditions.go
+++ b/controllers/component_controller_conditions.go
@@ -68,25 +68,6 @@ func (r *ComponentReconciler) SetCreateConditionAndUpdateCR(ctx context.Context,
 		return err
 	}
 
-	// if err != nil {
-	// 	// Retry, and if still fails, then return an error
-	// 	var currentComponent appstudiov1alpha1.Component
-	// 	err := r.Get(ctx, req.NamespacedName, &currentComponent)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// 	patch := client.MergeFrom(currentComponent.DeepCopy())
-
-	// 	meta.SetStatusCondition(&currentComponent.Status.Conditions, condition)
-	// 	currentComponent.Status.Devfile = component.Status.Devfile
-	// 	currentComponent.Status.ContainerImage = component.Status.ContainerImage
-	// 	currentComponent.Status.GitOps = component.Status.GitOps
-	// 	err = r.Client.Status().Patch(ctx, &currentComponent, patch)
-	// 	if err != nil {
-	// 		log.Error(err, "Unable to update Component")
-	// 		return err
-	// 	}
-	// }
 	return nil
 }
 
@@ -127,26 +108,6 @@ func (r *ComponentReconciler) SetUpdateConditionAndUpdateCR(ctx context.Context,
 		log.Error(err, "Unable to update Component")
 		return err
 	}
-	// if err != nil {
-	// 	// Retry, and if still fails, then return an error
-	// 	var currentComponent appstudiov1alpha1.Component
-	// 	err := r.Get(ctx, req.NamespacedName, &currentComponent)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// 	patch := client.MergeFrom(currentComponent.DeepCopy())
-
-	// 	meta.SetStatusCondition(&currentComponent.Status.Conditions, condition)
-	// 	currentComponent.Status.Devfile = component.Status.Devfile
-	// 	currentComponent.Status.ContainerImage = component.Status.ContainerImage
-	// 	currentComponent.Status.GitOps = component.Status.GitOps
-	// 	err = r.Client.Status().Patch(ctx, &currentComponent, patch)
-	// 	if err != nil {
-	// 		log.Error(err, "Unable to update Component")
-	// 	}
-
-	// 	return err
-	// }
 
 	return nil
 }

--- a/controllers/component_controller_conditions.go
+++ b/controllers/component_controller_conditions.go
@@ -22,8 +22,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	logutil "github.com/redhat-appstudio/application-service/pkg/log"
@@ -50,28 +50,43 @@ func (r *ComponentReconciler) SetCreateConditionAndUpdateCR(ctx context.Context,
 		}
 		logutil.LogAPIResourceChangeEvent(log, component.Name, "Component", logutil.ResourceCreate, createError)
 	}
-	meta.SetStatusCondition(&component.Status.Conditions, condition)
-	updateErr := r.Client.Status().Update(ctx, component)
-	if updateErr != nil {
-		// Retry, and if still fails, then return an error
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var currentComponent appstudiov1alpha1.Component
 		err := r.Get(ctx, req.NamespacedName, &currentComponent)
 		if err != nil {
 			return err
 		}
-		patch := client.MergeFrom(currentComponent.DeepCopy())
-
 		meta.SetStatusCondition(&currentComponent.Status.Conditions, condition)
 		currentComponent.Status.Devfile = component.Status.Devfile
 		currentComponent.Status.ContainerImage = component.Status.ContainerImage
 		currentComponent.Status.GitOps = component.Status.GitOps
-		err = r.Client.Status().Patch(ctx, &currentComponent, patch)
-		if err != nil {
-			log.Error(err, "Unable to update Component")
-		}
-
+		err = r.Client.Status().Update(ctx, &currentComponent)
+		return err
+	})
+	if err != nil {
+		log.Error(err, "Unable to update Component")
 		return err
 	}
+
+	// if err != nil {
+	// 	// Retry, and if still fails, then return an error
+	// 	var currentComponent appstudiov1alpha1.Component
+	// 	err := r.Get(ctx, req.NamespacedName, &currentComponent)
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// 	patch := client.MergeFrom(currentComponent.DeepCopy())
+
+	// 	meta.SetStatusCondition(&currentComponent.Status.Conditions, condition)
+	// 	currentComponent.Status.Devfile = component.Status.Devfile
+	// 	currentComponent.Status.ContainerImage = component.Status.ContainerImage
+	// 	currentComponent.Status.GitOps = component.Status.GitOps
+	// 	err = r.Client.Status().Patch(ctx, &currentComponent, patch)
+	// 	if err != nil {
+	// 		log.Error(err, "Unable to update Component")
+	// 		return err
+	// 	}
+	// }
 	return nil
 }
 
@@ -95,29 +110,43 @@ func (r *ComponentReconciler) SetUpdateConditionAndUpdateCR(ctx context.Context,
 		}
 		logutil.LogAPIResourceChangeEvent(log, component.Name, "Component", logutil.ResourceUpdate, updateError)
 	}
-
-	meta.SetStatusCondition(&component.Status.Conditions, condition)
-	updateErr := r.Client.Status().Update(ctx, component)
-	if updateErr != nil {
-		// Retry, and if still fails, then return an error
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var currentComponent appstudiov1alpha1.Component
 		err := r.Get(ctx, req.NamespacedName, &currentComponent)
 		if err != nil {
 			return err
 		}
-		patch := client.MergeFrom(currentComponent.DeepCopy())
-
 		meta.SetStatusCondition(&currentComponent.Status.Conditions, condition)
 		currentComponent.Status.Devfile = component.Status.Devfile
 		currentComponent.Status.ContainerImage = component.Status.ContainerImage
 		currentComponent.Status.GitOps = component.Status.GitOps
-		err = r.Client.Status().Patch(ctx, &currentComponent, patch)
-		if err != nil {
-			log.Error(err, "Unable to update Component")
-		}
-
+		err = r.Client.Status().Update(ctx, &currentComponent)
+		return err
+	})
+	if err != nil {
+		log.Error(err, "Unable to update Component")
 		return err
 	}
+	// if err != nil {
+	// 	// Retry, and if still fails, then return an error
+	// 	var currentComponent appstudiov1alpha1.Component
+	// 	err := r.Get(ctx, req.NamespacedName, &currentComponent)
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// 	patch := client.MergeFrom(currentComponent.DeepCopy())
+
+	// 	meta.SetStatusCondition(&currentComponent.Status.Conditions, condition)
+	// 	currentComponent.Status.Devfile = component.Status.Devfile
+	// 	currentComponent.Status.ContainerImage = component.Status.ContainerImage
+	// 	currentComponent.Status.GitOps = component.Status.GitOps
+	// 	err = r.Client.Status().Patch(ctx, &currentComponent, patch)
+	// 	if err != nil {
+	// 		log.Error(err, "Unable to update Component")
+	// 	}
+
+	// 	return err
+	// }
 
 	return nil
 }
@@ -142,27 +171,42 @@ func (r *ComponentReconciler) SetGitOpsGeneratedConditionAndUpdateCR(ctx context
 		}
 		logutil.LogAPIResourceChangeEvent(log, component.Name, "ComponentGitOpsResources", logutil.ResourceCreate, generateError)
 	}
-	meta.SetStatusCondition(&component.Status.Conditions, condition)
-	updateErr := r.Client.Status().Update(ctx, component)
-	if updateErr != nil {
-		// Retry, and if still fails, then return an error
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var currentComponent appstudiov1alpha1.Component
 		err := r.Get(ctx, req.NamespacedName, &currentComponent)
 		if err != nil {
 			return err
 		}
-		patch := client.MergeFrom(currentComponent.DeepCopy())
-
 		meta.SetStatusCondition(&currentComponent.Status.Conditions, condition)
 		currentComponent.Status.Devfile = component.Status.Devfile
 		currentComponent.Status.ContainerImage = component.Status.ContainerImage
 		currentComponent.Status.GitOps = component.Status.GitOps
-		err = r.Client.Status().Patch(ctx, &currentComponent, patch)
-		if err != nil {
-			log.Error(err, "Unable to update Component")
-		}
-
+		err = r.Client.Status().Update(ctx, &currentComponent)
+		return err
+	})
+	if err != nil {
+		log.Error(err, "Unable to update Component")
 		return err
 	}
+	// if err != nil {
+	// 	// Retry, and if still fails, then return an error
+	// 	var currentComponent appstudiov1alpha1.Component
+	// 	err := r.Get(ctx, req.NamespacedName, &currentComponent)
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// 	patch := client.MergeFrom(currentComponent.DeepCopy())
+
+	// 	meta.SetStatusCondition(&currentComponent.Status.Conditions, condition)
+	// 	currentComponent.Status.Devfile = component.Status.Devfile
+	// 	currentComponent.Status.ContainerImage = component.Status.ContainerImage
+	// 	currentComponent.Status.GitOps = component.Status.GitOps
+	// 	err = r.Client.Status().Patch(ctx, &currentComponent, patch)
+	// 	if err != nil {
+	// 		log.Error(err, "Unable to update Component")
+	// 	}
+
+	// 	return err
+	// }
 	return nil
 }

--- a/controllers/component_controller_conditions.go
+++ b/controllers/component_controller_conditions.go
@@ -149,25 +149,5 @@ func (r *ComponentReconciler) SetGitOpsGeneratedConditionAndUpdateCR(ctx context
 		log.Error(err, "Unable to update Component")
 		return err
 	}
-	// if err != nil {
-	// 	// Retry, and if still fails, then return an error
-	// 	var currentComponent appstudiov1alpha1.Component
-	// 	err := r.Get(ctx, req.NamespacedName, &currentComponent)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// 	patch := client.MergeFrom(currentComponent.DeepCopy())
-
-	// 	meta.SetStatusCondition(&currentComponent.Status.Conditions, condition)
-	// 	currentComponent.Status.Devfile = component.Status.Devfile
-	// 	currentComponent.Status.ContainerImage = component.Status.ContainerImage
-	// 	currentComponent.Status.GitOps = component.Status.GitOps
-	// 	err = r.Client.Status().Patch(ctx, &currentComponent, patch)
-	// 	if err != nil {
-	// 		log.Error(err, "Unable to update Component")
-	// 	}
-
-	// 	return err
-	// }
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
This PR use `retryOnConflict` as suggested by https://github.com/kubernetes-sigs/controller-runtime/issues/1748#issuecomment-994512902

The component status update cannot simply use patch, as it may lost previous gitops created status.

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
https://issues.redhat.com/browse/RHTAPBUGS-267

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
