### PR TITLE
[DEVHAS-407] Detect branch from cloned repo

### DIFF
--- a/cdq-analysis/pkg/componentdetectionquery_test.go
+++ b/cdq-analysis/pkg/componentdetectionquery_test.go
@@ -96,6 +96,7 @@ language: JavaScript
 		wantDevfilesURLMap       map[string]string
 		wantDockerfileContextMap map[string]string
 		wantComponentsPortMap    map[string][]int
+		wantBranch               string
 	}{
 		{
 			testCase:            "repo with devfile - should successfully detect spring component",
@@ -109,6 +110,7 @@ language: JavaScript
 				"./": "https://raw.githubusercontent.com/devfile-samples/devfile-sample-java-springboot-basic/main/docker/Dockerfile",
 			},
 			wantComponentsPortMap: map[string][]int{},
+			wantBranch:            "main",
 		},
 		{
 			testCase:            "repo without devfile and dockerfile - should successfully detect spring component",
@@ -126,6 +128,7 @@ language: JavaScript
 				"./": "https://raw.githubusercontent.com/devfile-samples/devfile-sample-java-springboot-basic/main/docker/Dockerfile",
 			},
 			wantComponentsPortMap: map[string][]int{},
+			wantBranch:            "main",
 		},
 		{
 			testCase:                 "private repo - should error out with no token provided",
@@ -177,6 +180,7 @@ language: JavaScript
 				"python-src-none":             "https://raw.githubusercontent.com/devfile-samples/devfile-sample-python-basic/main/docker/Dockerfile",
 			},
 			wantComponentsPortMap: map[string][]int{},
