### PR TITLE
[DEVHAS-514]update SEB with the proper error message set

### DIFF
--- a/controllers/update.go
+++ b/controllers/update.go
@@ -131,14 +131,14 @@ func (r *ComponentReconciler) updateComponentDevfileModel(req ctrl.Request, hasC
 			for i, devfileEnv := range currentENV {
 				if devfileEnv.Name == name {
 					isPresent = true
-					log.Info(fmt.Sprintf("setting devfileComponent %s env %s value to %v", kubernetesComponent.Name, devfileEnv.Name, value))
+					log.Info(fmt.Sprintf("setting devfileComponent %s env %s", kubernetesComponent.Name, devfileEnv.Name))
 					devfileEnv.Value = value
 					currentENV[i] = devfileEnv
 				}
 			}
 
 			if !isPresent {
-				log.Info(fmt.Sprintf("appending to devfile component %s env %s : %v", kubernetesComponent.Name, name, value))
+				log.Info(fmt.Sprintf("appending to devfile component %s env %s", kubernetesComponent.Name, name))
 				currentENV = append(currentENV, env)
 			}
 			var err error


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
Similarly as https://github.com/redhat-appstudio/application-service/pull/404
update the push protection error message for SEB controller, and also update the log message to not logging the ENV values to avoid potential secret leak in log. 

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
https://issues.redhat.com/browse/DEVHAS-514

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
