### PR TITLE
Update local test execution flow.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,12 +142,19 @@ gosec:
 lint:
 	golangci-lint --version
 	GOMAXPROCS=2 golangci-lint run --fix --verbose --timeout 300s
+	
+unit-tests: 
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" SKIP_PACT_TESTS=true go test ./... -coverprofile cover.out -v
 
-test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out -v
+pact-tests: 
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -v --run TestContracts 
 
 pact: manifests generate fmt vet envtest ## Run just Pact tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -v --run TestContracts 
+	make pact-tests
+
+test: manifests generate fmt vet envtest ## Run tests.
+	make unit-tests
+	make pact-tests
 
 ##@ Build
 

--- a/controllers/application_pact_test.go
+++ b/controllers/application_pact_test.go
@@ -48,6 +48,10 @@ func TestContracts(t *testing.T) {
 		BrokerPassword:             "pactCommonPassword123",
 	}
 
+	if os.Getenv("SKIP_PACT_TESTS") == "true" {
+		t.Skip("Skipping Pact tests as SKIP_PACT_TESTS is set to true.")
+	}
+
 	// setup credentials and publishing
 	if os.Getenv("PR_CHECK") == "true" {
 		if os.Getenv("COMMIT_SHA") == "" {


### PR DESCRIPTION
### What does this PR do?:
Separate unit and pact test runs during local development to make the debugging simpler.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/HAC-4269

### How to test changes / Special notes to the reviewer:
To test those changes, run `make test` locally and see first running the unit test suite and then the Pact test suite.