+			wantBranch:            "main",
 		},
 		{
 			testCase:              "should successfully detect single component when context is provided",
@@ -191,12 +195,13 @@ language: JavaScript
 			wantDockerfileContextMap: map[string]string{
 				"devfile-sample-nodejs-basic": "https://raw.githubusercontent.com/nodeshift-starters/devfile-sample/main/Dockerfile",
 			},
+			wantBranch: "main",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.testCase, func(t *testing.T) {
-			devfilesMap, devfilesURLMap, dockerfileContextMap, componentsPortMap, err := CloneAndAnalyze(k8sClient, tt.gitToken, namespaceName, compName, tt.context, tt.devfilePath, "", tt.URL, tt.Revision, tt.DevfileRegistryURL, tt.isDevfilePresent, tt.isDockerfilePresent)
+			devfilesMap, devfilesURLMap, dockerfileContextMap, componentsPortMap, branch, err := CloneAndAnalyze(k8sClient, tt.gitToken, namespaceName, compName, tt.context, tt.devfilePath, "", tt.URL, tt.Revision, tt.DevfileRegistryURL, tt.isDevfilePresent, tt.isDockerfilePresent)
 			if (err != nil) != (tt.wantErr != "") {
 				t.Errorf("got unexpected error %v", err)
 			} else if err == nil {
@@ -222,6 +227,9 @@ language: JavaScript
 				}
 				if !reflect.DeepEqual(componentsPortMap, tt.wantComponentsPortMap) {
 					t.Errorf("Expected componentsPortMap: %+v, Got: %+v", tt.wantComponentsPortMap, componentsPortMap)
+				}
+				if branch != tt.wantBranch {
+					t.Errorf("Expected branch: %+v, Got: %+v", tt.wantBranch, branch)
 				}
 			} else if err != nil {
 				assert.Regexp(t, tt.wantErr, err.Error(), "Error message should match")

--- a/cdq-analysis/pkg/util.go
+++ b/cdq-analysis/pkg/util.go
@@ -71,6 +71,24 @@ func CloneRepo(clonePath, repoURL string, revision string, token string) error {
 	return nil
 }
 
+// GetBranchFromRepo gets the current branch from the cloned repository
+func GetBranchFromRepo(clonePath string) (string, error) {
+	// Command we want to run is: git rev-parse --abbrev-ref HEAD
+	c := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	c.Dir = clonePath
+
+	// Get the output of the command
+	branchBytes, err := c.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to get the branch from the repo: %v", err)
+	}
+	branch := string(branchBytes)
+
+	// Remove newline characters potentially present
+	branch = strings.Split(branch, "\n")[0]
+	return branch, nil
+}
+
 // CurlEndpoint curls the endpoint and returns the response or an error if the response is a non-200 status
 func CurlEndpoint(endpoint string) ([]byte, error) {
 	var respBytes []byte

--- a/cdq-analysis/pkg/util_test.go
+++ b/cdq-analysis/pkg/util_test.go
@@ -177,6 +177,59 @@ func TestCloneRepo(t *testing.T) {
 	}
 }
 
+func TestGetBranchFromRepo(t *testing.T) {
+	os.Mkdir("/tmp/alreadyexistingdir", 0755)
+
+	tests := []struct {
+		name      string
+		clonePath string
+		repo      string
+		revision  string
+		token     string
+		wantErr   bool
+		want      string
+	}{
+		{
+			name:      "Detect Successfully",
+			clonePath: "/tmp/testspringbootclone",
+			repo:      "https://github.com/devfile-samples/devfile-sample-java-springboot-basic",
+			want:      "main",
+		},
+		{
+			name:      "Detect alternate branch Successfully",
+			clonePath: "/tmp/testspringbootclonealt",
+			repo:      "https://github.com/devfile-samples/devfile-sample-java-springboot-basic",
+			revision:  "testbranch",
+			want:      "testbranch",
+		},
+		{
+			name:      "Repo not exist",
+			clonePath: "FDSFSDFSDFSDFjsdklfjsdklfjs",
+			repo:      "https://github.com/devfile-samples/devfile-sample-java-springboot-basic",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.RemoveAll(tt.clonePath)
+			if tt.name != "Repo not exist" {
+				CloneRepo(tt.clonePath, tt.repo, tt.revision, tt.token)
+			}
+
+			branch, err := GetBranchFromRepo(tt.clonePath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TestGetBranchFromRepo() unexpected error: %v", err)
+			}
+			if err != nil {
+				if branch != tt.want {
+					t.Errorf("TestGetBranchFromRepo() unexpected branch, expected %v got %v", tt.want, branch)
+				}
+			}
+		})
+	}
+}
+
 func TestConvertGitHubURL(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/controllers/componentdetectionquery_controller_test.go
+++ b/controllers/componentdetectionquery_controller_test.go
@@ -569,7 +569,7 @@ var _ = Describe("Component Detection Query controller", func() {
 
 			// index is 1 because of CDQ status condition Processing
 			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Status).Should(Equal(metav1.ConditionFalse))
-			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Message).Should(ContainSubstring("error getting devfile info from url: failed to retrieve"))
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Message).Should(ContainSubstring("failed to clone the repo: exit status 128"))
 
 			// Delete the specified Detection Query resource
 			deleteCompDetQueryCR(hasCompDetQueryLookupKey)
@@ -628,7 +628,7 @@ var _ = Describe("Component Detection Query controller", func() {
 
 			// index is 1 because of CDQ status condition Processing
 			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Status).Should(Equal(metav1.ConditionFalse))
-			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Message).Should(ContainSubstring("error getting devfile info from url: failed to retrieve"))
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Message).Should(ContainSubstring("failed to clone the repo: exit status 128"))
 
 			// Delete the specified Detection Query resource
 			deleteCompDetQueryCR(hasCompDetQueryLookupKey)


### PR DESCRIPTION
### What does this PR do?:

This PR updates branch detection in CDQs, so that when we clone git repositories, we do branch detection based off of the cloned repository, rather than via the GitHub API. In cases where we don't have access to the cloned Git repo, we still use GitHub API for branch detection.


### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-407

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
