### PR TITLE
[RHTAPBUGS-442] Properly clean up cloned repositories in error states

### DIFF
--- a/pkg/util/ioutils/ioutils.go
+++ b/pkg/util/ioutils/ioutils.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/afero"
 )
 
@@ -55,4 +56,13 @@ func IsExisting(fs afero.Fs, path string) (bool, error) {
 // CreateTempPath creates a temp path with the prefix using the Afero FS
 func CreateTempPath(prefix string, appFs afero.Afero) (string, error) {
 	return appFs.TempDir(os.TempDir(), prefix)
+}
+
+// RemoveFolderAndLogError removes the specified folder. If the delete fails, no error is returned, but an error is logged
+// Used in cases where
+func RemoveFolderAndLogError(log logr.Logger, fs afero.Fs, path string) {
+	err := fs.RemoveAll(path)
+	if err != nil {
+		log.Error(err, fmt.Sprintf("Unable to delete folder %s", path))
+	}
 }

--- a/pkg/util/ioutils/ioutils.go
+++ b/pkg/util/ioutils/ioutils.go
@@ -59,7 +59,7 @@ func CreateTempPath(prefix string, appFs afero.Afero) (string, error) {
 }
 
 // RemoveFolderAndLogError removes the specified folder. If the delete fails, no error is returned, but an error is logged
-// Used in cases where
+// Used in cases where we're cleaning up after encountering an error, but want to return the original error instead.
 func RemoveFolderAndLogError(log logr.Logger, fs afero.Fs, path string) {
 	err := fs.RemoveAll(path)
 	if err != nil {

--- a/pkg/util/ioutils/ioutils_test.go
+++ b/pkg/util/ioutils/ioutils_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 func TestIsExisting(t *testing.T) {
@@ -150,6 +152,41 @@ func TestCreateTempPath(t *testing.T) {
 					t.Errorf("TestCreateTempPath unexpected error: %v", err)
 				}
 			}
+		})
+	}
+}
+
+func TestRemoveFolderAndLogError(t *testing.T) {
+	fs := NewFilesystem()
+	inmemoryFs := NewMemoryFilesystem()
+	readOnlyFs := NewReadOnlyFs()
+
+	tests := []struct {
+		name string
+		fs   afero.Afero
+	}{
+		{
+			name: "inmemory fs",
+			fs:   inmemoryFs,
+		},
+		{
+			name: "read only fs",
+			fs:   readOnlyFs,
+		},
+		{
+			name: "local fs",
+			fs:   fs,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, _ := CreateTempPath("TestCreateTempPath", tt.fs)
+			log := zap.New(zap.UseFlagOptions(&zap.Options{
+				Development: true,
+				TimeEncoder: zapcore.ISO8601TimeEncoder,
+			}))
+			RemoveFolderAndLogError(log, tt.fs, path)
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?:
This PR ensures that HAS properly cleans up git repositories that it clones, when HAS encounters an error, before it usually cleans up the Git repository. 

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/RHTAPBUGS-442

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
