### PR TITLE
[DEVHAS-528] Add validating webhook for build-nudges-ref

### DIFF
--- a/controllers/webhooks/application_webhook.go
+++ b/controllers/webhooks/application_webhook.go
@@ -48,6 +48,7 @@ func (w *ApplicationWebhook) Register(mgr ctrl.Manager, log *logr.Logger) error 
 }
 
 // +kubebuilder:webhook:path=/validate-appstudio-redhat-com-v1alpha1-application,mutating=false,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=applications,verbs=create;update,versions=v1alpha1,name=vapplication.kb.io,admissionReviewVersions=v1
+
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *ApplicationWebhook) Default(ctx context.Context, obj runtime.Object) error {
 

--- a/controllers/webhooks/application_webhook.go
+++ b/controllers/webhooks/application_webhook.go
@@ -42,11 +42,18 @@ func (w *ApplicationWebhook) Register(mgr ctrl.Manager, log *logr.Logger) error 
 
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&appstudiov1alpha1.Application{}).
+		WithDefaulter(w).
 		WithValidator(w).
 		Complete()
 }
 
 // +kubebuilder:webhook:path=/validate-appstudio-redhat-com-v1alpha1-application,mutating=false,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=applications,verbs=create;update,versions=v1alpha1,name=vapplication.kb.io,admissionReviewVersions=v1
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *ApplicationWebhook) Default(ctx context.Context, obj runtime.Object) error {
+
+	// TODO(user): fill in your defaulting logic.
+	return nil
+}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *ApplicationWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) error {

--- a/controllers/webhooks/component_webhook.go
+++ b/controllers/webhooks/component_webhook.go
@@ -142,7 +142,7 @@ func (r *ComponentWebhook) ValidateDelete(ctx context.Context, obj runtime.Objec
 	return nil
 }
 
-// validateBuildNudgesRefTree returns an error if a cycle was found in the 'build-nudges-ref' dependency graph
+// validateBuildNudgesRefGraph returns an error if a cycle was found in the 'build-nudges-ref' dependency graph
 // If no cycle is found, it returns nil
 func (r *ComponentWebhook) validateBuildNudgesRefGraph(ctx context.Context, nudgedComponentNames []string, componentNamespace string, componentName string, componentApp string) error {
 	for _, nudgedComponentName := range nudgedComponentNames {

--- a/controllers/webhooks/component_webhook.go
+++ b/controllers/webhooks/component_webhook.go
@@ -54,6 +54,7 @@ func (w *ComponentWebhook) Register(mgr ctrl.Manager, log *logr.Logger) error {
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
 // +kubebuilder:webhook:path=/mutate-appstudio-redhat-com-v1alpha1-component,mutating=true,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=components,verbs=create;update,versions=v1alpha1,name=mcomponent.kb.io,admissionReviewVersions=v1
+
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *ComponentWebhook) Default(ctx context.Context, obj runtime.Object) error {
 

--- a/controllers/webhooks/component_webhook_unit_test.go
+++ b/controllers/webhooks/component_webhook_unit_test.go
@@ -22,10 +22,16 @@ import (
 
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 func TestComponentCreateValidatingWebhook(t *testing.T) {
@@ -319,4 +325,347 @@ func TestComponentDeleteValidatingWebhook(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateBuildNudgesRefGraph(t *testing.T) {
+	fakeClient := setUpComponents(t)
+	fakeErrorClient := NewFakeErrorClient(t)
+
+	compWebhook := ComponentWebhook{
+		client: fakeClient,
+		log: zap.New(zap.UseFlagOptions(&zap.Options{
+			Development: true,
+			TimeEncoder: zapcore.ISO8601TimeEncoder,
+		})),
+	}
+
+	errCompWebhook := ComponentWebhook{
+		client: fakeErrorClient,
+		log: zap.New(zap.UseFlagOptions(&zap.Options{
+			Development: true,
+			TimeEncoder: zapcore.ISO8601TimeEncoder,
+		})),
+	}
+
+	tests := []struct {
+		name     string
+		compName string
+		webhook  ComponentWebhook
+		errStr   string
+	}{
+		{
+			name:     "simple component relationship, no errors",
+			compName: "component1",
+			webhook:  compWebhook,
+		},
+		{
+			name:     "component references itself",
+			compName: "component-self-ref",
+			webhook:  compWebhook,
+			errStr:   "cycle detected: component component-self-ref cannot reference itself, directly or indirectly, via build-nudges-ref",
+		},
+		{
+			name:     "nudged component belongs to different app",
+			compName: "component-invalid-app",
+			webhook:  compWebhook,
+			errStr:   "component component4 cannot be added to spec.build-nudges-ref as it belongs to a different application",
+		},
+		{
+			name:     "complex component relationship - some valid, some not valid (self referential)",
+			compName: "complexComponent",
+			webhook:  compWebhook,
+			errStr:   "cycle detected: component complexComponent cannot reference itself, directly or indirectly, via build-nudges-ref",
+		},
+		{
+			name:     "unrelated get error from kubernetes",
+			compName: "component1",
+			webhook:  errCompWebhook,
+			errStr:   "some error",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			component := &appstudiov1alpha1.Component{}
+			fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: test.compName}, component)
+
+			err := test.webhook.validateBuildNudgesRefGraph(context.Background(), component.Spec.BuildNudgesRef, "default", test.compName, component.Spec.Application)
+			var errStr string
+			if err != nil {
+				errStr = err.Error()
+			}
+			if errStr != test.errStr {
+				t.Errorf("TestValidateBuildNudgesRefGraph() unexpected error value: want %v, got %v", test.errStr, errStr)
+			}
+		})
+	}
+}
+
+// setUpComponents creates a fake controller-runtime Kube client with components to test the build-nudges-ref field
+func setUpComponents(t *testing.T) client.WithWatch {
+	s := scheme.Scheme
+	err := appstudiov1alpha1.AddToScheme(s)
+	require.NoError(t, err)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(s).
+		Build()
+
+	component1 := appstudiov1alpha1.Component{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "component1",
+			Namespace: "default",
+		},
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "appstudio.redhat.com/v1alpha1",
+			Kind:       "Component",
+		},
+		Spec: appstudiov1alpha1.ComponentSpec{
+			ComponentName:  "component1",
+			Application:    "application1",
+			BuildNudgesRef: []string{"component2"},
+		},
+	}
+	err = fakeClient.Create(context.Background(), &component1)
+	require.NoError(t, err)
+
+	component2 := appstudiov1alpha1.Component{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "component2",
+			Namespace: "default",
+		},
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "appstudio.redhat.com/v1alpha1",
+			Kind:       "Component",
+		},
+		Spec: appstudiov1alpha1.ComponentSpec{
+			ComponentName:  "component2",
+			Application:    "application1",
+			BuildNudgesRef: []string{"component3"},
+		},
+	}
+	err = fakeClient.Create(context.Background(), &component2)
+	require.NoError(t, err)
+
+	component3 := appstudiov1alpha1.Component{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "component3",
+			Namespace: "default",
+		},
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "appstudio.redhat.com/v1alpha1",
+			Kind:       "Component",
+		},
+		Spec: appstudiov1alpha1.ComponentSpec{
+			ComponentName: "component3",
+			Application:   "application1",
+		},
+	}
+	err = fakeClient.Create(context.Background(), &component3)
+	require.NoError(t, err)
+
+	componentSelfReference := appstudiov1alpha1.Component{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "component-self-ref",
+			Namespace: "default",
+		},
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "appstudio.redhat.com/v1alpha1",
+			Kind:       "Component",
+		},
+		Spec: appstudiov1alpha1.ComponentSpec{
+			ComponentName:  "component-self-ref",
+			Application:    "application1",
+			BuildNudgesRef: []string{"component-self-ref"},
+		},
+	}
+	err = fakeClient.Create(context.Background(), &componentSelfReference)
+	require.NoError(t, err)
+
+	componentInvalidApp := appstudiov1alpha1.Component{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "component-invalid-app",
+			Namespace: "default",
+		},
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "appstudio.redhat.com/v1alpha1",
+			Kind:       "Component",
+		},
+		Spec: appstudiov1alpha1.ComponentSpec{
+			ComponentName:  "component-invalid-app",
+			Application:    "application1",
+			BuildNudgesRef: []string{"component4"},
+		},
+	}
+	err = fakeClient.Create(context.Background(), &componentInvalidApp)
+	require.NoError(t, err)
+
+	component4 := appstudiov1alpha1.Component{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "component4",
+			Namespace: "default",
+		},
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "appstudio.redhat.com/v1alpha1",
+			Kind:       "Component",
+		},
+		Spec: appstudiov1alpha1.ComponentSpec{
+			ComponentName: "component2",
+			Application:   "application2",
+		},
+	}
+	err = fakeClient.Create(context.Background(), &component4)
+	require.NoError(t, err)
+
+	complexComponent := appstudiov1alpha1.Component{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "complexComponent",
+			Namespace: "default",
+		},
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "appstudio.redhat.com/v1alpha1",
+			Kind:       "Component",
+		},
+		Spec: appstudiov1alpha1.ComponentSpec{
+			ComponentName:  "complexComponent",
+			Application:    "application1",
+			BuildNudgesRef: []string{"component1", "complexComponentNudged"},
+		},
+	}
+	err = fakeClient.Create(context.Background(), &complexComponent)
+	require.NoError(t, err)
+
+	complexComponentNudged := appstudiov1alpha1.Component{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "complexComponentNudged",
+			Namespace: "default",
+		},
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "appstudio.redhat.com/v1alpha1",
+			Kind:       "Component",
+		},
+		Spec: appstudiov1alpha1.ComponentSpec{
+			ComponentName:  "complexComponentNudged",
+			Application:    "application1",
+			BuildNudgesRef: []string{"component5", "component6", "component7"},
+		},
+	}
+	err = fakeClient.Create(context.Background(), &complexComponentNudged)
+	require.NoError(t, err)
+
+	component5 := appstudiov1alpha1.Component{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "component5",
+			Namespace: "default",
+		},
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "appstudio.redhat.com/v1alpha1",
+			Kind:       "Component",
+		},
+		Spec: appstudiov1alpha1.ComponentSpec{
+			ComponentName: "component5",
+			Application:   "application1",
+		},
+	}
+	err = fakeClient.Create(context.Background(), &component5)
+	require.NoError(t, err)
+
+	component6 := appstudiov1alpha1.Component{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "component6",
+			Namespace: "default",
+		},
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "appstudio.redhat.com/v1alpha1",
+			Kind:       "Component",
+		},
+		Spec: appstudiov1alpha1.ComponentSpec{
+			ComponentName:  "component6",
+			Application:    "application1",
+			BuildNudgesRef: []string{"component8"},
+		},
+	}
+	err = fakeClient.Create(context.Background(), &component6)
+	require.NoError(t, err)
+
+	component7 := appstudiov1alpha1.Component{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "component7",
+			Namespace: "default",
+		},
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "appstudio.redhat.com/v1alpha1",
+			Kind:       "Component",
+		},
+		Spec: appstudiov1alpha1.ComponentSpec{
+			ComponentName:  "component7",
+			Application:    "application1",
+			BuildNudgesRef: []string{"component9"},
+		},
+	}
+	err = fakeClient.Create(context.Background(), &component7)
+	require.NoError(t, err)
+
+	component8 := appstudiov1alpha1.Component{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "component8",
+			Namespace: "default",
+		},
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "appstudio.redhat.com/v1alpha1",
+			Kind:       "Component",
+		},
+		Spec: appstudiov1alpha1.ComponentSpec{
+			ComponentName: "component8",
+			Application:   "application1",
+		},
+	}
+	err = fakeClient.Create(context.Background(), &component8)
+	require.NoError(t, err)
+
+	component9 := appstudiov1alpha1.Component{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "component9",
+			Namespace: "default",
+		},
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "appstudio.redhat.com/v1alpha1",
+			Kind:       "Component",
+		},
+		Spec: appstudiov1alpha1.ComponentSpec{
+			ComponentName:  "component9",
+			Application:    "application1",
+			BuildNudgesRef: []string{"complexComponent"},
+		},
+	}
+	err = fakeClient.Create(context.Background(), &component9)
+	require.NoError(t, err)
+
+	return fakeClient
+}
+
+// NewFakeErrorClient returns a fake Kube client whose get method returns an error
+// Currently it always returns an error, but can be modified in the future to selectively return errors
+func NewFakeErrorClient(t *testing.T, initObjs ...runtime.Object) *FakeClient {
+	s := scheme.Scheme
+	err := appstudiov1alpha1.AddToScheme(s)
+	require.NoError(t, err)
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(initObjs...).
+		Build()
+	return &FakeClient{Client: cl, MockGet: func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+		return fmt.Errorf("some error")
+	}}
+}
+
+type FakeClient struct {
+	client.Client
+	MockList func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error
+	MockGet  func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error
+}
+
+func (c *FakeClient) Get(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+	if c.MockGet != nil {
+		return c.MockGet(ctx, key, obj)
+	}
+	return c.Client.Get(ctx, key, obj)
 }

--- a/controllers/webhooks/webhook_suite_test.go
+++ b/controllers/webhooks/webhook_suite_test.go
@@ -62,7 +62,7 @@ var _ = BeforeSuite(func() {
 	ctx, cancel = context.WithCancel(context.TODO())
 
 	By("bootstrapping test environment")
-	applicationAPIDepVersion := "v0.0.0-20230616144210-9dad8e40e3ed"
+	applicationAPIDepVersion := "v0.0.0-20231016183051-2dde965fce17"
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join(build.Default.GOPATH, "pkg", "mod", "github.com", "redhat-appstudio", "application-api@"+applicationAPIDepVersion, "manifests")},
 		ErrorIfCRDPathMissing: false,

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/openshift/api v0.0.0-20220912161038-458ad9ca9ca5
 	github.com/pact-foundation/pact-go/v2 v2.0.0-beta.23
 	github.com/prometheus/client_golang v1.16.0
-	github.com/redhat-appstudio/application-api v0.0.0-20230704143842-035c661f115f
+	github.com/redhat-appstudio/application-api v0.0.0-20231016183051-2dde965fce17
 	github.com/redhat-appstudio/application-service/cdq-analysis v0.0.0
 	github.com/redhat-appstudio/operator-toolkit v0.0.0-20230913085326-6c5e9d368a6a
 	github.com/redhat-appstudio/service-provider-integration-operator v0.2023.22-0.20230713080056-eae17aa8c172

--- a/go.sum
+++ b/go.sum
@@ -294,7 +294,6 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bluekeyes/go-gitdiff v0.4.0 h1:Q3qUnQ5cv27vG6ywUTiSQUobRYRcQIBs8KVGKojLg9I=
 github.com/bluekeyes/go-gitdiff v0.4.0/go.mod h1:QpfYYO1E0fTVHVZAZKiRjtSGY9823iCdvGXBcEzHGbM=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
@@ -569,7 +568,6 @@ github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
-github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -803,7 +801,6 @@ github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJr
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
-github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
@@ -879,7 +876,6 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
-github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
@@ -1144,8 +1140,6 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/redhat-appstudio/application-api v0.0.0-20230704143842-035c661f115f h1:XeHZfA9nZQjLBfjwWo2EvL8TiF3vUZLj7AlY19yTUoM=
-github.com/redhat-appstudio/application-api v0.0.0-20230704143842-035c661f115f/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
 github.com/redhat-appstudio/application-api v0.0.0-20231016183051-2dde965fce17 h1:j/PSJj8lrHvW/V06wJzpr7XEa4UBr5QhBmFMm4H8bvY=
 github.com/redhat-appstudio/application-api v0.0.0-20231016183051-2dde965fce17/go.mod h1:E277KEEjL6rEXUHIhc0FQd6jyf3CzCQ7MOkauqF3gt4=
 github.com/redhat-appstudio/operator-toolkit v0.0.0-20230913085326-6c5e9d368a6a h1:pwTvkRzRF6zyLW1Bb4vEuqaNXlGJOnBtt9n5gNp0/r4=
@@ -1196,7 +1190,6 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
-github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
@@ -1252,7 +1245,6 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=

--- a/go.sum
+++ b/go.sum
@@ -294,6 +294,7 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bluekeyes/go-gitdiff v0.4.0 h1:Q3qUnQ5cv27vG6ywUTiSQUobRYRcQIBs8KVGKojLg9I=
 github.com/bluekeyes/go-gitdiff v0.4.0/go.mod h1:QpfYYO1E0fTVHVZAZKiRjtSGY9823iCdvGXBcEzHGbM=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
@@ -568,6 +569,7 @@ github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
+github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -801,6 +803,7 @@ github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJr
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
+github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
@@ -876,6 +879,7 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
@@ -1142,6 +1146,8 @@ github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPH
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/redhat-appstudio/application-api v0.0.0-20230704143842-035c661f115f h1:XeHZfA9nZQjLBfjwWo2EvL8TiF3vUZLj7AlY19yTUoM=
 github.com/redhat-appstudio/application-api v0.0.0-20230704143842-035c661f115f/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
+github.com/redhat-appstudio/application-api v0.0.0-20231016183051-2dde965fce17 h1:j/PSJj8lrHvW/V06wJzpr7XEa4UBr5QhBmFMm4H8bvY=
+github.com/redhat-appstudio/application-api v0.0.0-20231016183051-2dde965fce17/go.mod h1:E277KEEjL6rEXUHIhc0FQd6jyf3CzCQ7MOkauqF3gt4=
 github.com/redhat-appstudio/operator-toolkit v0.0.0-20230913085326-6c5e9d368a6a h1:pwTvkRzRF6zyLW1Bb4vEuqaNXlGJOnBtt9n5gNp0/r4=
 github.com/redhat-appstudio/operator-toolkit v0.0.0-20230913085326-6c5e9d368a6a/go.mod h1:7cX2+4KGZLJ4Yoj+1v0iV5hkCGBzbSd9wkNJQjCdDJs=
 github.com/redhat-appstudio/remote-secret v0.0.0-20230713072146-a6094c712436 h1:6XYknDslXDSVpNqEKnI+gKj3Uu4afK2S+IIH3KogX1E=
@@ -1190,6 +1196,7 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
+github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
@@ -1245,6 +1252,7 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=


### PR DESCRIPTION
### What does this PR do?:
This PR adds changes to the Component's validating webhook to handle the `build-nudges-ref` field:
- If any nudged components belong to a different application, an error is returned and the create/update operation is blocked
- If any nudged components refer to the nudging component, either directly or indirectly, an error is returned and the operation is blocked

This PR also adds back the stub `Default()` functions for the Application and Component webhooks, as they were accidentally removed when migrating the webhooks from application-api. These functions will be needed to implement mutating webhooks as part of [DEVHAS-529](https://issues.redhat.com/browse/DEVHAS-529)
 
### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-528

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [x] Documentation 

N/A

- [x] Client Impact

N/A


### How to test changes / Special notes to the reviewer:
