### PR TITLE
Add support for private DevfileURL in Component

### DIFF
--- a/cdq-analysis/pkg/componentdetectionquery.go
+++ b/cdq-analysis/pkg/componentdetectionquery.go
@@ -170,7 +170,7 @@ func CloneAndAnalyze(k K8sInfoClient, namespace, name, context string, cdqInfo *
 			return nil, nil, nil, nil, "", err
 		}
 
-		shouldIgnoreDevfile, devfileBytes, err := ValidateDevfile(log, updatedLink, gitToken) // check for internal private paths
+		shouldIgnoreDevfile, devfileBytes, err := ValidateDevfile(log, updatedLink, gitToken)
 		if err != nil {
 			retErr := &InvalidDevfile{Err: err}
 			k.SendBackDetectionResult(devfilesMap, devfilesURLMap, dockerfileContextMap, componentPortsMap, revision, name, namespace, retErr)

--- a/cdq-analysis/pkg/devfile.go
+++ b/cdq-analysis/pkg/devfile.go
@@ -98,14 +98,14 @@ func ScanRepo(log logr.Logger, a Alizer, localpath string, srcContext string, cd
 // If no kubernetes components being defined in devfile, then it's not a valid outerloop devfile, the devfile should be ignored.
 // If more than one kubernetes components in the devfile, but no deploy commands being defined. return an error
 // If more than one image components in the devfile, but no apply commands being defined. return an error
-func ValidateDevfile(log logr.Logger, URL string, token string) (shouldIgnoreDevfile bool, devfileBytes []byte, err error) {
-	log.Info(fmt.Sprintf("Validating devfile from %s...", URL))
+func ValidateDevfile(log logr.Logger, devfileLocation string, token string) (shouldIgnoreDevfile bool, devfileBytes []byte, err error) {
+	log.Info(fmt.Sprintf("Validating the devfile from location: %s...", devfileLocation))
 	shouldIgnoreDevfile = false
 	parserArgs := &parser.ParserArgs{Token: token}
-	if strings.HasPrefix(URL, "http://") || strings.HasPrefix(URL, "https://") {
-		parserArgs.URL = URL
+	if strings.HasPrefix(devfileLocation, "http://") || strings.HasPrefix(devfileLocation, "https://") {
+		parserArgs.URL = devfileLocation
 	} else {
-		parserArgs.Path = URL
+		parserArgs.Path = devfileLocation
 	}
 
 	devfileData, err := ParseDevfileWithParserArgs(parserArgs)
@@ -126,15 +126,15 @@ func ValidateDevfile(log logr.Logger, URL string, token string) (shouldIgnoreDev
 		}
 		if newErr != nil {
 			if merr, ok := newErr.(*multierror.Error); !ok || len(merr.Errors) != 0 {
-				log.Error(err, fmt.Sprintf("failed to parse the devfile content from %s", URL))
-				return shouldIgnoreDevfile, nil, fmt.Errorf(fmt.Sprintf("err: %v, failed to parse the devfile content from %s", err, URL))
+				log.Error(err, fmt.Sprintf("failed to parse the devfile content from %s", devfileLocation))
+				return shouldIgnoreDevfile, nil, fmt.Errorf(fmt.Sprintf("err: %v, failed to parse the devfile content from %s", err, devfileLocation))
 			}
 		}
 	}
 	deployCompMap, err := parser.GetDeployComponents(devfileData)
 	if err != nil {
-		log.Error(err, fmt.Sprintf("failed to get deploy components from %s", URL))
-		return shouldIgnoreDevfile, nil, fmt.Errorf(fmt.Sprintf("err: %v, failed to get deploy components from %s", err, URL))
+		log.Error(err, fmt.Sprintf("failed to get deploy components from %s", devfileLocation))
+		return shouldIgnoreDevfile, nil, fmt.Errorf(fmt.Sprintf("err: %v, failed to get deploy components from %s", err, devfileLocation))
 	}
 	devfileBytes, err = yaml.Marshal(devfileData)
 	if err != nil {
@@ -147,12 +147,12 @@ func ValidateDevfile(log logr.Logger, URL string, token string) (shouldIgnoreDev
 	}
 	kubeComp, err := devfileData.GetComponents(kubeCompFilter)
 	if err != nil {
-		log.Error(err, fmt.Sprintf("failed to get kubernetes component from %s", URL))
+		log.Error(err, fmt.Sprintf("failed to get kubernetes component from %s", devfileLocation))
 		shouldIgnoreDevfile = true
 		return shouldIgnoreDevfile, nil, nil
 	}
 	if len(kubeComp) == 0 {
-		log.Info(fmt.Sprintf("Found 0 kubernetes components being defined in devfile from %s, it is not a valid outerloop definition, the devfile will be ignored. A devfile will be matched from registry...", URL))
+		log.Info(fmt.Sprintf("Found 0 kubernetes components being defined in devfile from %s, it is not a valid outerloop definition, the devfile will be ignored. A devfile will be matched from the devfile registry...", devfileLocation))
 		shouldIgnoreDevfile = true
 		return shouldIgnoreDevfile, nil, nil
 	} else {
@@ -165,7 +165,7 @@ func ValidateDevfile(log logr.Logger, URL string, token string) (shouldIgnoreDev
 				}
 			}
 			if !found {
-				err = fmt.Errorf("found more than one kubernetes components, but no deploy command associated with any being defined in the devfile from %s", URL)
+				err = fmt.Errorf("found more than one kubernetes components, but no deploy command associated with any being defined in the devfile from %s", devfileLocation)
 				log.Error(err, "failed to validate devfile")
 				return shouldIgnoreDevfile, nil, err
 			}
@@ -179,61 +179,84 @@ func ValidateDevfile(log logr.Logger, URL string, token string) (shouldIgnoreDev
 	}
 	imageComp, err := devfileData.GetComponents(imageCompFilter)
 	if err != nil {
-		log.Error(err, fmt.Sprintf("failed to get image component from %s", URL))
-		return shouldIgnoreDevfile, nil, fmt.Errorf(fmt.Sprintf("err: %v, failed to get image component from %s", err, URL))
+		log.Error(err, fmt.Sprintf("failed to get image component from %s", devfileLocation))
+		return shouldIgnoreDevfile, nil, fmt.Errorf(fmt.Sprintf("err: %v, failed to get image component from %s", err, devfileLocation))
 	}
 	if len(imageComp) == 0 {
-		log.Info(fmt.Sprintf("Found 0 image components being defined in devfile from %s, it is not a valid outerloop definition, the devfile will be ignored. A devfile will be matched from registry...", URL))
+		log.Info(fmt.Sprintf("Found 0 image components being defined in devfile from %s, it is not a valid outerloop definition, the devfile will be ignored. A devfile will be matched from the devfile registry...", devfileLocation))
 		shouldIgnoreDevfile = true
 		return shouldIgnoreDevfile, nil, nil
-	} else {
-		if len(imageComp) > 1 {
-			found := false
-			for _, component := range imageComp {
-				if component.Image != nil && component.Image.Dockerfile != nil && component.Image.Dockerfile.DockerfileSrc.Uri != "" {
-					dockerfileURI := component.Image.Dockerfile.DockerfileSrc.Uri
-					absoluteURI := strings.HasPrefix(dockerfileURI, "http://") || strings.HasPrefix(dockerfileURI, "https://")
-					if absoluteURI {
-						// image uri
-						_, err = CurlEndpoint(dockerfileURI)
-					} else {
-						if parserArgs.Path != "" {
-							// local devfile src with relative Dockerfile uri
-							dockerfileURI = path.Join(path.Dir(URL), dockerfileURI)
-							err = parserUtil.ValidateFile(dockerfileURI)
-						} else {
-							// remote devfile src with relative Dockerfile uri
-							var u *url.URL
-							u, err = url.Parse(URL)
-							if err != nil {
-								log.Error(err, fmt.Sprintf("failed to parse URL from %s", URL))
-								return shouldIgnoreDevfile, nil, fmt.Errorf(fmt.Sprintf("failed to parse URL from %s", URL))
-							}
-							u.Path = path.Join(u.Path, dockerfileURI)
-							dockerfileURI = u.String()
-							_, err = CurlEndpoint(dockerfileURI)
-						}
-					}
-					if err != nil {
-						log.Error(err, fmt.Sprintf("failed to get Dockerfile from the URI %s, invalid image component: %s", URL, component.Name))
-						return shouldIgnoreDevfile, nil, fmt.Errorf(fmt.Sprintf("failed to get Dockerfile from the URI %s, invalid image component: %s", URL, component.Name))
-					}
-				}
-				if _, ok := deployCompMap[component.Name]; ok {
-					found = true
-					break
-				}
-			}
-			if !found {
-				err = fmt.Errorf("found more than one image components, but no deploy command associated with any being defined in the devfile from %s", URL)
-				log.Error(err, "failed to validate devfile")
+	} else if len(imageComp) > 1 {
+		found := false
+		for _, component := range imageComp {
+			err = validateImageComponentDockerfile(log, component, devfileLocation, token)
+			if err != nil {
+				log.Error(err, fmt.Sprintf("failed to validate the Dockerfile from the Image Component %s in the devfile", component.Name))
 				return shouldIgnoreDevfile, nil, err
 			}
+
+			if _, ok := deployCompMap[component.Name]; ok {
+				found = true
+				break
+			}
 		}
+		if !found {
+			err = fmt.Errorf("found more than one image components, but no deploy command associated with any being defined in the devfile from %s", devfileLocation)
+			log.Error(err, "failed to validate devfile")
+			return shouldIgnoreDevfile, nil, err
+		}
+	} else if len(imageComp) == 1 {
 		// TODO: if only one image component, should return a warning that no apply command being defined
+		component := imageComp[0]
+		err = validateImageComponentDockerfile(log, component, devfileLocation, token)
+		if err != nil {
+			log.Error(err, fmt.Sprintf("failed to validate the Dockerfile from the Image Component %s in the devfile", component.Name))
+			return shouldIgnoreDevfile, nil, err
+		}
 	}
 
 	return shouldIgnoreDevfile, devfileBytes, nil
+}
+
+// validateImageComponentDockerfile validates the given image component dockerfile for a devfile location
+func validateImageComponentDockerfile(log logr.Logger, component v1alpha2.Component, devfileLocation, token string) (err error) {
+	if component.Image != nil && component.Image.Dockerfile != nil && component.Image.Dockerfile.DockerfileSrc.Uri != "" {
+		dockerfileURI := component.Image.Dockerfile.DockerfileSrc.Uri
+		absoluteDockerfileURI := strings.HasPrefix(dockerfileURI, "http://") || strings.HasPrefix(dockerfileURI, "https://")
+		absoluteDevfileLocation := strings.HasPrefix(devfileLocation, "http://") || strings.HasPrefix(devfileLocation, "https://")
+
+		if absoluteDockerfileURI {
+			// absolute Dockerfile uri
+			log.Info(fmt.Sprintf("Checking if the Dockerfile location %s is reachable", dockerfileURI))
+			_, err = CurlEndpoint(dockerfileURI, token) // if private URI does it succeed?
+		} else {
+			if !absoluteDevfileLocation {
+				// local devfile src with relative Dockerfile uri
+				dockerfileURI = path.Join(path.Dir(devfileLocation), dockerfileURI)
+				log.Info(fmt.Sprintf("Checking if the Dockerfile location %s is reachable", dockerfileURI))
+				err = parserUtil.ValidateFile(dockerfileURI)
+			} else {
+				// remote devfile src with relative Dockerfile uri
+				var u *url.URL
+				u, err = url.Parse(devfileLocation)
+				if err != nil {
+					log.Error(err, fmt.Sprintf("failed to parse URL from %s", devfileLocation))
+					return fmt.Errorf(fmt.Sprintf("failed to parse URL from %s", devfileLocation))
+				}
+				u.Path = path.Join(path.Dir(u.Path), dockerfileURI)
+				dockerfileURI = u.String()
+				log.Info(fmt.Sprintf("Checking if the Dockerfile location %s is reachable", dockerfileURI))
+				_, err = CurlEndpoint(dockerfileURI, token) // will it succeed on private link?
+			}
+		}
+		if err != nil {
+			errMsg := fmt.Sprintf("failed to get Dockerfile from the location %s for the image component: %s", dockerfileURI, component.Name)
+			log.Error(err, errMsg)
+			return fmt.Errorf(errMsg)
+		}
+	}
+
+	return nil
 }
 
 // DevfileSrc specifies the src of the Devfile

--- a/cdq-analysis/pkg/devfile.go
+++ b/cdq-analysis/pkg/devfile.go
@@ -228,7 +228,7 @@ func validateImageComponentDockerfile(log logr.Logger, component v1alpha2.Compon
 		if absoluteDockerfileURI {
 			// absolute Dockerfile uri
 			log.Info(fmt.Sprintf("Checking if the Dockerfile location %s is reachable", dockerfileURI))
-			_, err = CurlEndpoint(dockerfileURI, token) // if private URI does it succeed?
+			_, err = CurlEndpoint(dockerfileURI, token)
 		} else {
 			if !absoluteDevfileLocation {
 				// local devfile src with relative Dockerfile uri
@@ -246,7 +246,7 @@ func validateImageComponentDockerfile(log logr.Logger, component v1alpha2.Compon
 				u.Path = path.Join(path.Dir(u.Path), dockerfileURI)
 				dockerfileURI = u.String()
 				log.Info(fmt.Sprintf("Checking if the Dockerfile location %s is reachable", dockerfileURI))
-				_, err = CurlEndpoint(dockerfileURI, token) // will it succeed on private link?
+				_, err = CurlEndpoint(dockerfileURI, token)
 			}
 		}
 		if err != nil {

--- a/cdq-analysis/pkg/util_test.go
+++ b/cdq-analysis/pkg/util_test.go
@@ -91,7 +91,7 @@ func TestCurlEndpoint(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			contents, err := CurlEndpoint(tt.url)
+			contents, err := CurlEndpoint(tt.url, "")
 			if tt.wantErr && (err == nil) {
 				t.Error("wanted error but got nil")
 			} else if !tt.wantErr && err != nil {

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -278,7 +278,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				if string(sourceURL[len(sourceURL)-1]) == "/" {
 					sourceURL = sourceURL[0 : len(sourceURL)-1]
 				}
-				log.Info(fmt.Sprintf("Looking for default branch of repo %s... %v", source.GitSource.URL, req.NamespacedName))
+				log.Info(fmt.Sprintf("Looking for the default branch of the repo %s... %v", source.GitSource.URL, req.NamespacedName))
 				metricsLabel := prometheus.Labels{"controller": cdqName, "tokenName": ghClient.TokenName, "operation": "GetDefaultBranchFromURL"}
 				metrics.ControllerGitRequest.With(metricsLabel).Inc()
 				source.GitSource.Revision, err = ghClient.GetDefaultBranchFromURL(sourceURL, ctx)
@@ -314,7 +314,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 						return ctrl.Result{}, err
 					}
 
-					devfileBytes, devfileLocation, err = devfile.FindAndDownloadDevfile(gitURL)
+					devfileBytes, devfileLocation, err = devfile.FindAndDownloadDevfile(gitURL, gitToken)
 					// FindAndDownloadDevfile only returns user error
 					metrics.ImportGitRepoSucceeded.Inc()
 					if err != nil {

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -308,7 +308,7 @@ var _ = Describe("Component controller", func() {
 			// Make sure the err was set
 			Expect(createdHasComp.Status.Devfile).Should(Equal(""))
 			Expect(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Reason).Should(Equal("Error"))
-			Expect(strings.ToLower(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message)).Should(ContainSubstring("unable to get"))
+			Expect(strings.ToLower(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message)).Should(ContainSubstring("error getting devfile"))
 
 			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
 

--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -159,7 +159,7 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 		if string(sourceURL[len(sourceURL)-1]) == "/" {
 			sourceURL = sourceURL[0 : len(sourceURL)-1]
 		}
-		err = util.ValidateEndpoint(sourceURL)
+		err = util.ValidateEndpoint(sourceURL) // does this work without token?
 		if err != nil {
 			log.Error(err, fmt.Sprintf("Failed to validate the source URL %v... %v", source.URL, req.NamespacedName))
 			r.SetCompleteConditionAndUpdateCR(ctx, req, &componentDetectionQuery, copiedCDQ, err)

--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -159,7 +159,10 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 		if string(sourceURL[len(sourceURL)-1]) == "/" {
 			sourceURL = sourceURL[0 : len(sourceURL)-1]
 		}
-		err = util.ValidateEndpoint(sourceURL) // does this work without token?
+
+		// there is no need to perform a GET on the url as we are going to clone soon,
+		// this also saves us the headache of using token here for private repos.
+		err = util.ValidateEndpoint(sourceURL)
 		if err != nil {
 			log.Error(err, fmt.Sprintf("Failed to validate the source URL %v... %v", source.URL, req.NamespacedName))
 			r.SetCompleteConditionAndUpdateCR(ctx, req, &componentDetectionQuery, copiedCDQ, err)

--- a/docs/private-git-repos.md
+++ b/docs/private-git-repos.md
@@ -4,27 +4,23 @@
 
 In order to use HAS resources (e.g. `Applications`, `Components`, `ComponentDetectionQuery`) with private git repositories, SPI must be installed on the same cluster as HAS (TODO review HAS install instructions):
 
-1) Clone the [SPI operator repo](https://github.com/redhat-appstudio/service-provider-integration-operator) and run the [make command ](https://github.com/redhat-appstudio/service-provider-integration-operator/blob/main/docs/DEVELOP.md#running-in-cluster) corresponding to your target cluster type e.g. `make deploy_openshift`
+1) Clone the [SPI operator repo](https://github.com/redhat-appstudio/service-provider-integration-operator) and run the [make command](https://github.com/redhat-appstudio/service-provider-integration-operator/blob/main/docs/DEVELOP.md#running-in-cluster) corresponding to your target cluster type e.g. `make deploy_openshift`
 
 
 2) Set up SPI
-
-    a) Get SPI oauth route URL from `spi-system` namespace `oc get routes -n spi-system`
-
-    b) Create oauth app in GitHub (`Settings` -> `Developer Settings` -> `OAuth Apps`)
-
+   1) Get SPI oauth route URL from `spi-system` namespace `oc get routes -n spi-system`
+   2) Create oauth app in GitHub (`Settings` -> `Developer Settings` -> `OAuth Apps`)
       - Use the SPI oauth url as the Application Callback URL.
       - Homepage URL does not matter
       - Record the Client ID and Client Secret values 
-
-    c) To set up a Github Oauth app with SPI, modify the overlay in your cloned SPI repo that corresponds with the cluster type e.g. in config/overlays/openshift_vault/config.yaml, replace the `clientId` and `clientSecret` with the values from the oauth app you created in step 2.  Run ` kustomize build config/overlays/openshift_vault | kubectl apply -f -` to update the `shared-configuration-file` secret
+   3) To set up a Github Oauth app with SPI, modify the overlay in your cloned SPI repo that corresponds with the cluster type e.g. in config/overlays/openshift_vault/config.yaml, replace the `clientId` and `clientSecret` with the values from the oauth app you created in step 2.  Run ` kustomize build config/overlays/openshift_vault | kubectl apply -f -` to update the `shared-configuration-file` secret
 
 
 
 ## Creating a Token
 
-1) In Github, generate a new classic token with User and Repo scope
-2)  To create a token to use with HAS, create an `SPIAccessTokenBinding` resource with the following contents:
+1) In Github, generate a new classic token with User and Repo scope and note down the token value.
+2) To create a token secret to use with HAS, draft a `SPIAccessTokenBinding` resource with the following contents:
    ```yaml
     apiVersion: appstudio.redhat.com/v1beta1
     kind: SPIAccessTokenBinding
@@ -41,20 +37,20 @@ In order to use HAS resources (e.g. `Applications`, `Components`, `ComponentDete
         type: kubernetes.io/basic-auth
    ```
    
-3) Create the resource in the namespace you will be creating HAS resources in.  Upon successful creation, the CR will be in `AwaitingTokenData` phase status and a corresponding SPIAccessToken CR will be created in the same namespace.
+3) Create the resource in the namespace you will be creating HAS resources in.  Upon successful creation, the CR will be in `AwaitingTokenData` phase status and a corresponding `SPIAccessToken` CR will be created in the same namespace.
 
 3) Upload the token: 
    1) Set the TARGET_NAMESPACE to where your CRs instances are.  Run `UPLOAD_URL=$(kubectl get spiaccesstokenbinding/test-access-token-binding -n $TARGET_NAMESPACE -o  json | jq -r .status.uploadUrl)`
-   2) Inject the token where TOKEN is the console admin secret and GITHUB_TOKEN is the token created in step 1)
+   2) Inject the token with the curl command, where TOKEN is the console admin token and GITHUB_TOKEN is the token created in main step 1 above
    
       `curl -v -H 'Content-Type: application/json' -H "Authorization: bearer "$TOKEN -d "{ \"access_token\": \"$GITHUB_TOKEN\" }" $UPLOAD_URL`
-   3)  The state of the SPIAccessTokenBinding should change to `Injected` and the state of the SPIAccessToken should be `Ready`
-   4)  This will also create a K8s secret corresponding to the name of the secret that was specified in the SPIAccessTokenBinding created in step 2.
+   3)  The state of the `SPIAccessTokenBinding` CR should change to `Injected` and the state of the `SPIAccessToken` should be `Ready`
+   4)  This will also create a K8s secret corresponding to the name of the secret that was specified in the `SPIAccessTokenBinding` created in main step 2 above, for example `token-secret`. Use the secret in HAS CRs for private repositories.
  
    
 ## Using Private Git Repositories
 
-Now, with the token secret created for the git repository, when creating HAS resources (`Components`, `ComponentDetectionQueries`) that need to access that Git repository, just pass in the token secret to the resource:
+Now, with the token secret created for the git repository, when creating HAS resources (`Components`, `ComponentDetectionQueries`) that need to access that private Git repository, just pass in the token secret to the resource:
 
 **Component**
 
@@ -70,7 +66,7 @@ spec:
   source:
     git:
       url: https://github.com/johnmcollier/devfile-private.git
-  secret: token-multi-secret
+  secret: token-secret
 ```
 
 **ComponentDetectionQuery**
@@ -81,8 +77,7 @@ kind: ComponentDetectionQuery
 metadata:
   name: componentdetectionquery-sample
 spec:
-  isMultiComponent: true
   git:
     url: https://github.com/johnmcollier/multi-component-private.git
-  secret: token-multi-secret
+  secret: token-secret
 ```

--- a/pkg/devfile/devfile.go
+++ b/pkg/devfile/devfile.go
@@ -780,18 +780,6 @@ func DownloadFile(file, token string) ([]byte, error) {
 	return cdqanalysis.CurlEndpoint(file, token)
 }
 
-// DownloadDevfileAndDockerfile attempts to download and return the devfile, devfile context, Dockerfile and Dockerfile context from the root of the specified url
-// not used
-func DownloadDevfileAndDockerfile(url, token string) ([]byte, string, []byte, string) {
-	var devfileBytes, dockerfileBytes []byte
-	var devfilePath, dockerfilePath string
-
-	devfileBytes, devfilePath, _ = FindAndDownloadDevfile(url, token)
-	dockerfileBytes, dockerfilePath, _ = FindAndDownloadDockerfile(url, token)
-
-	return devfileBytes, devfilePath, dockerfileBytes, dockerfilePath
-}
-
 // UpdateLocalDockerfileURItoAbsolute takes in a Devfile, and a DockefileURL, and returns back a Devfile with any local URIs to the Dockerfile updates to be absolute
 func UpdateLocalDockerfileURItoAbsolute(devfile data.DevfileData, dockerfileURL string) (data.DevfileData, error) {
 	devfileComponents, err := devfile.GetComponents(common.DevfileOptions{ComponentOptions: common.ComponentOptions{

--- a/pkg/devfile/devfile.go
+++ b/pkg/devfile/devfile.go
@@ -741,13 +741,13 @@ func getMatchLabel(name string) map[string]string {
 }
 
 // FindAndDownloadDevfile downloads devfile from the various possible devfile locations in dir and returns the contents and its context
-func FindAndDownloadDevfile(dir string) ([]byte, string, error) {
+func FindAndDownloadDevfile(dir, token string) ([]byte, string, error) {
 	var devfileBytes []byte
 	var err error
 
 	for _, path := range cdqanalysis.ValidDevfileLocations {
 		devfilePath := dir + "/" + path
-		devfileBytes, err = DownloadFile(devfilePath)
+		devfileBytes, err = DownloadFile(devfilePath, token)
 		if err == nil {
 			// if we get a 200, return
 			return devfileBytes, path, err
@@ -758,14 +758,14 @@ func FindAndDownloadDevfile(dir string) ([]byte, string, error) {
 }
 
 // FindAndDownloadDockerfile downloads Dockerfile from the various possible Dockerfile, or Containerfile locations in dir and returns the contents and its context
-func FindAndDownloadDockerfile(dir string) ([]byte, string, error) {
+func FindAndDownloadDockerfile(dir, token string) ([]byte, string, error) {
 	var dockerfileBytes []byte
 	var err error
 	// Containerfile is an alternate name for Dockerfile
 
 	for _, path := range cdqanalysis.ValidDockerfileLocations {
 		dockerfilePath := dir + "/" + path
-		dockerfileBytes, err = DownloadFile(dockerfilePath)
+		dockerfileBytes, err = DownloadFile(dockerfilePath, token)
 		if err == nil {
 			// if we get a 200, return
 			return dockerfileBytes, path, err
@@ -776,17 +776,18 @@ func FindAndDownloadDockerfile(dir string) ([]byte, string, error) {
 }
 
 // DownloadFile downloads the specified file
-func DownloadFile(file string) ([]byte, error) {
-	return cdqanalysis.CurlEndpoint(file)
+func DownloadFile(file, token string) ([]byte, error) {
+	return cdqanalysis.CurlEndpoint(file, token)
 }
 
 // DownloadDevfileAndDockerfile attempts to download and return the devfile, devfile context, Dockerfile and Dockerfile context from the root of the specified url
-func DownloadDevfileAndDockerfile(url string) ([]byte, string, []byte, string) {
+// not used
+func DownloadDevfileAndDockerfile(url, token string) ([]byte, string, []byte, string) {
 	var devfileBytes, dockerfileBytes []byte
 	var devfilePath, dockerfilePath string
 
-	devfileBytes, devfilePath, _ = FindAndDownloadDevfile(url)
-	dockerfileBytes, dockerfilePath, _ = FindAndDownloadDockerfile(url)
+	devfileBytes, devfilePath, _ = FindAndDownloadDevfile(url, token)
+	dockerfileBytes, dockerfilePath, _ = FindAndDownloadDockerfile(url, token)
 
 	return devfileBytes, devfilePath, dockerfileBytes, dockerfilePath
 }

--- a/pkg/devfile/devfile_test.go
+++ b/pkg/devfile/devfile_test.go
@@ -395,46 +395,6 @@ func TestCreateDevfileForDockerfileBuild(t *testing.T) {
 	}
 }
 
-func TestDownloadDevfileAndDockerfile(t *testing.T) {
-	tests := []struct {
-		name                  string
-		url                   string
-		wantDevfileContext    string
-		wantDockerfileContext string
-		want                  bool
-	}{
-		{
-			name:                  "Curl devfile.yaml and Dockerfile",
-			url:                   "https://raw.githubusercontent.com/maysunfaisal/devfile-sample-python-samelevel/main",
-			wantDevfileContext:    ".devfile.yaml",
-			wantDockerfileContext: "Dockerfile",
-			want:                  true,
-		},
-		{
-			name: "Cannot curl for a devfile nor a Dockerfile",
-			url:  "https://github.com/octocat/Hello-World",
-			want: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			devfile, devfileContext, dockerfile, dockerfileContext := DownloadDevfileAndDockerfile(tt.url, "")
-			if tt.want != (len(devfile) > 0 && len(dockerfile) > 0) {
-				t.Errorf("devfile and a Dockerfile wanted: %v but got devfile: %v Dockerfile: %v", tt.want, len(devfile) > 0, len(dockerfile) > 0)
-			}
-
-			if devfileContext != tt.wantDevfileContext {
-				t.Errorf("devfile context did not match, got %v, wanted %v", devfileContext, tt.wantDevfileContext)
-			}
-
-			if dockerfileContext != tt.wantDockerfileContext {
-				t.Errorf("Dockerfile context did not match, got %v, wanted %v", dockerfileContext, tt.wantDockerfileContext)
-			}
-		})
-	}
-}
-
 func TestGetRouteFromEndpoint(t *testing.T) {
 
 	var (

--- a/pkg/devfile/devfile_test.go
+++ b/pkg/devfile/devfile_test.go
@@ -227,7 +227,7 @@ func TestFindAndDownloadDevfile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			contents, devfileContext, err := FindAndDownloadDevfile(tt.url)
+			contents, devfileContext, err := FindAndDownloadDevfile(tt.url, "")
 			if tt.wantErr && (err == nil) {
 				t.Error("wanted error but got nil")
 			} else if !tt.wantErr && err != nil {
@@ -302,7 +302,7 @@ func TestFindAndDownloadDockerfile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			contents, dockerfileContext, err := FindAndDownloadDockerfile(tt.url)
+			contents, dockerfileContext, err := FindAndDownloadDockerfile(tt.url, "")
 			if tt.wantErr && (err == nil) {
 				t.Error("wanted error but got nil")
 			} else if !tt.wantErr && err != nil {
@@ -419,7 +419,7 @@ func TestDownloadDevfileAndDockerfile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			devfile, devfileContext, dockerfile, dockerfileContext := DownloadDevfileAndDockerfile(tt.url)
+			devfile, devfileContext, dockerfile, dockerfileContext := DownloadDevfileAndDockerfile(tt.url, "")
 			if tt.want != (len(devfile) > 0 && len(dockerfile) > 0) {
 				t.Errorf("devfile and a Dockerfile wanted: %v but got devfile: %v Dockerfile: %v", tt.want, len(devfile) > 0, len(dockerfile) > 0)
 			}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -20,12 +20,10 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math/rand"
-	"net/http"
 	"net/url"
 	"reflect"
 	"regexp"
 	"strings"
-	"time"
 
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	gitopsgenv1alpha1 "github.com/redhat-developer/gitops-generator/api/v1alpha1"
@@ -86,9 +84,6 @@ func ProcessGitOpsStatus(gitopsStatus appstudiov1alpha1.GitOpsStatus, gitToken s
 }
 
 func ValidateEndpoint(endpoint string) error {
-	var (
-		retries int = 3
-	)
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return fmt.Errorf("failed to parse the url: %v, err: %v", endpoint, err)
@@ -98,16 +93,7 @@ func ValidateEndpoint(endpoint string) error {
 		return fmt.Errorf("url %v is invalid", endpoint)
 	}
 
-	client := &http.Client{Timeout: 3 * time.Second}
-	for retries > 0 {
-		_, err := client.Get(endpoint)
-		if err != nil {
-			retries -= 1
-		} else {
-			return nil
-		}
-	}
-	return fmt.Errorf("failed to get the url: %v, might due to a network issue or the url is invalid", endpoint)
+	return nil
 }
 
 // CheckWithRegex checks if a name matches the pattern.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -83,6 +83,7 @@ func ProcessGitOpsStatus(gitopsStatus appstudiov1alpha1.GitOpsStatus, gitToken s
 	return remoteURL, gitOpsBranch, gitOpsContext, nil
 }
 
+// ValidateEndpoint validates if the endpoint url can be parsed and if it has a host and a scheme
 func ValidateEndpoint(endpoint string) error {
 	u, err := url.Parse(endpoint)
 	if err != nil {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -136,7 +136,6 @@ func TestProcessGitOpsStatus(t *testing.T) {
 }
 
 func TestValidateEndpoint(t *testing.T) {
-	invalidEndpoint := "failed to get the url"
 	parseFail := "failed to parse the url"
 
 	tests := []struct {
@@ -151,11 +150,6 @@ func TestValidateEndpoint(t *testing.T) {
 		{
 			name: "Valid private repo",
 			url:  "https://github.com/yangcao77/multi-components-private",
-		},
-		{
-			name:    "Invalid Endpoint",
-			url:     "protocal://google.ca/somepath",
-			wantErr: &invalidEndpoint,
 		},
 		{
 			name:    "Invalid URL failed to be parsed",


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
- Adds in private DevfileURL support for Component
- Adds in private link support for Devfiles in CDQ

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
https://issues.redhat.com/browse/DEVHAS-444

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:

#### Component:
- Pass in the DevfileURL:
```yaml
source:
    git:
      context: ./
      devfileUrl: https://raw.githubusercontent.com/maysunfaisal/devfile-sample-go-basic-private/main/devfile.yaml
      revision: main
      url: https://github.com/maysunfaisal/devfile-sample-go-basic-dockerfile-empty-private
secret: token-secret
```
- Create a Dockerfile only Component:
```yaml
source:
    git:
      context: ./
      dockerfileUrl: docker/Dockerfile
      revision: main
      url: https://github.com/maysunfaisal/devfile-sample-go-basic-dockerfile-only-private
secret: token-secret
```

#### CDQ
```yaml
Private Repo NOTES

Component:
source:
    git:
      context: ./
      revision: main
      url: https://github.com/maysunfaisal/devfile-sample-go-basic-private

source:
    git:
      context: ./
      devfileUrl: https://raw.githubusercontent.com/maysunfaisal/devfile-sample-go-basic-private/main/devfile.yaml
      revision: main
      url: https://github.com/maysunfaisal/devfile-sample-go-basic-dockerfile-empty-private

CDQ:
spec:
  git:
    url: https://github.com/maysunfaisal/devfile-sample-go-basic-private # Regular Go Sample just private
  secret: token-secret

spec:
  git:
    url: https://github.com/maysunfaisal/devfile-sample-go-basic-dockerfile-empty-private # Private Go Sample has no Devfile and no Dockerfile
  secret: token-secret

spec:
  git:
    url: https://github.com/maysunfaisal/devfile-sample-go-basic-private-dockerfile-full-private # Private Go Sample has Devfile with a private Dockerfile URI instead of a relative path. Example, uri: https://raw.githubusercontent.com/maysunfaisal/devfile-sample-go-basic-private/main/docker/Dockerfile. This link needs to use the same token secret
  secret: token-secret

spec:
  git:
    url: https://github.com/maysunfaisal/devfile-sample-go-basic-private-devfile-nested # Private Go Sample which is multi component. componentA has both devfile and Dockerfile. componentB has neither.
  secret: token-secret

spec:
  git:
    devfileUrl: https://raw.githubusercontent.com/devfile-samples/devfile-sample-go-basic/main/devfile.yaml
    url: https://github.com/maysunfaisal/devfile-sample-go-basic-private # Not really used in RHTAP but since we have the code path in the controller, we can also use CDQ with a devfileURL which over is a private link to a devfile. This link needs to use the same token secret.
  secret: token-secret

spec:
  git:
    url: https://github.com/maysunfaisal/devfile-sample-go-basic-dockerfile-only-private # Basic Go sample but without a devfile. A Dockerfile is present so this is a Dockerfile only Component
  secret: token-secret
```
