### PR TITLE
[DEVHAS-381] Don't panic when route's spec.Port is nil

### DIFF
--- a/pkg/devfile/devfile.go
+++ b/pkg/devfile/devfile.go
@@ -410,7 +410,11 @@ func GetResourceFromDevfile(log logr.Logger, devfileData data.DevfileData, deplo
 					} else {
 						resources.Routes[0].ObjectMeta.Labels = k8sLabels
 					}
+
 					if currentPort > 0 {
+						if resources.Routes[0].Spec.Port == nil {
+							resources.Routes[0].Spec.Port = &routev1.RoutePort{}
+						}
 						resources.Routes[0].Spec.Port.TargetPort = intstr.FromInt(currentPort)
 						// Update for route
 						route := component.Attributes.GetString(RouteKey, &err)

--- a/pkg/devfile/devfile_test.go
+++ b/pkg/devfile/devfile_test.go
@@ -1257,6 +1257,73 @@ metadata:
   name: java-springboot
 schemaVersion: 2.2.0`
 
+	kubernetesInlinedDevfileRouteNoTargetPort := `
+commands:
+- apply:
+    component: image-build
+  id: build-image
+- apply:
+    component: kubernetes-deploy
+  id: deployk8s
+- composite:
+    commands:
+    - build-image
+    - deployk8s
+    group:
+      isDefault: true
+      kind: deploy
+    parallel: false
+  id: deploy
+components:
+- image:
+    autoBuild: false
+    dockerfile:
+      buildContext: .
+      rootRequired: false
+      uri: docker/Dockerfile
+    imageName: java-springboot-image:latest
+  name: image-build
+- attributes:
+    api.devfile.io/k8sLikeComponent-originalURI: deploy.yaml
+    deployment/container-port: 5566
+    deployment/containerENV:
+    - name: FOO
+      value: foo11
+    - name: BAR
+      value: bar11
+    deployment/cpuLimit: "2"
+    deployment/cpuRequest: 701m
+    deployment/memoryLimit: 500Mi
+    deployment/memoryRequest: 401Mi
+    deployment/replicas: 5
+    deployment/route: route111222
+    deployment/storageLimit: 400Mi
+    deployment/storageRequest: 201Mi
+  kubernetes:
+    deployByDefault: false
+    inlined: |-
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      metadata:
+        creationTimestamp: null
+        name: route-sample-2
+        labels:
+          test: test
+      spec:
+        host: route111
+        tls:
+          insecureEdgeTerminationPolicy: Redirect
+          termination: edge
+        to:
+          kind: Service
+          name: component-sample
+          weight: 100
+      status: {}
+  name: kubernetes-deploy
+metadata:
+  name: java-springboot
+schemaVersion: 2.2.0`
+
 	kubernetesInlinedDevfileSvc := `
 commands:
 - apply:
@@ -2793,6 +2860,45 @@ schemaVersion: 2.2.0`
 		{
 			name:          "Simple devfile from Inline with only route",
 			devfileString: kubernetesInlinedDevfileRoute,
+			componentName: "component-sample",
+			appName:       "application-sample",
+			image:         "image1",
+			wantRoute: routev1.Route{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Route",
+					APIVersion: "route.openshift.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "component-sample",
+					Labels: map[string]string{
+						"app.kubernetes.io/created-by": "application-service",
+						"app.kubernetes.io/instance":   "component-sample",
+						"app.kubernetes.io/managed-by": "kustomize",
+						"app.kubernetes.io/name":       "component-sample",
+						"app.kubernetes.io/part-of":    "application-sample",
+						"test":                         "test",
+					},
+				},
+				Spec: routev1.RouteSpec{
+					Host: "route111222",
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.FromInt(5566),
+					},
+					To: routev1.RouteTargetReference{
+						Kind:   "Service",
+						Name:   "component-sample",
+						Weight: &weight,
+					},
+					TLS: &routev1.TLSConfig{
+						Termination:                   routev1.TLSTerminationEdge,
+						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+					},
+				},
+			},
+		},
+		{
+			name:          "Simple devfile from Inline with only route, no targetport - should not panic",
+			devfileString: kubernetesInlinedDevfileRouteNoTargetPort,
 			componentName: "component-sample",
 			appName:       "application-sample",
 			image:         "image1",


### PR DESCRIPTION
### What does this PR do?:
Prevents HAS from panicking when it parses Component routes that have a nil `spec.Port`.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-381

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
