### PR TITLE
[RHTAPBUGS-322] Properly update SEB status

### DIFF
--- a/controllers/applicationsnapshotenvironmentbinding_controller.go
+++ b/controllers/applicationsnapshotenvironmentbinding_controller.go
@@ -158,7 +158,6 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 	var tempDir string
 	clone := true
 
-	//appSnapshotEnvBinding.Status.Components = []appstudiov1alpha1.BindingComponentStatus{}
 	for _, component := range components {
 		componentName := component.Name
 
@@ -385,15 +384,15 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 			componentStatus.GitOpsRepository.GeneratedResources = componentGeneratedResources[componentName]
 		}
 
-		componentUpdated := false
+		isNewComponent := true
 		for i := range appSnapshotEnvBinding.Status.Components {
 			if appSnapshotEnvBinding.Status.Components[i].Name == componentStatus.Name {
 				appSnapshotEnvBinding.Status.Components[i] = componentStatus
-				componentUpdated = true
+				isNewComponent = false
 				break
 			}
 		}
-		if !componentUpdated {
+		if isNewComponent {
 			appSnapshotEnvBinding.Status.Components = append(appSnapshotEnvBinding.Status.Components, componentStatus)
 		}
 

--- a/controllers/applicationsnapshotenvironmentbinding_controller.go
+++ b/controllers/applicationsnapshotenvironmentbinding_controller.go
@@ -385,11 +385,16 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 			componentStatus.GitOpsRepository.GeneratedResources = componentGeneratedResources[componentName]
 		}
 
+		componentUpdated := false
 		for i := range appSnapshotEnvBinding.Status.Components {
 			if appSnapshotEnvBinding.Status.Components[i].Name == componentStatus.Name {
 				appSnapshotEnvBinding.Status.Components[i] = componentStatus
+				componentUpdated = true
 				break
 			}
+		}
+		if !componentUpdated {
+			appSnapshotEnvBinding.Status.Components = append(appSnapshotEnvBinding.Status.Components, componentStatus)
 		}
 
 		// Set the clone to false, since we dont want to clone the repo again for the other components

--- a/controllers/applicationsnapshotenvironmentbinding_controller.go
+++ b/controllers/applicationsnapshotenvironmentbinding_controller.go
@@ -158,7 +158,7 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 	var tempDir string
 	clone := true
 
-	appSnapshotEnvBinding.Status.Components = []appstudiov1alpha1.BindingComponentStatus{}
+	//appSnapshotEnvBinding.Status.Components = []appstudiov1alpha1.BindingComponentStatus{}
 	for _, component := range components {
 		componentName := component.Name
 
@@ -385,7 +385,12 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 			componentStatus.GitOpsRepository.GeneratedResources = componentGeneratedResources[componentName]
 		}
 
-		appSnapshotEnvBinding.Status.Components = append(appSnapshotEnvBinding.Status.Components, componentStatus)
+		for i := range appSnapshotEnvBinding.Status.Components {
+			if appSnapshotEnvBinding.Status.Components[i].Name == componentStatus.Name {
+				appSnapshotEnvBinding.Status.Components[i] = componentStatus
+				break
+			}
+		}
 
 		// Set the clone to false, since we dont want to clone the repo again for the other components
 		clone = false


### PR DESCRIPTION
### What does this PR do?:
Changes how we update the SEB status during reconciles to ensure the route name is always persisted. If we can do so without breaking other components, it would be best to change the `BindingComponent` array in the status to a map later on. 

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/RHTAPBUGS-322

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
