### PR TITLE
[DEVHAS-376] rework rate limiting metrics

### DIFF
--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -36,6 +36,7 @@ type GitHubClient struct {
 	Token              string
 	Client             *github.Client
 	SecondaryRateLimit SecondaryRateLimit
+	PrimaryRateLimited bool // flag to denote if the token has been near primary rate limited
 }
 
 type SecondaryRateLimit struct {

--- a/pkg/github/mock.go
+++ b/pkg/github/mock.go
@@ -194,6 +194,34 @@ func GetMockedPrimaryRateLimitedClient() *github.Client {
 
 }
 
+func GetMockedResetPrimaryRateLimitedClient() *github.Client {
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatchHandler(
+			mock.GetRateLimit,
+			http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				/* #nosec G104 -- test code */
+				response := new(struct {
+					Resources *github.RateLimits `json:"resources"`
+				})
+				response.Resources = &github.RateLimits{
+					Core: &github.Rate{
+						Limit:     5000,
+						Remaining: 4999,
+					},
+					Search: &github.Rate{
+						Limit:     30,
+						Remaining: 29,
+					},
+				}
+				w.Write(mock.MustMarshal(response))
+			}),
+		),
+	)
+
+	cl, _ := createGitHubClientFromToken(&mockedHTTPClient.Transport, "", "mock")
+	return cl.Client
+}
+
 func GetMockedSecondaryRateLimitedClient() *github.Client {
 	mockedHTTPClient := mock.NewMockedHTTPClient(
 		mock.WithRequestMatchHandler(

--- a/pkg/github/token.go
+++ b/pkg/github/token.go
@@ -236,7 +236,6 @@ func rateLimitCallBackfunc(cbContext *github_ratelimit.CallbackContext) {
 
 		client.SecondaryRateLimit.mu.Lock()
 		client.SecondaryRateLimit.isLimitReached = true
-		log.Info("SRL metric incremented ")
 		srlTokenMetric.Inc()
 		client.SecondaryRateLimit.mu.Unlock()
 
@@ -244,7 +243,6 @@ func rateLimitCallBackfunc(cbContext *github_ratelimit.CallbackContext) {
 		time.Sleep(time.Until(*cbContext.SleepUntil))
 		client.SecondaryRateLimit.mu.Lock()
 		client.SecondaryRateLimit.isLimitReached = false
-		log.Info("SRL metric decremented ")
 		srlTokenMetric.Dec()
 		client.SecondaryRateLimit.mu.Unlock()
 	}(ghClient)

--- a/pkg/github/token.go
+++ b/pkg/github/token.go
@@ -123,6 +123,8 @@ func getRandomClient(clientPool map[string]*GitHubClient) (*GitHubClient, error)
 	if err != nil {
 		return nil, err
 	}
+
+	prlTokenMetric := metrics.TokenPoolGauge.With(prometheus.Labels{"rateLimited": "primary", "tokenName": ghClient.TokenName})
 	if rl != nil && (rl.Core != nil && rl.Core.Remaining < 10) || (rl.Search != nil && rl.Search.Remaining < 2) {
 		newClientPool := make(map[string]*GitHubClient)
 		for k, v := range clientPool {
@@ -130,8 +132,20 @@ func getRandomClient(clientPool map[string]*GitHubClient) (*GitHubClient, error)
 				newClientPool[k] = v
 			}
 		}
-		metrics.TokenPoolCounter.With(prometheus.Labels{"rateLimited": "primary", "tokenName": ghClient.TokenName}).Inc()
+
+		// if token has not been previously rate limited, increment the metric
+		if !ghClient.PrimaryRateLimited {
+			prlTokenMetric.Inc()
+			ghClient.PrimaryRateLimited = true
+		}
+
 		return getRandomClient(newClientPool)
+	}
+
+	// if token has been previously rate limited, then decrement the counter and reset the boolean
+	if ghClient.PrimaryRateLimited {
+		prlTokenMetric.Dec()
+		ghClient.PrimaryRateLimited = false
 	}
 
 	// Check the secondary rate limit
@@ -147,7 +161,7 @@ func getRandomClient(clientPool map[string]*GitHubClient) (*GitHubClient, error)
 				newClientPool[k] = v
 			}
 		}
-		metrics.TokenPoolCounter.With(prometheus.Labels{"rateLimited": "secondary", "tokenName": ghClient.TokenName}).Inc()
+
 		return getRandomClient(newClientPool)
 	}
 	return ghClient, nil
@@ -218,14 +232,20 @@ func rateLimitCallBackfunc(cbContext *github_ratelimit.CallbackContext) {
 
 	// Start a goroutine that marks the given client as rate limited and sleeps for 'TotalSleepTime'
 	go func(client *GitHubClient) {
+		srlTokenMetric := metrics.TokenPoolGauge.With(prometheus.Labels{"rateLimited": "secondary", "tokenName": client.TokenName})
+
 		client.SecondaryRateLimit.mu.Lock()
 		client.SecondaryRateLimit.isLimitReached = true
+		log.Info("SRL metric incremented ")
+		srlTokenMetric.Inc()
 		client.SecondaryRateLimit.mu.Unlock()
 
 		// Sleep until the rate limit is over
 		time.Sleep(time.Until(*cbContext.SleepUntil))
 		client.SecondaryRateLimit.mu.Lock()
 		client.SecondaryRateLimit.isLimitReached = false
+		log.Info("SRL metric decremented ")
+		srlTokenMetric.Dec()
 		client.SecondaryRateLimit.mu.Unlock()
 	}(ghClient)
 

--- a/pkg/github/token_mock.go
+++ b/pkg/github/token_mock.go
@@ -21,7 +21,7 @@ type MockGitHubTokenClient struct {
 type MockPrimaryRateLimitGitHubTokenClient struct {
 }
 
-type MockSecondaryRateLimitGitHubTokenClient struct {
+type MockResetPrimaryRateLimitGitHubTokenClient struct {
 }
 
 // GetNewGitHubClient returns a mocked Go-GitHub client. No actual tokens are passed in or used when this function is called
@@ -52,6 +52,17 @@ func (g MockPrimaryRateLimitGitHubTokenClient) GetNewGitHubClient(token string) 
 		TokenName: "fake1",
 		Token:     token,
 		Client:    GetMockedPrimaryRateLimitedClient(),
+	}
+
+	return getRandomClient(fakeClients)
+}
+
+func (g MockResetPrimaryRateLimitGitHubTokenClient) GetNewGitHubClient(token string) (*GitHubClient, error) {
+	fakeClients := make(map[string]*GitHubClient)
+	fakeClients["fake_reset"] = &GitHubClient{
+		TokenName: "fake_reset",
+		Token:     token,
+		Client:    GetMockedResetPrimaryRateLimitedClient(),
 	}
 
 	return getRandomClient(fakeClients)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -66,10 +66,10 @@ var (
 		[]string{"controller", "tokenName", "operation"},
 	)
 
-	TokenPoolCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "token_pool",
-			Help: "Counter to determine how many times a token has been primary/secondary rate limited",
+	TokenPoolGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "token_pool_gauge",
+			Help: "Gauge counter to track whether a token has been primary/secondary rate limited",
 		},
 
 		//rateLimited - can have the value of "primary" or "secondary"
@@ -80,7 +80,7 @@ var (
 
 func init() {
 	// Register custom metrics with the global prometheus registry
-	metrics.Registry.MustRegister(GitOpsRepoCreationTotalReqs, GitOpsRepoCreationFailed, GitOpsRepoCreationSucceeded, ControllerGitRequest, SecondaryRateLimitCounter, PrimaryRateLimitCounter, TokenPoolCounter)
+	metrics.Registry.MustRegister(GitOpsRepoCreationTotalReqs, GitOpsRepoCreationFailed, GitOpsRepoCreationSucceeded, ControllerGitRequest, SecondaryRateLimitCounter, PrimaryRateLimitCounter, TokenPoolGauge)
 }
 
 // HandleRateLimitMetrics checks the error type to verify a primary or secondary rate limit has been encountered


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

- Changes the rate limiting metrics to a gauge so counter can be decremented
- Introduces a PrimaryRateLimited boolean flag in the  GitHubClient type to track when a token has been near rate limited for the purpose of incrementing and decrementing the counter
- Updated the unit tests

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
https://issues.redhat.com/browse/DEVHAS-376

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
