### PR TITLE
[DEVHAS-514] push protection error

### DIFF
--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -617,7 +617,7 @@ func (r *ComponentReconciler) generateGitops(ctx context.Context, ghClient *gith
 			splited := strings.Split(strings.ToLower(err.Error()), "unblock-secret/")
 			if len(splited) > 1 {
 				token := strings.Split(splited[1], " ")[0]
-				unblockURL = fmt.Sprintf("%v/security/secret-scanning/unblock-secret/%v", gitOpsURL, token)
+				unblockURL = fmt.Sprintf("%v/security/secret-scanning/unblock-secret/%v", component.Status.GitOps.RepositoryURL, token)
 				log.Error(retErr, fmt.Sprintf("unable to generate gitops resources due to git push protecton error, follow the link to unblock the secret: %v", unblockURL))
 			}
 		} else {
@@ -640,7 +640,7 @@ func (r *ComponentReconciler) generateGitops(ctx context.Context, ghClient *gith
 			splited := strings.Split(strings.ToLower(err.Error()), "unblock-secret/")
 			if len(splited) > 1 {
 				token := strings.Split(splited[1], " ")[0]
-				unblockURL = fmt.Sprintf("%v/security/secret-scanning/unblock-secret/%v", gitOpsURL, token)
+				unblockURL = fmt.Sprintf("%v/security/secret-scanning/unblock-secret/%v", component.Status.GitOps.RepositoryURL, token)
 				log.Error(retErr, fmt.Sprintf("unable to commit and push gitops resources due to git push protecton error, follow the link to unblock the secret: %v", unblockURL))
 			}
 		} else {

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -607,18 +608,46 @@ func (r *ComponentReconciler) generateGitops(ctx context.Context, ghClient *gith
 	metrics.ControllerGitRequest.With(prometheus.Labels{"controller": componentName, "tokenName": ghClient.TokenName, "operation": "CloneGenerateAndPush"}).Inc()
 	err = r.Generator.CloneGenerateAndPush(tempDir, gitOpsURL, mappedGitOpsComponent, r.AppFS, gitOpsBranch, gitOpsContext, false)
 	if err != nil {
-		log.Error(err, "unable to generate gitops resources due to error")
+		retErr := err
+		if strings.Contains(strings.ToLower(err.Error()), "github push protection") {
+			retErr = fmt.Errorf("potential secret leak caught by github push protection")
+			// to get the URL token
+			// e.g. <GitURL>/security/secret-scanning/unblock-secret/2WlUv72plUf05tgshlpRLzSlH4R        \n
+			var unblockURL string
+			splited := strings.Split(strings.ToLower(err.Error()), "unblock-secret/")
+			if len(splited) > 1 {
+				token := strings.Split(splited[1], " ")[0]
+				unblockURL = fmt.Sprintf("%v/security/secret-scanning/unblock-secret/%v", gitOpsURL, token)
+				log.Error(retErr, fmt.Sprintf("unable to generate gitops resources due to git push protecton error, follow the link to unblock the secret: %v", unblockURL))
+			}
+		} else {
+			log.Error(retErr, "unable to generate gitops resources due to error")
+		}
 		ioutils.RemoveFolderAndLogError(log, r.AppFS, tempDir)
-		return err
+		return retErr
 	}
 
 	//Gitops functions return sanitized error messages
 	metrics.ControllerGitRequest.With(prometheus.Labels{"controller": componentName, "tokenName": ghClient.TokenName, "operation": "CommitAndPush"}).Inc()
 	err = r.Generator.CommitAndPush(tempDir, "", gitOpsURL, mappedGitOpsComponent.Name, gitOpsBranch, "Generating GitOps resources")
 	if err != nil {
-		log.Error(err, "unable to commit and push gitops resources due to error")
+		retErr := err
+		if strings.Contains(strings.ToLower(err.Error()), "github push protection") {
+			retErr = fmt.Errorf("potential secret leak caught by github push protection")
+			// to get the URL token
+			// e.g. <GitURL>/security/secret-scanning/unblock-secret/2WlUv72plUf05tgshlpRLzSlH4R        \n
+			var unblockURL string
+			splited := strings.Split(strings.ToLower(err.Error()), "unblock-secret/")
+			if len(splited) > 1 {
+				token := strings.Split(splited[1], " ")[0]
+				unblockURL = fmt.Sprintf("%v/security/secret-scanning/unblock-secret/%v", gitOpsURL, token)
+				log.Error(retErr, fmt.Sprintf("unable to commit and push gitops resources due to git push protecton error, follow the link to unblock the secret: %v", unblockURL))
+			}
+		} else {
+			log.Error(retErr, "unable to commit and push gitops resources due to error")
+		}
 		ioutils.RemoveFolderAndLogError(log, r.AppFS, tempDir)
-		return err
+		return retErr
 	}
 
 	// Get the commit ID for the gitops repository


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
This PR set a more user friendly error message for git push protection error. 

before this change, the message was too long and hard to read, also exposed the unblock-secret URL to the end user
```
    Last Transition Time:  2023-10-23T21:57:49Z
    Message:               Component updated failed: Unable to generate gitops resources for component application-service-system/devfile-sample-go-basic3: failed to push remote to repository "https://<TOKEN>@github.com/redhat-appstudio-appdata/application-sample2-2Ej_G-comply-travel" "remote: error: GH013: Repository rule violations found for refs/heads/main.        \nremote: Review all repository rules at http://github.com/redhat-appstudio-appdata/application-sample2-2Ej_G-comply-travel/rules?ref=refs%2Fheads%2Fmain        \nremote: \nremote: - GITHUB PUSH PROTECTION        \nremote:   ——————————————————————————————————————————————————————        \nremote:    Resolve the following secrets before pushing again.        \nremote:           \nremote:    (?) Learn how to resolve a blocked push        \nremote:    https://docs.github.com/code-security/secret-scanning/pushing-a-branch-blocked-by-push-protection        \nremote:           \nremote:           \nremote:   —— GitHub Personal Access Token ——————————————————————        \nremote:    locations:        \nremote:      - commit: 0a5b103f093ee971010e620a99c88d2b3c4a7664        \nremote:        path: components/devfile-sample-go-basic3/base/deployment.yaml:34        \nremote:           \nremote:    (?) To push, remove secret from commit(s) or follow this URL to allow the secret.        \nremote:    https://github.com/redhat-appstudio-appdata/application-sample2-2Ej_G-comply-travel/security/secret-scanning/unblock-secret/2XBMxzO3gwqvUrkFENwEIF43Hze        \nremote: \nTo https://github.com/redhat-appstudio-appdata/application-sample2-2Ej_G-comply-travel\n ! [remote rejected] main -> main (push declined due to repository rule violations)\nerror: failed to push some refs to 'https://github.com/redhat-appstudio-appdata/application-sample2-2Ej_G-comply-travel'\n": exit status 1
    Reason:                Error
    Status:                False
    Type:                  Updated
```

With this change: 
```
    Last Transition Time:  2023-10-26T16:36:32Z
    Message:               Component create failed: Unable to generate gitops resources for component application-service-system/devfile-sample-go-basic3: potential secret leak caught by github push protection
    Reason:                Error
    Status:                False
    Type:                  Created
```

Also use a log message to expose the URL to unblock secret to org admin/ security manager. 
an SOP will be created for org admin/security manager on how to get the link from log to unblock false positive case.
(The following example link is already invalid, as I deleted the application already)
```
{"level":"error","ts":"2023-10-26T16:36:31.981Z","msg":"unable to commit and push gitops resources due to git push protecton error, follow the link to unblock the secret: https://github.com/redhat-appstudio-appdata/application-sample2-2Ej_G-strengthen-overcome/security/secret-scanning/unblock-secret/2xjdggfxak2a9qdwixqkffrx3x2","controller":"component","controllerGroup":"appstudio.redhat.com","controllerKind":"Component","Component":{"name":"devfile-sample-go-basic3","namespace":"application-service-system"}
```


### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
https://issues.redhat.com/browse/DEVHAS-514

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
