### PR TITLE
Add the stale action for PRs

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,28 @@
+name: Mark stale PRs and close rotten PRs
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+
+    permissions:
+      pull-requests: write  # for actions/stale to close stale PRs
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v8
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: "A friendly reminder that this PR had no activity for 90 days. Stale PRs will be closed after an additional 30 days of inactivity."
+        close-pr-message: "This PR was closed because it has been inactive for 60 days since being marked as stale."
+        days-before-stale: 90
+        days-before-close: 60
+        stale-pr-label: 'lifecycle/stale'
+        exempt-pr-labels: 'lifecycle/frozen'
+        close-pr-label: 'lifecycle/rotten'
+        start-date: '2023-03-16T00:00:00Z'


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
Adds the stale action for the PRs in the repo
- No activity for 90days, the label `lifecycle/stale` will be applied
- No activity for 60 days and has the label `lifecycle/stale`, the label `lifecycle/rotten` will be applied and the PR will be closed
- If the label `lifecycle/frozen` is applied, the PRs will not go stale or rotten

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
N/A

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
