### PR TITLE
[DEVHAS-374] update HAS rate limiting metrics dashboard

### DIFF
--- a/config/monitoring/grafana-dashboards/has-rate-limiting-metrics.json
+++ b/config/monitoring/grafana-dashboards/has-rate-limiting-metrics.json
@@ -24,10 +24,24 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 14,
-  "iteration": 1684247965309,
+  "id": 9,
+  "iteration": 1687197580165,
   "links": [],
   "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 112,
+      "panels": [],
+      "title": "Overall Rate Limiting Git Operations per hour",
+      "type": "row"
+    },
     {
       "datasource": null,
       "description": "Git operations that have underlying go-github API calls.  Sum across all controllers and all tokens over an interval of 1 hr",
@@ -49,7 +63,7 @@
               "tooltip": false
             },
             "lineInterpolation": "linear",
-            "lineWidth": 2,
+            "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
@@ -67,7 +81,7 @@
               },
               {
                 "color": "red",
-                "value": 50000
+                "value": 80
               }
             ]
           },
@@ -79,7 +93,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 1
       },
       "id": 48,
       "options": {
@@ -97,17 +111,17 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(increase(controller_git_request{operation=\"GenerateNewRepository\"}[1h]))",
+          "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"GenerateNewRepository\"}[1h]))",
           "interval": "",
-          "legendFormat": "GenerateNewRepository",
+          "legendFormat": "App_GenerateNewRepository",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "sum(increase(controller_git_request{operation=\"DeleteRepository\"}[1h]))",
+          "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"DeleteRepository\"}[1h]))",
           "hide": false,
           "interval": "",
-          "legendFormat": "DeleteRepository",
+          "legendFormat": "App_DeleteRepository",
           "refId": "B"
         },
         {
@@ -156,95 +170,77 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 11
       },
       "id": 46,
       "panels": [
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Approximate Primary Rate Limits",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 11
+            "y": 12
           },
+          "hiddenSeries": false,
           "id": 50,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateNewRepository\", tokenName=\"token1\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"GenerateNewRepository\", tokenName=\"token1\"}[1h])) by (operation)",
+              "instant": false,
               "interval": "",
-              "legendFormat": "GenerateNewRepository",
+              "legendFormat": "App_GenerateNewRepository",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"DeleteRepository\", tokenName=\"token1\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"DeleteRepository\", tokenName=\"token1\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "DeleteRepository",
+              "legendFormat": "App_DeleteRepository",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token1\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token1\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetDefaultBranchFromURL",
@@ -252,7 +248,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\",operation=\"GetBranchFromURL\", tokenName=\"token1\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token1\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetBranchFromURL",
@@ -260,7 +256,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token1\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token1\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetDefaultBranchFromURL",
@@ -268,103 +264,121 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token1\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token1\"}[1h])) by (operation) ",
               "hide": false,
               "interval": "",
-              "legendFormat": "Comp_GetDefaultBranchFromURL",
+              "legendFormat": "Comp_GetBranchFromURL",
               "refId": "F"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token1",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Approximate Primary Rate Limits",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 11
+            "y": 12
           },
+          "hiddenSeries": false,
           "id": 52,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateNewRepository\", tokenName=\"token2\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"GenerateNewRepository\", tokenName=\"token2\"}[1h])) by (operation)",
               "interval": "",
-              "legendFormat": "GenerateNewRepository",
+              "legendFormat": "App_GenerateNewRepository",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"DeleteRepository\", tokenName=\"token2\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"DeleteRepository\", tokenName=\"token2\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "DeleteRepository",
+              "legendFormat": "App_DeleteRepository",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token2\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token2\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetDefaultBranchFromURL",
@@ -372,7 +386,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token2\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token2\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetBranchFromURL",
@@ -380,7 +394,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token2\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token2\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetDefaultBranchFromURL",
@@ -388,103 +402,120 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token2\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token2\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetBranchFromURL",
               "refId": "F"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token2",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Approximate Primary Rate Limits",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 19
+            "y": 20
           },
+          "hiddenSeries": false,
           "id": 51,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateNewRepository\", tokenName=\"token3\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"GenerateNewRepository\", tokenName=\"token3\"}[1h])) by (operation) ",
               "interval": "",
-              "legendFormat": "GenerateNewRepository",
+              "legendFormat": "App_GenerateNewRepository",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"DeleteRepository\", tokenName=\"token3\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"DeleteRepository\", tokenName=\"token3\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "DeleteRepository",
+              "legendFormat": "App_DeleteRepository",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\",operation=\"GetDefaultBranchFromURL\", tokenName=\"token3\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\",operation=\"GetDefaultBranchFromURL\", tokenName=\"token3\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetDefaultBranchFromURL",
@@ -492,7 +523,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token3\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token3\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetBranchFromURL",
@@ -500,7 +531,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token3\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token3\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetDefaultBranchFromURL",
@@ -508,103 +539,121 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token3\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token3\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetBranchFromURL",
               "refId": "F"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token3",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Approximate Primary Rate Limits",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 19
+            "y": 20
           },
+          "hiddenSeries": false,
           "id": 53,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateNewRepository\", tokenName=\"token4\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"GenerateNewRepository\", tokenName=\"token4\"}[1h])) by (operation) ",
               "interval": "",
-              "legendFormat": "GenerateNewRepository",
+              "legendFormat": "App_GenerateNewRepository",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"DeleteRepository\", tokenName=\"token4\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"DeleteRepository\", tokenName=\"token4\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "DeleteRepository",
+              "legendFormat": "App_DeleteRepository",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GetDefaultBranchFromURL\", tokenName=\"token4\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\",operation=\"GetDefaultBranchFromURL\", tokenName=\"token4\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetDefaultBranchFromURL",
@@ -612,7 +661,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GetBranchFromURL\", tokenName=\"token4\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token4\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetBranchFromURL",
@@ -620,7 +669,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token4\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token4\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetDefaultBranchFromURL",
@@ -628,103 +677,120 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token4\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token4\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetBranchFromURL",
               "refId": "F"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token4",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Approximate Primary Rate Limits",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27
+            "y": 28
           },
+          "hiddenSeries": false,
           "id": 54,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateNewRepository\", tokenName=\"token5\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"GenerateNewRepository\", tokenName=\"token5\"}[1h])) by (operation)",
               "interval": "",
-              "legendFormat": "GenerateNewRepository",
+              "legendFormat": "App_GenerateNewRepository",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"DeleteRepository\", tokenName=\"token5\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"DeleteRepository\", tokenName=\"token5\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "DeleteRepository",
+              "legendFormat": "App_DeleteRepository",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token5\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token5\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetDefaultBranchFromURL",
@@ -732,7 +798,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token5\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token5\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetBranchFromURL",
@@ -740,7 +806,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token5\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token5\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetDefaultBranchFromURL",
@@ -748,103 +814,120 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token5\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token5\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetBranchFromURL",
               "refId": "F"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token5",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Approximate Primary Rate Limits",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 27
+            "y": 28
           },
+          "hiddenSeries": false,
           "id": 55,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateNewRepository\", tokenName=\"token6\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"GenerateNewRepository\", tokenName=\"token6\"}[1h])) by (operation)",
               "interval": "",
-              "legendFormat": "GenerateNewRepository",
+              "legendFormat": "App_GenerateNewRepository",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"DeleteRepository\", tokenName=\"token6\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"DeleteRepository\", tokenName=\"token6\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "DeleteRepository",
+              "legendFormat": "App_DeleteRepository",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token6\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token6\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetDefaultBranchFromURL",
@@ -852,7 +935,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token6\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token6\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetBranchFromURL",
@@ -860,7 +943,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token6\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token6\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetDefaultBranchFromURL",
@@ -868,103 +951,120 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token6\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token6\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetBranchFromURL",
               "refId": "F"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token6",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Approximate Primary Rate Limits",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 36
           },
+          "hiddenSeries": false,
           "id": 57,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateNewRepository\", tokenName=\"token7\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"GenerateNewRepository\", tokenName=\"token7\"}[1h])) by (operation)",
               "interval": "",
-              "legendFormat": "GenerateNewRepository",
+              "legendFormat": "App_GenerateNewRepository",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"DeleteRepository\", tokenName=\"token7\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"DeleteRepository\", tokenName=\"token7\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "DeleteRepository",
+              "legendFormat": "App_DeleteRepository",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token7\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token7\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetDefaultBranchFromURL",
@@ -972,7 +1072,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token7\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token7\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetBranchFromURL",
@@ -980,7 +1080,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token7\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token7\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetDefaultBranchFromURL",
@@ -988,103 +1088,120 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token7\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token7\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetBranchFromURL",
               "refId": "F"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token7",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Approximate Primary Rate Limits",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 36
           },
+          "hiddenSeries": false,
           "id": 56,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateNewRepository\", tokenName=\"token8\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"GenerateNewRepository\", tokenName=\"token8\"}[1h])) by (operation)",
               "interval": "",
-              "legendFormat": "GenerateNewRepository",
+              "legendFormat": "App_GenerateNewRepository",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"DeleteRepository\", tokenName=\"token8\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"DeleteRepository\", tokenName=\"token8\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "DeleteRepository",
+              "legendFormat": "App_DeleteRepository",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token8\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token8\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetDefaultBranchFromURL",
@@ -1092,7 +1209,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token8\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token8\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetBranchFromURL",
@@ -1100,7 +1217,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token8\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token8\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetDefaultBranchFromURL",
@@ -1108,17 +1225,53 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token8\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token8\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetBranchFromURL",
               "refId": "F"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token8",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "datasource": null,
@@ -1141,7 +1294,7 @@
                   "tooltip": false
                 },
                 "lineInterpolation": "linear",
-                "lineWidth": 2,
+                "lineWidth": 1,
                 "pointSize": 5,
                 "scaleDistribution": {
                   "type": "linear"
@@ -1159,7 +1312,7 @@
                   },
                   {
                     "color": "red",
-                    "value": 5000
+                    "value": 80
                   }
                 ]
               },
@@ -1171,7 +1324,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 43
+            "y": 44
           },
           "id": 58,
           "options": {
@@ -1189,22 +1342,22 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateNewRepository\", tokenName=\"token9\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"GenerateNewRepository\", tokenName=\"token9\"}[1h])) by (operation)",
               "interval": "",
-              "legendFormat": "GenerateNewRepository",
+              "legendFormat": "App_GenerateNewRepository",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"DeleteRepository\", tokenName=\"token9\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"DeleteRepository\", tokenName=\"token9\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "DeleteRepository",
+              "legendFormat": "App_DeleteRepository",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token9\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token9\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetDefaultBranchFromURL",
@@ -1212,7 +1365,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token9\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token9\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetBranchFromURL",
@@ -1220,7 +1373,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token9\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token9\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetDefaultBranchFromURL",
@@ -1228,7 +1381,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token9\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token9\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetBranchFromURL",
@@ -1241,90 +1394,71 @@
           "type": "timeseries"
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Approximate Primary Rate Limits",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 43
+            "y": 44
           },
+          "hiddenSeries": false,
           "id": 59,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateNewRepository\", tokenName=\"token10\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"GenerateNewRepository\", tokenName=\"token10\"}[1h])) by (operation)",
               "interval": "",
-              "legendFormat": "GenerateNewRepository",
+              "legendFormat": "App_GenerateNewRepository",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"DeleteRepository\", tokenName=\"token10\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"DeleteRepository\", tokenName=\"token10\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "DeleteRepository",
+              "legendFormat": "App_DeleteRepository",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token10\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token10\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetDefaultBranchFromURL",
@@ -1332,7 +1466,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token10\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token10\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetBranchFromURL",
@@ -1340,7 +1474,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token10\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token10\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetDefaultBranchFromURL",
@@ -1348,17 +1482,53 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token10\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token10\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetBranchFromURL",
               "refId": "F"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token10",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
       "title": "Rate Limiting Git Operations per token per hour",
@@ -1371,95 +1541,76 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 11
+        "y": 12
       },
       "id": 61,
       "panels": [
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Approximate Secondary Rate Limits",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 100
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 12
+            "y": 13
           },
+          "hiddenSeries": false,
           "id": 62,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateNewRepository\", tokenName=\"token1\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"GenerateNewRepository\", tokenName=\"token1\"}[5m])) by (operation)",
               "interval": "",
-              "legendFormat": "GenerateNewRepository",
+              "legendFormat": "App_GenerateNewRepository",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"DeleteRepository\", tokenName=\"token1\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"DeleteRepository\", tokenName=\"token1\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "DeleteRepository",
+              "legendFormat": "App_DeleteRepository",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\",operation=\"GetDefaultBranchFromURL\", tokenName=\"token1\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\",operation=\"GetDefaultBranchFromURL\", tokenName=\"token1\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetDefaultBranchFromURL",
@@ -1467,7 +1618,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token1\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token1\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetBranchFromURL",
@@ -1475,7 +1626,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token1\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token1\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetDefaultBranchFromURL",
@@ -1483,103 +1634,120 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token1\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token1\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetBranchFromURL",
               "refId": "F"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token1",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Approximate Secondary Rate Limits",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 100
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 12
+            "y": 13
           },
+          "hiddenSeries": false,
           "id": 63,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateNewRepository\", tokenName=\"token2\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"GenerateNewRepository\", tokenName=\"token2\"}[5m])) by (operation)",
               "interval": "",
-              "legendFormat": "GenerateNewRepository",
+              "legendFormat": "App_GenerateNewRepository",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"DeleteRepository\", tokenName=\"token2\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"DeleteRepository\", tokenName=\"token2\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "DeleteRepository",
+              "legendFormat": "App_DeleteRepository",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token2\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token2\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetDefaultBranchFromURL",
@@ -1587,7 +1755,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token2\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token2\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetBranchFromURL",
@@ -1595,7 +1763,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token2\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token2\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetDefaultBranchFromURL",
@@ -1603,103 +1771,120 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token2\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token2\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetBranchFromURL",
               "refId": "F"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token2",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Approximate Secondary Rate Limits",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 100
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 20
+            "y": 21
           },
+          "hiddenSeries": false,
           "id": 65,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateNewRepository\", tokenName=\"token3\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"GenerateNewRepository\", tokenName=\"token3\"}[5m])) by (operation)",
               "interval": "",
-              "legendFormat": "GenerateNewRepository",
+              "legendFormat": "App_GenerateNewRepository",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"DeleteRepository\", tokenName=\"token3\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\",operation=\"DeleteRepository\", tokenName=\"token3\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "DeleteRepository",
+              "legendFormat": "App_DeleteRepository",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token3\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token3\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetDefaultBranchFromURL",
@@ -1707,7 +1892,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token3\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token3\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetBranchFromURL",
@@ -1715,7 +1900,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token3\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token3\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetDefaultBranchFromURL",
@@ -1723,103 +1908,120 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token3\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token3\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetBranchFromURL",
               "refId": "F"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token3",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Approximate Secondary Rate Limits",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 100
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 20
+            "y": 21
           },
