### PR TITLE
chore: Update Grafana dashboard path

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -20,7 +20,7 @@ spec:
         sed -i -e 's|\(https://github.com/redhat-appstudio/application-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/has/production/kustomization.yaml        
         sed -i -e 's|\(https://github.com/redhat-appstudio/application-service/config/prometheus/?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/has/production/kustomization.yaml
         sed -i -e 's|\(https://github.com/redhat-appstudio/application-service/config/prometheus/?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/has/staging/kustomization.yaml
-        sed -i -e 's|\(https://github.com/redhat-appstudio/application-service/config/monitoring/?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/monitoring/grafana/base/has/kustomization.yaml
+        sed -i -e 's|\(https://github.com/redhat-appstudio/application-service/config/monitoring/?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/monitoring/grafana/base/dashboards/has/kustomization.yaml
 
   pipelineRef:
     params:


### PR DESCRIPTION

### What does this PR do?:
Update Grafana dashboard path after change in `infra-deployments`



