### PR TITLE
[DEVHAS-453] Fix Kube-Linter errors

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -20,6 +20,16 @@ spec:
         - containerPort: 8443
           protocol: TCP
           name: https
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+        resources:
+          limits:
+            cpu: 500m
+            memory: 400Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,6 +22,9 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      volumes:
+      - name: tmp-storage
+        emptyDir: {}
       securityContext:
         runAsNonRoot: true
       containers:
@@ -34,6 +37,7 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /healthz
@@ -90,5 +94,9 @@ spec:
               name: feature-flag-config
               key: ENVIRONMENT
               optional: true
+        volumeMounts:
+        - name: tmp-storage
+          mountPath: /tmp
+          readOnly: false
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
### What does this PR do?:
This PR addresses the errors found by [kube-linter](https://github.com/stackrox/kube-linter):
- Adds CPU and Memory requests and limits to the rbac proxy container
- Enables readOnlyRootFilesystem for both containers (HAS and rbac proxy)
- Adds an empty dir volume for the /tmp directory for HAS to be able to write to

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-453

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
1. Download Kube-Linter from https://github.com/stackrox/kube-linter
2. cd into `config/default`
3. Run `kustomize build . > mainfests.yaml`
4. Run `kube-linter lint manifests.yaml`. You should see:
```
KubeLinter development

No lint errors found!
```