+          "hiddenSeries": false,
           "id": 64,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateNewRepository\", tokenName=\"token4\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"GenerateNewRepository\", tokenName=\"token4\"}[5m])) by (operation)",
               "interval": "",
-              "legendFormat": "GenerateNewRepository",
+              "legendFormat": "App_GenerateNewRepository",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"DeleteRepository\", tokenName=\"token4\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"DeleteRepository\", tokenName=\"token4\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "DeleteRepository",
+              "legendFormat": "App_DeleteRepository",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token4\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token4\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetDefaultBranchFromURL",
@@ -1827,7 +2029,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token4\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token4\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetBranchFromURL",
@@ -1835,7 +2037,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token4\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token4\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetDefaultBranchFromURL",
@@ -1843,103 +2045,120 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token4\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token4\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetBranchFromURL",
               "refId": "F"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token4",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Approximate Secondary Rate Limits",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 100
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 28
+            "y": 29
           },
+          "hiddenSeries": false,
           "id": 66,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateNewRepository\", tokenName=\"token5\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"GenerateNewRepository\", tokenName=\"token5\"}[5m])) by (operation)",
               "interval": "",
-              "legendFormat": "GenerateNewRepository",
+              "legendFormat": "App_GenerateNewRepository",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"DeleteRepository\", tokenName=\"token5\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"DeleteRepository\", tokenName=\"token5\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "DeleteRepository",
+              "legendFormat": "App_DeleteRepository",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token5\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token5\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetDefaultBranchFromURL",
@@ -1947,7 +2166,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token5\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token5\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetBranchFromURL",
@@ -1955,7 +2174,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token5\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token5\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetDefaultBranchFromURL",
@@ -1963,103 +2182,120 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token5\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token5\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetBranchFromURL",
               "refId": "F"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token5",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Approximate Secondary Rate Limits",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 100
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 28
+            "y": 29
           },
+          "hiddenSeries": false,
           "id": 67,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateNewRepository\", tokenName=\"token6\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"GenerateNewRepository\", tokenName=\"token6\"}[5m])) by (operation)",
               "interval": "",
-              "legendFormat": "GenerateNewRepository",
+              "legendFormat": "App_GenerateNewRepository",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"DeleteRepository\", tokenName=\"token6\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"DeleteRepository\", tokenName=\"token6\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "DeleteRepository",
+              "legendFormat": "App_DeleteRepository",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token6\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token6\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetDefaultBranchFromURL",
@@ -2067,7 +2303,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\",operation=\"GetBranchFromURL\", tokenName=\"token6\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\",operation=\"GetBranchFromURL\", tokenName=\"token6\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetBranchFromURL",
@@ -2075,7 +2311,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token6\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token6\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetDefaultBranchFromURL",
@@ -2083,103 +2319,120 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\",operation=\"GetBranchFromURL\", tokenName=\"token6\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\",operation=\"GetBranchFromURL\", tokenName=\"token6\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetBranchFromURL",
               "refId": "F"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token6",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Approximate Secondary Rate Limits",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 100
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 36
+            "y": 37
           },
+          "hiddenSeries": false,
           "id": 68,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateNewRepository\", tokenName=\"token7\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"GenerateNewRepository\", tokenName=\"token7\"}[5m])) by (operation)",
               "interval": "",
-              "legendFormat": "GenerateNewRepository",
+              "legendFormat": "App_GenerateNewRepository",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"DeleteRepository\", tokenName=\"token7\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"DeleteRepository\", tokenName=\"token7\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "DeleteRepository",
+              "legendFormat": "App_DeleteRepository",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token7\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token7\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetDefaultBranchFromURL",
@@ -2187,7 +2440,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\",operation=\"GetBranchFromURL\", tokenName=\"token7\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\",operation=\"GetBranchFromURL\", tokenName=\"token7\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetBranchFromURL",
@@ -2195,7 +2448,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token7\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token7\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetDefaultBranchFromURL",
@@ -2203,103 +2456,120 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\",operation=\"GetBranchFromURL\", tokenName=\"token7\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\",operation=\"GetBranchFromURL\", tokenName=\"token7\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetBranchFromURL",
               "refId": "F"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token7",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Approximate Secondary Rate Limits",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 100
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 36
+            "y": 37
           },
+          "hiddenSeries": false,
           "id": 69,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateNewRepository\", tokenName=\"token8\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"GenerateNewRepository\", tokenName=\"token8\"}[5m])) by (operation)",
               "interval": "",
-              "legendFormat": "GenerateNewRepository",
+              "legendFormat": "App_GenerateNewRepository",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"DeleteRepository\", tokenName=\"token8\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"DeleteRepository\", tokenName=\"token8\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "DeleteRepository",
+              "legendFormat": "App_DeleteRepository",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token8\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token8\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetDefaultBranchFromURL",
@@ -2307,7 +2577,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token8\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token8\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetBranchFromURL",
@@ -2315,7 +2585,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token8\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token8\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetDefaultBranchFromURL",
@@ -2323,103 +2593,120 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token8\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token8\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetBranchFromURL",
               "refId": "F"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token8",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Approximate Secondary Rate Limits",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 100
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 44
+            "y": 45
           },
+          "hiddenSeries": false,
           "id": 70,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateNewRepository\", tokenName=\"token9\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"GenerateNewRepository\", tokenName=\"token9\"}[5m])) by (operation)",
               "interval": "",
-              "legendFormat": "GenerateNewRepository",
+              "legendFormat": "App_GenerateNewRepository",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"DeleteRepository\", tokenName=\"token9\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"DeleteRepository\", tokenName=\"token9\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "DeleteRepository",
+              "legendFormat": "App_DeleteRepository",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token9\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token9\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetDefaultBranchFromURL",
@@ -2427,7 +2714,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token9\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token9\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetBranchFromURL",
@@ -2435,7 +2722,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token9\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token9\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetDefaultBranchFromURL",
@@ -2443,103 +2730,120 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token9\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token9\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetBranchFromURL",
               "refId": "F"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token9",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Approximate Secondary Rate Limits",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 100
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 44
+            "y": 45
           },
+          "hiddenSeries": false,
           "id": 71,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateNewRepository\", tokenName=\"token10\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Application\", operation=\"GenerateNewRepository\", tokenName=\"token10\"}[5m])) by (operation)",
               "interval": "",
-              "legendFormat": "GenerateNewRepository",
+              "legendFormat": "App_GenerateNewRepository",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"DeleteRepository\", tokenName=\"token10\"}[5m])",
+              "expr": "sum(increase(controller_git_request{ontroller=\"Application\", operation=\"DeleteRepository\", tokenName=\"token10\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "DeleteRepository",
+              "legendFormat": "App_DeleteRepository",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token10\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token10\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetDefaultBranchFromURL",
@@ -2547,7 +2851,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token10\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"ComponentDetectionQuery\", operation=\"GetBranchFromURL\", tokenName=\"token10\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "CDQ_GetBranchFromURL",
@@ -2555,7 +2859,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token10\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetDefaultBranchFromURL\", tokenName=\"token10\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetDefaultBranchFromURL",
@@ -2563,20 +2867,650 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token10\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetBranchFromURL\", tokenName=\"token10\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Comp_GetBranchFromURL",
               "refId": "F"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token10",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
       "title": "Rate Limiting Git Operations per token per 5min",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 98,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "The sum of tokens primary or secondary rate limited over the course of an hour",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 54
