### PR TITLE
[RHTAPBUGS-462] Always update the SEB status

### DIFF
--- a/controllers/applicationsnapshotenvironmentbinding_controller.go
+++ b/controllers/applicationsnapshotenvironmentbinding_controller.go
@@ -384,17 +384,6 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 
 		appSnapshotEnvBinding.Status.Components = append(appSnapshotEnvBinding.Status.Components, componentStatus)
 
-		// On OpenShift, we generate a unique route name for each Component, so include that in the status
-		if !isKubernetesCluster {
-			componentStatus.GeneratedRouteName = routeName
-		}
-
-		if _, ok := componentGeneratedResources[componentName]; ok {
-			componentStatus.GitOpsRepository.GeneratedResources = componentGeneratedResources[componentName]
-		}
-
-		appSnapshotEnvBinding.Status.Components = append(appSnapshotEnvBinding.Status.Components, componentStatus)
-
 		// Set the clone to false, since we dont want to clone the repo again for the other components
 		clone = false
 	}

--- a/controllers/applicationsnapshotenvironmentbinding_controller.go
+++ b/controllers/applicationsnapshotenvironmentbinding_controller.go
@@ -158,6 +158,7 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 	var tempDir string
 	clone := true
 
+	appSnapshotEnvBinding.Status.Components = []appstudiov1alpha1.BindingComponentStatus{}
 	for _, component := range components {
 		componentName := component.Name
 


### PR DESCRIPTION
### What does this PR do?:
This PR ensures that the SEB controller always updates the necessary status fields of the resource during each reconcile. This will ensure that status fields like the commit ID are kept up to date with what's generated in the gitops repository overlays.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/RHTAPBUGS-462
https://issues.redhat.com/browse/RHTAPBUGS-322

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
