### PR TITLE
fix: update the application even if gitop fails

### DIFF
--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -159,6 +159,10 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			// only attempt to finalize and update the gitops repo if an Application is present & the previous Component status is good
 			// A finalizer is present for the Component CR, so make sure we do the necessary cleanup steps
 			if err := r.Finalize(ctx, &component, &hasApplication, ghClient); err != nil {
+				if errors.IsConflict(err) {
+					//conflict means we just retry, we are updating the shared application so conflicts are not unexpected
+					return ctrl.Result{}, err
+				}
 				// if fail to delete the external dependency here, log the error, but don't return error
 				// Don't want to get stuck in a cycle of repeatedly trying to update the repository and failing
 				log.Error(err, "Unable to update GitOps repository for component %v in namespace %v", component.GetName(), component.GetNamespace())


### PR DESCRIPTION
When deleting a component currently the Application will not be updated if the gitops deletion fails.

fixes [RHTAPBUGS-503](https://issues.redhat.com//browse/RHTAPBUGS-503)

### What does this PR do?:

Currently the finalizer for the component cleans up gitops and removes the component from the application devfile, however if the gitops fails the application is not updated.

Note that I am not 100% sure that this is the correct behavior, but it seems to make sense.

### Which issue(s)/story(ies) does this PR fixes:

https://issues.redhat.com/browse/RHTAPBUGS-503