+          },
+          "hiddenSeries": false,
+          "id": 102,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(increase(token_pool_gauge{rateLimited=\"primary\"}[1h]))",
+              "interval": "",
+              "legendFormat": "primary_rate_limited",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(token_pool_gauge{rateLimited=\"secondary\"}[1h]))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "secondary_rate_limited",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Sum of All Tokens Rate Limited over an hour",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "datasource": null,
+          "description": "The number of tokens left in the token pool over the course of an hour",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 3
+                  },
+                  {
+                    "color": "#6ED0E0",
+                    "value": 5
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 62
+          },
+          "id": 107,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "text": {}
+          },
+          "pluginVersion": "7.5.17",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "10-sum(increase(token_pool_gauge{rateLimited=\"primary\"}[1h]))",
+              "interval": "",
+              "legendFormat": "Available Tokens",
+              "refId": "A"
+            }
+          ],
+          "title": "Available Tokens - Not Primary Rate Limited",
+          "type": "gauge"
+        },
+        {
+          "datasource": null,
+          "description": "The number of tokens left in the token pool over 5m",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 3
+                  },
+                  {
+                    "color": "#6ED0E0",
+                    "value": 5
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 62
+          },
+          "id": 108,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "text": {}
+          },
+          "pluginVersion": "7.5.17",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "10-sum(increase(token_pool_gauge{rateLimited=\"secondary\"}[5m]))",
+              "interval": "",
+              "legendFormat": "Available Tokens",
+              "refId": "A"
+            }
+          ],
+          "title": "Available Tokens - Not Secondary Rate Limited",
+          "type": "gauge"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Tokens that have been primary rate limited  over the course of an hour.  ",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 70
+          },
+          "hiddenSeries": false,
+          "id": 104,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(increase(token_pool_gauge{rateLimited=\"primary\",tokenName=\"token1\"}[1h])) by (tokenName)",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "token1",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(token_pool_gauge{rateLimited=\"primary\",tokenName=\"token2\"}[1h])) by (tokenName)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "token2",
+              "refId": "B"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(token_pool_gauge{rateLimited=\"primary\",tokenName=\"token3\"}[1h])) by (tokenName)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "token3",
+              "refId": "C"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(token_pool_gauge{rateLimited=\"primary\",tokenName=\"token4\"}[1h])) by (tokenName)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "token4",
+              "refId": "D"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(token_pool_gauge{rateLimited=\"primary\",tokenName=\"token5\"}[1h])) by (tokenName)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "token5",
+              "refId": "E"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(token_pool_gauge{rateLimited=\"primary\",tokenName=\"token6\"}[1h])) by (tokenName)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "token6",
+              "refId": "F"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(token_pool_gauge{rateLimited=\"primary\",tokenName=\"token7\"}[1h])) by (tokenName)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "token7",
+              "refId": "G"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(token_pool_gauge{rateLimited=\"primary\",tokenName=\"token8\"}[1h])) by (tokenName)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "token8",
+              "refId": "H"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(token_pool_gauge{rateLimited=\"primary\",tokenName=\"token9\"}[1h])) by (tokenName)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "token9",
+              "refId": "I"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(token_pool_gauge{rateLimited=\"primary\",tokenName=\"token10\"}[1h])) by (tokenName)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "token10",
+              "refId": "J"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Primary Rate limited Tokens",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Tokens that have been secondary rate limited  over 5m intervals",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 70
+          },
+          "hiddenSeries": false,
+          "id": 105,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(increase(token_pool_gauge{rateLimited=\"secondary\",tokenName=\"token1\"}[5m])) by (tokenName)",
+              "interval": "",
+              "legendFormat": "token1",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(token_pool_gauge{rateLimited=\"secondary\",tokenName=\"token2\"}[5m])) by (tokenName)",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "token2",
+              "refId": "B"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(token_pool_gauge{rateLimited=\"secondary\",tokenName=\"token3\"}[5m])) by (tokenName)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "token3",
+              "refId": "C"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(token_pool_gauge{rateLimited=\"secondary\",tokenName=\"token4\"}[5m])) by (tokenName)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "token4",
+              "refId": "D"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(token_pool_gauge{rateLimited=\"secondary\",tokenName=\"token5\"}[5m])) by (tokenName)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "token5",
+              "refId": "E"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(token_pool_gauge{rateLimited=\"secondary\",tokenName=\"token6\"}[5m])) by (tokenName)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "token6",
+              "refId": "F"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(token_pool_gauge{rateLimited=\"secondary\",tokenName=\"token7\"}[5m])) by (tokenName)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "token7",
+              "refId": "G"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(token_pool_gauge{rateLimited=\"secondary\",tokenName=\"token8\"}[5m])) by (tokenName)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "token8",
+              "refId": "H"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(token_pool_gauge{rateLimited=\"secondary\",tokenName=\"token9\"}[5m])) by (tokenName)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "token9",
+              "refId": "I"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(token_pool_gauge{rateLimited=\"secondary\",tokenName=\"token10\"}[5m])) by (tokenName)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "token10",
+              "refId": "J"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Secondary Rate limited Tokens",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Token Pool Metrics",
       "type": "row"
     },
     {
@@ -2586,11 +3520,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 14
       },
-      "id": 98,
+      "id": 114,
       "panels": [],
-      "title": "Token Pool Metrics",
+      "title": "Overall Git CLI Operations per hour",
       "type": "row"
     },
     {
@@ -2599,7 +3533,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "The sum of tokens primary or secondary rate limited over the course of an hour",
+      "description": "The number of Git CLI operations across all controllers and tokens per hour",
       "fieldConfig": {
         "defaults": {
           "unit": "short"
@@ -2609,13 +3543,13 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 15
       },
       "hiddenSeries": false,
-      "id": 102,
+      "id": 110,
       "legend": {
         "avg": false,
         "current": false,
@@ -2643,495 +3577,49 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(increase(token_pool{rateLimited=\"primary\"}[1h]))",
+          "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\"}[1h]))",
           "interval": "",
-          "legendFormat": "primary_rate_limited",
+          "legendFormat": "ASEB_GetCommitIDFromRepo",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "sum(increase(token_pool{rateLimited=\"secondary\"}[1h]))",
+          "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\"}[1h]))",
           "hide": false,
           "interval": "",
-          "legendFormat": "secondary_rate_limited",
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Sum of All Tokens Rate Limited over an hour",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "datasource": null,
-      "description": "The number of tokens left in the token pool over the course of an hour",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 2
-              },
-              {
-                "color": "#EAB839",
-                "value": 3
-              },
-              {
-                "color": "#6ED0E0",
-                "value": 5
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 21
-      },
-      "id": 107,
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "text": {}
-      },
-      "pluginVersion": "7.5.17",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "10-sum(increase(token_pool{rateLimited=\"primary\"}[1h]))",
-          "interval": "",
-          "legendFormat": "Available Tokens",
-          "refId": "A"
-        }
-      ],
-      "title": "Available Tokens - Not Primary Rate Limited",
-      "type": "gauge"
-    },
-    {
-      "datasource": null,
-      "description": "The number of tokens left in the token pool over an hour",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 2
-              },
-              {
-                "color": "#EAB839",
-                "value": 3
-              },
-              {
-                "color": "#6ED0E0",
-                "value": 5
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 21
-      },
-      "id": 108,
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "text": {}
-      },
-      "pluginVersion": "7.5.17",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "10-sum(increase(token_pool{rateLimited=\"secondary\"}[1h]))",
-          "interval": "",
-          "legendFormat": "Available Tokens",
-          "refId": "A"
-        }
-      ],
-      "title": "Available Tokens - Not Secondary Rate Limited",
-      "type": "gauge"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "description": "Tokens that have been primary rate limited  over the course of an hour.  ",
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 29
-      },
-      "hiddenSeries": false,
-      "id": 104,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.5.17",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "increase(token_pool{rateLimited=\"primary\",tokenName=\"token1\"}[1h])",
-          "interval": "",
-          "legendFormat": "token1",
-          "refId": "A"
-        },
-        {
-          "exemplar": true,
-          "expr": "increase(token_pool{rateLimited=\"primary\",tokenName=\"token2\"}[1h])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "token2",
+          "legendFormat": "Comp_GetCommitIDFromRepo",
           "refId": "B"
         },
         {
           "exemplar": true,
-          "expr": "increase(token_pool{rateLimited=\"primary\",tokenName=\"token3\"}[1h])",
+          "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CloneGenerateAndPush\"}[1h]))",
           "hide": false,
           "interval": "",
-          "legendFormat": "token3",
+          "legendFormat": "Comp_CloneGenerateAndPush",
           "refId": "C"
         },
         {
           "exemplar": true,
-          "expr": "increase(token_pool{rateLimited=\"primary\",tokenName=\"token4\"}[1h])",
+          "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GenerateOverlaysAndPush\"}[1h]))",
           "hide": false,
           "interval": "",
-          "legendFormat": "token4",
+          "legendFormat": "ASEB_GenerateOverlaysAndPush",
           "refId": "D"
         },
         {
           "exemplar": true,
-          "expr": "increase(token_pool{rateLimited=\"primary\",tokenName=\"token5\"}[1h])",
+          "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CommitAndPush\"}[1h]))",
           "hide": false,
           "interval": "",
-          "legendFormat": "token5",
+          "legendFormat": "Comp_CommitAndPush",
           "refId": "E"
-        },
-        {
-          "exemplar": true,
-          "expr": "increase(token_pool{rateLimited=\"primary\",tokenName=\"token6\"}[1h])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "token6",
-          "refId": "F"
-        },
-        {
-          "exemplar": true,
-          "expr": "increase(token_pool{rateLimited=\"primary\",tokenName=\"token7\"}[1h])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "token7",
-          "refId": "G"
-        },
-        {
-          "exemplar": true,
-          "expr": "increase(token_pool{rateLimited=\"primary\",tokenName=\"token8\"}[1h])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "token8",
-          "refId": "H"
-        },
-        {
-          "exemplar": true,
-          "expr": "increase(token_pool{rateLimited=\"primary\",tokenName=\"token9\"}[1h])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "token9",
-          "refId": "I"
-        },
-        {
-          "exemplar": true,
-          "expr": "increase(token_pool{rateLimited=\"primary\",tokenName=\"token10\"}[1h])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "token110",
-          "refId": "J"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Primary Rate limited Tokens",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "description": "Tokens that have been secondary rate limited  over the course of an hour.  ",
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 29
-      },
-      "hiddenSeries": false,
-      "id": 105,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.5.17",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "increase(token_pool{rateLimited=\"secondary\",tokenName=\"token1\"}[1h])",
-          "interval": "",
-          "legendFormat": "token1",
-          "refId": "A"
-        },
-        {
-          "exemplar": true,
-          "expr": "increase(token_pool{rateLimited=\"secondary\",tokenName=\"token2\"}[1h])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "token2",
-          "refId": "B"
-        },
-        {
-          "exemplar": true,
-          "expr": "increase(token_pool{rateLimited=\"secondary\",tokenName=\"token3\"}[1h])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "token3",
-          "refId": "C"
-        },
-        {
-          "exemplar": true,
-          "expr": "increase(token_pool{rateLimited=\"secondary\",tokenName=\"token4\"}[1h])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "token4",
-          "refId": "D"
-        },
-        {
-          "exemplar": true,
-          "expr": "increase(token_pool{rateLimited=\"secondary\",tokenName=\"token5\"}[1h])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "token5",
-          "refId": "E"
-        },
-        {
-          "exemplar": true,
-          "expr": "increase(token_pool{rateLimited=\"secondary\",tokenName=\"token6\"}[1h])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "token6",
-          "refId": "F"
-        },
-        {
-          "exemplar": true,
-          "expr": "increase(token_pool{rateLimited=\"secondary\",tokenName=\"token7\"}[1h])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "token7",
-          "refId": "G"
-        },
-        {
-          "exemplar": true,
-          "expr": "increase(token_pool{rateLimited=\"secondary\",tokenName=\"token8\"}[1h])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "token8",
-          "refId": "H"
-        },
-        {
-          "exemplar": true,
-          "expr": "increase(token_pool{rateLimited=\"secondary\",tokenName=\"token9\"}[1h])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "token9",
-          "refId": "I"
-        },
-        {
-          "exemplar": true,
-          "expr": "increase(token_pool{rateLimited=\"secondary\",tokenName=\"token10\"}[1h])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "token110",
-          "refId": "J"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Secondary Rate limited Tokens",
+      "title": "Overall Git CLI Operations per hour",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -3175,80 +3663,61 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 37
+        "y": 24
       },
       "id": 73,
       "panels": [
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Non Rate limiting Git Operations per hour",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 13
+            "y": 25
           },
+          "hiddenSeries": false,
           "id": 75,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token1\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token1\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "ASEB_GetCommitIDFromRepo",
@@ -3256,112 +3725,129 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token1\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token1\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Component_GetCommitIDFromRepo",
+              "legendFormat": "Comp_GetCommitIDFromRepo",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CloneGenerateAndPush\", tokenName=\"token1\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CloneGenerateAndPush\", tokenName=\"token1\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CloneGenerateAndPush",
+              "legendFormat": "Comp_CloneGenerateAndPush",
               "refId": "C"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateOverlaysAndPush\", tokenName=\"token1\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GenerateOverlaysAndPush\", tokenName=\"token1\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "GenerateOverlaysAndPush",
+              "legendFormat": "ASEB_GenerateOverlaysAndPush",
               "refId": "D"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CommitAndPush\", tokenName=\"token1\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CommitAndPush\", tokenName=\"token1\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CommitAndPush",
+              "legendFormat": "Comp_CommitAndPush",
               "refId": "E"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token1",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Non Rate limiting Git Operations per hour",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 13
+            "y": 25
           },
+          "hiddenSeries": false,
           "id": 76,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token2\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token2\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "ASEB_GetCommitIDFromRepo",
@@ -3369,112 +3855,129 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token2\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token2\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Component_GetCommitIDFromRepo",
+              "legendFormat": "Comp_GetCommitIDFromRepo",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CloneGenerateAndPush\", tokenName=\"token2\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CloneGenerateAndPush\", tokenName=\"token2\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CloneGenerateAndPush",
+              "legendFormat": "Comp_CloneGenerateAndPush",
               "refId": "C"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateOverlaysAndPush\", tokenName=\"token2\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GenerateOverlaysAndPush\", tokenName=\"token2\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "GenerateOverlaysAndPush",
+              "legendFormat": "ASEB_GenerateOverlaysAndPush",
               "refId": "D"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CommitAndPush\", tokenName=\"token2\"}[1h])",
+              "expr": " sum(increase(controller_git_request{controller=\"Component\",operation=\"CommitAndPush\", tokenName=\"token2\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CommitAndPush",
+              "legendFormat": "Comp_CommitAndPush",
               "refId": "E"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token2",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Non Rate limiting Git Operations per hour",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 21
+            "y": 33
           },
+          "hiddenSeries": false,
           "id": 77,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token3\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token3\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "ASEB_GetCommitIDFromRepo",
@@ -3482,112 +3985,129 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token3\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token3\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Component_GetCommitIDFromRepo",
+              "legendFormat": "Comp_GetCommitIDFromRepo",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CloneGenerateAndPush\", tokenName=\"token3\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CloneGenerateAndPush\", tokenName=\"token3\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CloneGenerateAndPush",
+              "legendFormat": "Comp_CloneGenerateAndPush",
               "refId": "C"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateOverlaysAndPush\", tokenName=\"token3\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GenerateOverlaysAndPush\", tokenName=\"token3\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "GenerateOverlaysAndPush",
+              "legendFormat": "ASEB_GenerateOverlaysAndPush",
               "refId": "D"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CommitAndPush\", tokenName=\"token3\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CommitAndPush\", tokenName=\"token3\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CommitAndPush",
+              "legendFormat": "Comp_CommitAndPush",
               "refId": "E"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token3",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Non Rate limiting Git Operations per hour",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 21
+            "y": 33
           },
+          "hiddenSeries": false,
           "id": 78,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token4\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token4\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "ASEB_GetCommitIDFromRepo",
@@ -3595,112 +4115,129 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token4\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token4\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Component_GetCommitIDFromRepo",
+              "legendFormat": "Comp_GetCommitIDFromRepo",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CloneGenerateAndPush\", tokenName=\"token4\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CloneGenerateAndPush\", tokenName=\"token4\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CloneGenerateAndPush",
+              "legendFormat": "Comp_CloneGenerateAndPush",
               "refId": "C"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateOverlaysAndPush\", tokenName=\"token4\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GenerateOverlaysAndPush\", tokenName=\"token4\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "GenerateOverlaysAndPush",
+              "legendFormat": "ASEB_GenerateOverlaysAndPush",
               "refId": "D"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CommitAndPush\", tokenName=\"token4\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CommitAndPush\", tokenName=\"token4\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CommitAndPush",
+              "legendFormat": "Comp_CommitAndPush",
               "refId": "E"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token4",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Non Rate limiting Git Operations per hour",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 29
+            "y": 41
           },
+          "hiddenSeries": false,
           "id": 79,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token5\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token5\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "ASEB_GetCommitIDFromRepo",
@@ -3708,112 +4245,129 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token5\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token5\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Component_GetCommitIDFromRepo",
+              "legendFormat": "Comp_GetCommitIDFromRepo",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CloneGenerateAndPush\", tokenName=\"token5\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CloneGenerateAndPush\", tokenName=\"token5\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CloneGenerateAndPush",
+              "legendFormat": "Comp_CloneGenerateAndPush",
               "refId": "C"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateOverlaysAndPush\", tokenName=\"token5\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GenerateOverlaysAndPush\", tokenName=\"token5\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "GenerateOverlaysAndPush",
+              "legendFormat": "ASEB_GenerateOverlaysAndPush",
               "refId": "D"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CommitAndPush\", tokenName=\"token5\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CommitAndPush\", tokenName=\"token5\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CommitAndPush",
+              "legendFormat": "Comp_CommitAndPush",
               "refId": "E"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token5",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Non Rate limiting Git Operations per hour",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 29
+            "y": 41
           },
+          "hiddenSeries": false,
           "id": 80,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token6\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token6\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "ASEB_GetCommitIDFromRepo",
@@ -3821,112 +4375,129 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token6\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token6\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Component_GetCommitIDFromRepo",
+              "legendFormat": "Comp_GetCommitIDFromRepo",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CloneGenerateAndPush\", tokenName=\"token6\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CloneGenerateAndPush\", tokenName=\"token6\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CloneGenerateAndPush",
+              "legendFormat": "Comp_CloneGenerateAndPush",
               "refId": "C"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateOverlaysAndPush\", tokenName=\"token6\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GenerateOverlaysAndPush\", tokenName=\"token6\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "GenerateOverlaysAndPush",
+              "legendFormat": "ASEB_GenerateOverlaysAndPush",
               "refId": "D"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CommitAndPush\", tokenName=\"token6\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CommitAndPush\", tokenName=\"token6\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CommitAndPush",
+              "legendFormat": "Comp_CommitAndPush",
               "refId": "E"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token6",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Non Rate limiting Git Operations per hour",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 37
+            "y": 49
           },
+          "hiddenSeries": false,
           "id": 81,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token7\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token7\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "ASEB_GetCommitIDFromRepo",
@@ -3934,112 +4505,129 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token7\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token7\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Component_GetCommitIDFromRepo",
+              "legendFormat": "Comp_GetCommitIDFromRepo",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CloneGenerateAndPush\", tokenName=\"token7\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CloneGenerateAndPush\", tokenName=\"token7\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CloneGenerateAndPush",
+              "legendFormat": "Comp_CloneGenerateAndPush",
               "refId": "C"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateOverlaysAndPush\", tokenName=\"token7\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GenerateOverlaysAndPush\", tokenName=\"token7\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "GenerateOverlaysAndPush",
+              "legendFormat": "ASEB_GenerateOverlaysAndPush",
               "refId": "D"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CommitAndPush\", tokenName=\"token7\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CommitAndPush\", tokenName=\"token7\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CommitAndPush",
+              "legendFormat": "Comp_CommitAndPush",
               "refId": "E"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token7",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Non Rate limiting Git Operations per hour",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 37
+            "y": 49
           },
+          "hiddenSeries": false,
           "id": 82,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token8\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token8\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "ASEB_GetCommitIDFromRepo",
@@ -4047,7 +4635,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token8\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token8\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Component_GetCommitIDFromRepo",
@@ -4055,104 +4643,121 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CloneGenerateAndPush\", tokenName=\"token8\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CloneGenerateAndPush\", tokenName=\"token8\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CloneGenerateAndPush",
+              "legendFormat": "Comp_CloneGenerateAndPush",
               "refId": "C"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateOverlaysAndPush\", tokenName=\"token8\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GenerateOverlaysAndPush\", tokenName=\"token8\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "GenerateOverlaysAndPush",
+              "legendFormat": "ASEB_GenerateOverlaysAndPush",
               "refId": "D"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CommitAndPush\", tokenName=\"token8\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CommitAndPush\", tokenName=\"token8\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CommitAndPush",
+              "legendFormat": "Comp_CommitAndPush",
               "refId": "E"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token8",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Non Rate limiting Git Operations per hour",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 45
+            "y": 57
           },
+          "hiddenSeries": false,
           "id": 83,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token9\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token9\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "ASEB_GetCommitIDFromRepo",
@@ -4160,112 +4765,129 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token9\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token9\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Component_GetCommitIDFromRepo",
+              "legendFormat": "Comp_GetCommitIDFromRepo",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CloneGenerateAndPush\", tokenName=\"token9\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CloneGenerateAndPush\", tokenName=\"token9\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CloneGenerateAndPush",
+              "legendFormat": "Comp_CloneGenerateAndPush",
               "refId": "C"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateOverlaysAndPush\", tokenName=\"token9\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GenerateOverlaysAndPush\", tokenName=\"token9\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "GenerateOverlaysAndPush",
+              "legendFormat": "ASEB_GenerateOverlaysAndPush",
               "refId": "D"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CommitAndPush\", tokenName=\"token9\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CommitAndPush\", tokenName=\"token9\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CommitAndPush",
+              "legendFormat": "Comp_CommitAndPush",
               "refId": "E"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token9",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Non Rate limiting Git Operations per hour",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 45
+            "y": 57
           },
+          "hiddenSeries": false,
           "id": 84,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token10\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token10\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "ASEB_GetCommitIDFromRepo",
@@ -4273,44 +4895,80 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token10\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token10\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Component_GetCommitIDFromRepo",
+              "legendFormat": "Comp_GetCommitIDFromRepo",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CloneGenerateAndPush\", tokenName=\"token10\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CloneGenerateAndPush\", tokenName=\"token10\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CloneGenerateAndPush",
+              "legendFormat": "Comp_CloneGenerateAndPush",
               "refId": "C"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateOverlaysAndPush\", tokenName=\"token10\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GenerateOverlaysAndPush\", tokenName=\"token10\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "GenerateOverlaysAndPush",
+              "legendFormat": "ASEB_GenerateOverlaysAndPush",
               "refId": "D"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CommitAndPush\", tokenName=\"token10\"}[1h])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CommitAndPush\", tokenName=\"token10\"}[1h])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CommitAndPush",
+              "legendFormat": "Comp_CommitAndPush",
               "refId": "E"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token10",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
-      "title": "Non Rate Limiting Git Operations per token per hour",
+      "title": "Git CLI Operations per token per hour",
       "type": "row"
     },
     {
@@ -4320,80 +4978,61 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 25
       },
       "id": 86,
       "panels": [
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Non Rate limiting Git Operations per 5m",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 14
+            "y": 26
           },
+          "hiddenSeries": false,
           "id": 87,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token1\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token1\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "ASEB_GetCommitIDFromRepo",
@@ -4401,112 +5040,129 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token1\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token1\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Component_GetCommitIDFromRepo",
+              "legendFormat": "Comp_GetCommitIDFromRepo",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CloneGenerateAndPush\", tokenName=\"token1\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CloneGenerateAndPush\", tokenName=\"token1\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CloneGenerateAndPush",
+              "legendFormat": "Comp_CloneGenerateAndPush",
               "refId": "C"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateOverlaysAndPush\", tokenName=\"token1\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GenerateOverlaysAndPush\", tokenName=\"token1\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "GenerateOverlaysAndPush",
+              "legendFormat": "ASEB_GenerateOverlaysAndPush",
               "refId": "D"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CommitAndPush\", tokenName=\"token1\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CommitAndPush\", tokenName=\"token1\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CommitAndPush",
+              "legendFormat": "Comp_CommitAndPush",
               "refId": "E"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token1",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Non Rate limiting Git Operations per 5m",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 14
+            "y": 26
           },
+          "hiddenSeries": false,
           "id": 88,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token2\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token2\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "ASEB_GetCommitIDFromRepo",
@@ -4514,112 +5170,129 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token2\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token2\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Component_GetCommitIDFromRepo",
+              "legendFormat": "Comp_GetCommitIDFromRepo",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CloneGenerateAndPush\", tokenName=\"token2\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CloneGenerateAndPush\", tokenName=\"token2\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CloneGenerateAndPush",
+              "legendFormat": "Comp_CloneGenerateAndPush",
               "refId": "C"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateOverlaysAndPush\", tokenName=\"token2\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GenerateOverlaysAndPush\", tokenName=\"token2\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "GenerateOverlaysAndPush",
+              "legendFormat": "ASEB_GenerateOverlaysAndPush",
               "refId": "D"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CommitAndPush\", tokenName=\"token2\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CommitAndPush\", tokenName=\"token2\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CommitAndPush",
+              "legendFormat": "Comp_CommitAndPush",
               "refId": "E"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token2",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Non Rate limiting Git Operations per 5m",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 22
+            "y": 34
           },
+          "hiddenSeries": false,
           "id": 89,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token3\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token3\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "ASEB_GetCommitIDFromRepo",
@@ -4627,7 +5300,7 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token3\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token3\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "Component_GetCommitIDFromRepo",
@@ -4635,104 +5308,121 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CloneGenerateAndPush\", tokenName=\"token3\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CloneGenerateAndPush\", tokenName=\"token3\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CloneGenerateAndPush",
+              "legendFormat": "Comp_CloneGenerateAndPush",
               "refId": "C"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateOverlaysAndPush\", tokenName=\"token3\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\",operation=\"GenerateOverlaysAndPush\", tokenName=\"token3\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "GenerateOverlaysAndPush",
+              "legendFormat": "ASEB_GenerateOverlaysAndPush",
               "refId": "D"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CommitAndPush\", tokenName=\"token3\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CommitAndPush\", tokenName=\"token3\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CommitAndPush",
+              "legendFormat": "Comp_CommitAndPush",
               "refId": "E"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token3",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Non Rate limiting Git Operations per 5m",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 22
+            "y": 34
           },
+          "hiddenSeries": false,
           "id": 90,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token4\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token4\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "ASEB_GetCommitIDFromRepo",
@@ -4740,112 +5430,129 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token4\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token4\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Component_GetCommitIDFromRepo",
+              "legendFormat": "Comp_GetCommitIDFromRepo",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CloneGenerateAndPush\", tokenName=\"token4\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CloneGenerateAndPush\", tokenName=\"token4\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CloneGenerateAndPush",
+              "legendFormat": "Comp_CloneGenerateAndPush",
               "refId": "C"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateOverlaysAndPush\", tokenName=\"token4\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\",operation=\"GenerateOverlaysAndPush\", tokenName=\"token4\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "GenerateOverlaysAndPush",
+              "legendFormat": "ASEB_GenerateOverlaysAndPush",
               "refId": "D"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CommitAndPush\", tokenName=\"token4\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CommitAndPush\", tokenName=\"token4\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CommitAndPush",
+              "legendFormat": "Comp_CommitAndPush",
               "refId": "E"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token4",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Non Rate limiting Git Operations per 5m",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 30
+            "y": 42
           },
+          "hiddenSeries": false,
           "id": 91,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token5\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token5\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "ASEB_GetCommitIDFromRepo",
@@ -4853,112 +5560,129 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token5\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token5\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Component_GetCommitIDFromRepo",
+              "legendFormat": "Comp_GetCommitIDFromRepo",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CloneGenerateAndPush\", tokenName=\"token5\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CloneGenerateAndPush\", tokenName=\"token5\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CloneGenerateAndPush",
+              "legendFormat": "Comp_CloneGenerateAndPush",
               "refId": "C"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateOverlaysAndPush\", tokenName=\"token5\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GenerateOverlaysAndPush\", tokenName=\"token5\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "GenerateOverlaysAndPush",
+              "legendFormat": "ASEB_GenerateOverlaysAndPush",
               "refId": "D"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CommitAndPush\", tokenName=\"token5\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CommitAndPush\", tokenName=\"token5\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CommitAndPush",
+              "legendFormat": "Comp_CommitAndPush",
               "refId": "E"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token5",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Non Rate limiting Git Operations per 5m",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 30
+            "y": 42
           },
+          "hiddenSeries": false,
           "id": 92,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token6\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token6\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "ASEB_GetCommitIDFromRepo",
@@ -4966,112 +5690,129 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token6\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token6\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Component_GetCommitIDFromRepo",
+              "legendFormat": "Comp_GetCommitIDFromRepo",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CloneGenerateAndPush\", tokenName=\"token6\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CloneGenerateAndPush\", tokenName=\"token6\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CloneGenerateAndPush",
+              "legendFormat": "Comp_CloneGenerateAndPush",
               "refId": "C"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateOverlaysAndPush\", tokenName=\"token6\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GenerateOverlaysAndPush\", tokenName=\"token6\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "GenerateOverlaysAndPush",
+              "legendFormat": "ASEB_GenerateOverlaysAndPush",
               "refId": "D"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CommitAndPush\", tokenName=\"token6\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CommitAndPush\", tokenName=\"token6\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CommitAndPush",
+              "legendFormat": "Comp_CommitAndPush",
               "refId": "E"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token6",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Non Rate limiting Git Operations per 5m",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 38
+            "y": 50
           },
+          "hiddenSeries": false,
           "id": 93,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token7\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token7\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "ASEB_GetCommitIDFromRepo",
@@ -5079,112 +5820,129 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token7\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token7\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Component_GetCommitIDFromRepo",
+              "legendFormat": "Comp_GetCommitIDFromRepo",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CloneGenerateAndPush\", tokenName=\"token7\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CloneGenerateAndPush\", tokenName=\"token7\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CloneGenerateAndPush",
+              "legendFormat": "Comp_CloneGenerateAndPush",
               "refId": "C"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateOverlaysAndPush\", tokenName=\"token7\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GenerateOverlaysAndPush\", tokenName=\"token7\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "GenerateOverlaysAndPush",
+              "legendFormat": "ASEB_GenerateOverlaysAndPush",
               "refId": "D"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CommitAndPush\", tokenName=\"token7\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CommitAndPush\", tokenName=\"token7\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CommitAndPush",
+              "legendFormat": "Comp_CommitAndPush",
               "refId": "E"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token7",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Non Rate limiting Git Operations per 5m",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 38
+            "y": 50
           },
+          "hiddenSeries": false,
           "id": 94,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token8\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token8\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "ASEB_GetCommitIDFromRepo",
@@ -5192,112 +5950,129 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token8\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token8\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Component_GetCommitIDFromRepo",
+              "legendFormat": "Comp_GetCommitIDFromRepo",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CloneGenerateAndPush\", tokenName=\"token8\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CloneGenerateAndPush\", tokenName=\"token8\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CloneGenerateAndPush",
+              "legendFormat": "Comp_CloneGenerateAndPush",
               "refId": "C"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateOverlaysAndPush\", tokenName=\"token8\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GenerateOverlaysAndPush\", tokenName=\"token8\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "GenerateOverlaysAndPush",
+              "legendFormat": "ASEB_GenerateOverlaysAndPush",
               "refId": "D"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CommitAndPush\", tokenName=\"token8\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CommitAndPush\", tokenName=\"token8\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CommitAndPush",
+              "legendFormat": "Comp_CommitAndPush",
               "refId": "E"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token8",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Non Rate limiting Git Operations per 5m",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 46
+            "y": 58
           },
+          "hiddenSeries": false,
           "id": 95,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token9\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token9\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "ASEB_GetCommitIDFromRepo",
@@ -5305,112 +6080,129 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token9\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token9\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Component_GetCommitIDFromRepo",
+              "legendFormat": "Comp_GetCommitIDFromRepo",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CloneGenerateAndPush\", tokenName=\"token9\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CloneGenerateAndPush\", tokenName=\"token9\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CloneGenerateAndPush",
+              "legendFormat": "Comp_CloneGenerateAndPush",
               "refId": "C"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateOverlaysAndPush\", tokenName=\"token9\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GenerateOverlaysAndPush\", tokenName=\"token9\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "GenerateOverlaysAndPush",
+              "legendFormat": "ASEB_GenerateOverlaysAndPush",
               "refId": "D"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CommitAndPush\", tokenName=\"token9\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CommitAndPush\", tokenName=\"token9\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CommitAndPush",
+              "legendFormat": "Comp_CommitAndPush",
               "refId": "E"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token9",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "description": "Non Rate limiting Git Operations per 5m",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 5000
-                  }
-                ]
-              },
               "unit": "short"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 46
+            "y": 58
           },
+          "hiddenSeries": false,
           "id": 96,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
           "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token10\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GetCommitIDFromRepo\", tokenName=\"token10\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
               "legendFormat": "ASEB_GetCommitIDFromRepo",
@@ -5418,44 +6210,80 @@
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token10\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"GetCommitIDFromRepo\", tokenName=\"token10\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Component_GetCommitIDFromRepo",
+              "legendFormat": "Comp_GetCommitIDFromRepo",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CloneGenerateAndPush\", tokenName=\"token10\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CloneGenerateAndPush\", tokenName=\"token10\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CloneGenerateAndPush",
+              "legendFormat": "Comp_CloneGenerateAndPush",
               "refId": "C"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"GenerateOverlaysAndPush\", tokenName=\"token10\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"SnapshotEnvironmentBinding\", operation=\"GenerateOverlaysAndPush\", tokenName=\"token10\"}[5m])) by (operation)",
               "hide": false,
               "interval": "",
-              "legendFormat": "GenerateOverlaysAndPush",
+              "legendFormat": "ASEB_GenerateOverlaysAndPush",
               "refId": "D"
             },
             {
               "exemplar": true,
-              "expr": "increase(controller_git_request{operation=\"CommitAndPush\", tokenName=\"token10\"}[5m])",
+              "expr": "sum(increase(controller_git_request{controller=\"Component\", operation=\"CommitAndPush\", tokenName=\"token10\"}[5m])) by (oepration)",
               "hide": false,
               "interval": "",
-              "legendFormat": "CommitAndPush",
+              "legendFormat": "Comp_CommitAndPush",
               "refId": "E"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Token10",
-          "type": "timeseries"
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
-      "title": "Non Rate Limiting Git Operations per token per 5m",
+      "title": "Git CLI Operations per token per 5m",
       "type": "row"
     }
   ],
@@ -5468,8 +6296,8 @@
       {
         "current": {
           "selected": false,
-          "text": "Prometheus",
-          "value": "Prometheus"
+          "text": "prometheus-appstudio-ds",
+          "value": "prometheus-appstudio-ds"
         },
         "description": null,
         "error": null,
@@ -5489,12 +6317,12 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-12h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "HAS Rate Limiting Metrics",
   "uid": "3e0a9e533b362be65d8262d0297eadb1576a5b8c",
-  "version": 28
+  "version": 1
 }


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

-    Added an Overall Git CLI Operations chart, similar to the one for Overall Rate Limiting operations
-    Updated the Token Pool Metrics chart queries to use token_pool_gauge
-    Updated query labels to have the format controller_operation instead of operation so it's clear which operation is called by which controller
-    Updated all queries to eliminate duplicate labels.  Since HAS has 3 pods, we could see 3 occurrences of the same label  depending on which pod has been active.  In order to ensure labels were unique, I had to change the queries to follow the format sum(query) by (operation or tokenName)


### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
https://issues.redhat.com/browse/DEVHAS-374

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:

