### PR TITLE
Gitops gen library update for Kustomization patch new syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.2)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5@v5.1.0)
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/redhat-appstudio/application-api v0.0.0-20230704143842-035c661f115f
 	github.com/redhat-appstudio/application-service/cdq-analysis v0.0.0
 	github.com/redhat-appstudio/service-provider-integration-scm-file-retriever v0.8.3
-	github.com/redhat-developer/gitops-generator v0.0.0-20230614175323-aff86c6bc55e
+	github.com/redhat-developer/gitops-generator v0.0.0-20230801134438-01747a27dcbf
 	github.com/spf13/afero v1.8.0
 	github.com/stretchr/testify v1.8.1
 	go.uber.org/zap v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -1000,8 +1000,8 @@ github.com/redhat-appstudio/service-provider-integration-scm-file-retriever v0.8
 github.com/redhat-appstudio/service-provider-integration-scm-file-retriever v0.8.3/go.mod h1:nGIC0XrYoMm63q1qHS7h/7ktUliMzgQcOOd2XLpNDbA=
 github.com/redhat-developer/alizer/go v0.0.0-20230516215932-135a2bb3fb90 h1:pFKn+Vqg3xXrueGboXYRkmKPJ6ObaVBNbKF1M7NG/mA=
 github.com/redhat-developer/alizer/go v0.0.0-20230516215932-135a2bb3fb90/go.mod h1:y7XToX/Yq1ASZY8hatAkmXJSzEXlHZV8lf59wliUfOw=
-github.com/redhat-developer/gitops-generator v0.0.0-20230614175323-aff86c6bc55e h1:YIADVYENP/Qy6XFcON9W4VMyxj1tiWYIPEtzW1DLF9A=
-github.com/redhat-developer/gitops-generator v0.0.0-20230614175323-aff86c6bc55e/go.mod h1:pKJez873Y9lZwQAgm99i/y1SmPI2dMd19ID74C+CxpU=
+github.com/redhat-developer/gitops-generator v0.0.0-20230801134438-01747a27dcbf h1:uRlhXqcVhbvp9YawKoggQoMLZwRP0/kpdLE3wkzqMuI=
+github.com/redhat-developer/gitops-generator v0.0.0-20230801134438-01747a27dcbf/go.mod h1:pKJez873Y9lZwQAgm99i/y1SmPI2dMd19ID74C+CxpU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
This PR pulls in the GitOps Gen Library update for the new Kustomization patch syntax. See https://github.com/redhat-developer/gitops-generator/pull/49

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
Fixes https://issues.redhat.com/browse/RHTAPBUGS-528

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:

- Create the appropriate Component and SEB
- clone the Gitops repo
- get the latest Kustomize version 5.x.x; Kustomize version 4.5.2 also works with the new syntax
- Do a `kustomize build .` on the environment overlays directory for example https://github.com/maysunfaisal/application-sample-lK5Sb-wan-score/tree/main/components/component-sample/overlays/staging



```
MacBook-Pro:staging maysun$ pwd
/Users/maysun/dev/appstudio/misc/application-sample-lK5Sb-wan-score/components/component-sample/overlays/staging

MacBook-Pro:staging maysun$ ls -la
total 24
drwxr-xr-x  5 maysun  staff  160 31 Jul 15:06 .
drwxr-xr-x  3 maysun  staff   96 31 Jul 15:06 ..
-rw-r--r--  1 maysun  staff  634 31 Jul 15:06 deployment-patch.yaml
-rw-r--r--  1 maysun  staff  140 31 Jul 15:06 kustomization.yaml
-rw-r--r--  1 maysun  staff  504 31 Jul 15:06 route.yaml

MacBook-Pro:staging maysun$ kustomize version
v5.1.0

MacBook-Pro:staging maysun$ kustomize build .
apiVersion: v1
kind: Service
metadata:
  creationTimestamp: null
  labels:
    app.kubernetes.io/created-by: application-service
    app.kubernetes.io/instance: component-sample
    app.kubernetes.io/managed-by: kustomize
    app.kubernetes.io/name: component-sample
    app.kubernetes.io/part-of: application-sample
  name: component-sample
spec:
  ports:
  - name: http-8081
    port: 8081
    protocol: TCP
    targetPort: 8081


[...]
```

