### PR TITLE
[RHTAPBUGS-442 Redux] Ensure gitops repository is cleaned up in error states

### DIFF
--- a/controllers/applicationsnapshotenvironmentbinding_controller.go
+++ b/controllers/applicationsnapshotenvironmentbinding_controller.go
@@ -277,6 +277,7 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 			err := fmt.Errorf("application snapshot %s did not reference component %s", snapshotName, componentName)
 			log.Error(err, "")
 			ioutils.RemoveFolderAndLogError(log, r.AppFS, tempDir)
+			r.SetConditionAndUpdateCR(ctx, req, &appSnapshotEnvBinding, err)
 			return ctrl.Result{}, err
 		}
 

--- a/controllers/component_controller_finalizer.go
+++ b/controllers/component_controller_finalizer.go
@@ -86,6 +86,7 @@ func (r *ComponentReconciler) Finalize(ctx context.Context, component *appstudio
 	//Gitops functions return sanitized error messages
 	err = r.Generator.GitRemoveComponent(tempDir, gitOpsURL, component.Name, gitOpsBranch, gitOpsContext)
 	if err != nil {
+		ioutils.RemoveFolderAndLogError(r.Log, r.AppFS, tempDir)
 		return err
 	}
 

--- a/pkg/util/ioutils/ioutils.go
+++ b/pkg/util/ioutils/ioutils.go
@@ -61,8 +61,10 @@ func CreateTempPath(prefix string, appFs afero.Afero) (string, error) {
 // RemoveFolderAndLogError removes the specified folder. If the delete fails, no error is returned, but an error is logged
 // Used in cases where we're cleaning up after encountering an error, but want to return the original error instead.
 func RemoveFolderAndLogError(log logr.Logger, fs afero.Fs, path string) {
-	err := fs.RemoveAll(path)
-	if err != nil {
-		log.Error(err, fmt.Sprintf("Unable to delete folder %s", path))
+	if path != "" {
+		err := fs.RemoveAll(path)
+		if err != nil {
+			log.Error(err, fmt.Sprintf("Unable to delete folder %s", path))
+		}
 	}
 }

--- a/pkg/util/ioutils/ioutils_test.go
+++ b/pkg/util/ioutils/ioutils_test.go
@@ -164,6 +164,7 @@ func TestRemoveFolderAndLogError(t *testing.T) {
 	tests := []struct {
 		name string
 		fs   afero.Afero
+		path string
 	}{
 		{
 			name: "inmemory fs",
@@ -172,21 +173,29 @@ func TestRemoveFolderAndLogError(t *testing.T) {
 		{
 			name: "read only fs",
 			fs:   readOnlyFs,
+			path: "/somepath",
 		},
 		{
 			name: "local fs",
 			fs:   fs,
 		},
+		{
+			name: "empty path",
+			fs:   fs,
+			path: "",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			path, _ := CreateTempPath("TestCreateTempPath", tt.fs)
+			if tt.path == "" && tt.name != "empty path" {
+				tt.path, _ = CreateTempPath("TestCreateTempPath", tt.fs)
+			}
 			log := zap.New(zap.UseFlagOptions(&zap.Options{
 				Development: true,
 				TimeEncoder: zapcore.ISO8601TimeEncoder,
 			}))
-			RemoveFolderAndLogError(log, tt.fs, path)
+			RemoveFolderAndLogError(log, tt.fs, tt.path)
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?:
This PR fixes some leftover git clones that were not being cleaned up when an error occurred, in the Component finalizer and SEB controller.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/RHTAPBUGS-442

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
