### PR TITLE
[RHTAPBUGS-418]multiple components with context path

### DIFF
--- a/controllers/componentdetectionquery_controller_test.go
+++ b/controllers/componentdetectionquery_controller_test.go
@@ -1505,6 +1505,60 @@ var _ = Describe("Component Detection Query controller", func() {
 			})
 		})
 
+		Context("Create Component Detection Query with multi comp repo with no devfiles and context path set", func() {
+			It("Should successfully get the correct devfiles and Dockerfiles", func() {
+				ctx := context.Background()
+
+				queryName := HASCompDetQuery + "multicontext" + "29"
+
+				hasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "appstudio.redhat.com/v1alpha1",
+						Kind:       "ComponentDetectionQuery",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      queryName,
+						Namespace: HASNamespace,
+					},
+					Spec: appstudiov1alpha1.ComponentDetectionQuerySpec{
+						GitSource: appstudiov1alpha1.GitSource{
+							URL:     "https://github.com/stuartwdouglas/multi-components-none-path",
+							Context: "context",
+						},
+					},
+				}
+
+				Expect(k8sClient.Create(ctx, hasCompDetectionQuery)).Should(Succeed())
+
+				// Look up the has app resource that was created.
+				// num(conditions) may still be < 1 on the first try, so retry until at least _some_ condition is set
+				hasCompDetQueryLookupKey := types.NamespacedName{Name: queryName, Namespace: HASNamespace}
+				createdHasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{}
+				Eventually(func() bool {
+					k8sClient.Get(context.Background(), hasCompDetQueryLookupKey, createdHasCompDetectionQuery)
+					return len(createdHasCompDetectionQuery.Status.Conditions) > 1
+				}, timeout, interval).Should(BeTrue())
+
+				// Make sure the a devfile is detected
+				Expect(len(createdHasCompDetectionQuery.Status.ComponentDetected)).Should(Equal(2))
+
+				for devfileName, devfileDesc := range createdHasCompDetectionQuery.Status.ComponentDetected {
+					Expect(devfileName).Should(Or(ContainSubstring("java-springboot"), ContainSubstring("python")))
+					Expect(devfileDesc.ComponentStub.Source.GitSource.Context).Should(BeElementOf([]string{"context/devfile-sample-java-springboot-basic", "context/devfile-sample-python-basic"}))
+					if strings.Contains(devfileName, "java-springboot") {
+						Expect(devfileDesc.ComponentStub.Source.GitSource.DevfileURL).Should(Equal("https://raw.githubusercontent.com/devfile-samples/devfile-sample-java-springboot-basic/main/devfile.yaml"))
+						Expect(devfileDesc.ComponentStub.Source.GitSource.DockerfileURL).Should(Equal("https://raw.githubusercontent.com/devfile-samples/devfile-sample-java-springboot-basic/main/docker/Dockerfile"))
+					} else if strings.Contains(devfileName, "python") {
+						Expect(devfileDesc.ComponentStub.Source.GitSource.DevfileURL).Should(Equal("https://raw.githubusercontent.com/devfile-samples/devfile-sample-python-basic/main/devfile.yaml"))
+						Expect(devfileDesc.ComponentStub.Source.GitSource.DockerfileURL).Should(Equal("https://raw.githubusercontent.com/devfile-samples/devfile-sample-python-basic/main/docker/Dockerfile"))
+					}
+				}
+
+				// Delete the specified Detection Query resource
+				deleteCompDetQueryCR(hasCompDetQueryLookupKey)
+			})
+		})
+
 		Context("Create Component Detection Query with repo that cannot find and dockerfile or devfile match", func() {
 			It("Should successfully return the CDQ", func() {
 				ctx := context.Background()

--- a/pkg/devfile/detect.go
+++ b/pkg/devfile/detect.go
@@ -47,7 +47,6 @@ type AlizerClient struct {
 // Map 3 returns a context to the Dockerfile uri or a matched DockerfileURL from the devfile registry if no Dockerfile is present in the context
 // Map 4 returns a context to the list of ports that were detected by alizer in the source code, at that given context
 func search(log logr.Logger, a Alizer, localpath string, devfileRegistryURL string, source appstudiov1alpha1.GitSource) (map[string][]byte, map[string]string, map[string]string, map[string][]int, error) {
-
 	devfileMapFromRepo := make(map[string][]byte)
 	devfilesURLMapFromRepo := make(map[string]string)
 	dockerfileContextMapFromRepo := make(map[string]string)
@@ -63,7 +62,8 @@ func search(log logr.Logger, a Alizer, localpath string, devfileRegistryURL stri
 			isDevfilePresent := false
 			isDockerfilePresent := false
 			curPath := path.Join(localpath, f.Name())
-			context := f.Name()
+			dirName := f.Name()
+			context := path.Join(source.Context, f.Name())
 			files, err := ioutil.ReadDir(curPath)
 			if err != nil {
 				return nil, nil, nil, nil, err
@@ -74,7 +74,7 @@ func search(log logr.Logger, a Alizer, localpath string, devfileRegistryURL stri
 					/* #nosec G304 -- false positive, filename is not based on user input*/
 					devfilePath := path.Join(curPath, f.Name())
 					// Set the proper devfile URL for the detected devfile
-					updatedLink, err := UpdateGitLink(source.URL, source.Revision, path.Join(source.Context, path.Join(context, f.Name())))
+					updatedLink, err := UpdateGitLink(source.URL, source.Revision, path.Join(source.Context, path.Join(dirName, f.Name())))
 					if err != nil {
 						return nil, nil, nil, nil, err
 					}
@@ -105,7 +105,7 @@ func search(log logr.Logger, a Alizer, localpath string, devfileRegistryURL stri
 							devfilePath := path.Join(hiddenDirPath, f.Name())
 
 							// Set the proper devfile URL for the detected devfile
-							updatedLink, err := UpdateGitLink(source.URL, source.Revision, path.Join(source.Context, path.Join(context, HiddenDevfileDir, f.Name())))
+							updatedLink, err := UpdateGitLink(source.URL, source.Revision, path.Join(source.Context, path.Join(dirName, HiddenDevfileDir, f.Name())))
 							if err != nil {
 								return nil, nil, nil, nil, err
 							}

--- a/pkg/devfile/devfile.go
+++ b/pkg/devfile/devfile.go
@@ -851,6 +851,7 @@ func DownloadDevfileAndDockerfile(url string) ([]byte, string, []byte, string) {
 // Map 3 returns a context to the Dockerfile uri or a matched DockerfileURL from the devfile registry if no Dockerfile/Containerfile is present in the context
 // Map 4 returns a context to the list of ports that were detected by alizer in the source code, at that given context
 func ScanRepo(log logr.Logger, a Alizer, localpath string, devfileRegistryURL string, source appstudiov1alpha1.GitSource) (map[string][]byte, map[string]string, map[string]string, map[string][]int, error) {
+
 	return search(log, a, localpath, devfileRegistryURL, source)
 }
 


### PR DESCRIPTION
Test for [RHTAPBUGS-418](https://issues.redhat.com//browse/RHTAPBUGS-418)

### What does this PR do?:
Test for an issue I saw in the UI where importing a project with multiple components and a context path set results in the context path going missing.

I could not get this test to run locally as all the detection tests are timing out for me.

### Which issue(s)/story(ies) does this PR fixes:

https://issues.redhat.com/browse/RHTAPBUGS-418

