### PR TITLE
[DEVHAS-490] Mocking CDQ Util for Private Repo Testing

### DIFF
--- a/cdq-analysis/main.go
+++ b/cdq-analysis/main.go
@@ -94,13 +94,15 @@ func main() {
 		CreateK8sJob: createK8sJob,
 	}
 
-	cdqInfo := &pkg.CDQInfoClient{
+	cdqInfo := &pkg.CDQInfo{
 		DevfileRegistryURL: DevfileRegistryURL,
 		GitURL:             pkg.GitURL{RepoURL: URL, Revision: Revision, Token: gitToken},
 	}
 
+	cdqUtil := pkg.NewCDQUtilClient()
+
 	/* #nosec G104 -- the main.go is triggerred by docker image, and the result as well as the error will be send by the k8s job*/
-	pkg.CloneAndAnalyze(k8sInfoClient, namespace, name, contextPath, cdqInfo)
+	pkg.CloneAndAnalyze(k8sInfoClient, namespace, name, contextPath, cdqInfo, cdqUtil)
 
 }
 

--- a/cdq-analysis/pkg/componentdetectionquery.go
+++ b/cdq-analysis/pkg/componentdetectionquery.go
@@ -132,8 +132,9 @@ func clone(k K8sInfoClient, cdqInfo *CDQInfo, namespace, name, context string) e
 	return nil
 }
 
-// CloneAndAnalyze clones and analyzes the Git repo with Alizer if necessary
-func CloneAndAnalyze(k K8sInfoClient, namespace, name, context string, cdqInfo *CDQInfo, cdqUtil CDQUtil) (map[string][]byte, map[string]string, map[string]string, map[string][]int, string, error) {
+// CloneAndAnalyze clones and analyzes the Git repo with Alizer if necessary and returns
+// devfilesMap, devfilesURLMap, dockerfileContextMap, componentPortsMap, revision and an error
+func CloneAndAnalyze(k K8sInfoClient, namespace, name, context string, cdqInfo *CDQInfo, cdqUtil CDQUtil) (devfilesMap map[string][]byte, devfilesURLMap map[string]string, dockerfileContextMap map[string]string, componentPortsMap map[string][]int, revision string, err error) {
 	if cdqInfo == nil {
 		return nil, nil, nil, nil, "", fmt.Errorf("CDQ cannot clone and analyze because no information was passed to it")
 	}
@@ -141,12 +142,11 @@ func CloneAndAnalyze(k K8sInfoClient, namespace, name, context string, cdqInfo *
 	log := k.Log
 	var clonePath, componentPath string
 	alizerClient := AlizerClient{}
-	devfilesMap := make(map[string][]byte)
-	devfilesURLMap := make(map[string]string)
-	dockerfileContextMap := make(map[string]string)
-	componentPortsMap := make(map[string][]int)
+	devfilesMap = make(map[string][]byte)
+	devfilesURLMap = make(map[string]string)
+	dockerfileContextMap = make(map[string]string)
+	componentPortsMap = make(map[string][]int)
 	var Fs afero.Afero
-	var err error
 
 	var components []model.Component
 
@@ -178,7 +178,7 @@ func CloneAndAnalyze(k K8sInfoClient, namespace, name, context string, cdqInfo *
 	Fs = cdqInfo.ClonedRepo.Fs
 	componentPath = cdqInfo.ClonedRepo.ComponentPath
 	clonePath = cdqInfo.ClonedRepo.ClonedPath
-	revision := cdqInfo.GitURL.Revision
+	revision = cdqInfo.GitURL.Revision
 	devfilePath := cdqInfo.devfilePath
 	dockerfilePath := cdqInfo.dockerfilePath
 

--- a/cdq-analysis/pkg/componentdetectionquery_test.go
+++ b/cdq-analysis/pkg/componentdetectionquery_test.go
@@ -228,11 +228,11 @@ func TestCloneAndAnalyze(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.testCase, func(t *testing.T) {
-			cdqInfo := &CDQInfoClient{
+			cdqInfo := &CDQInfo{
 				DevfileRegistryURL: tt.DevfileRegistryURL,
 				GitURL:             GitURL{RepoURL: tt.URL, Revision: tt.Revision, Token: tt.gitToken},
 			}
-			devfilesMap, devfilesURLMap, dockerfileContextMap, componentsPortMap, branch, err := CloneAndAnalyze(k8sClient, namespaceName, compName, tt.context, cdqInfo)
+			devfilesMap, devfilesURLMap, dockerfileContextMap, componentsPortMap, branch, err := CloneAndAnalyze(k8sClient, namespaceName, compName, tt.context, cdqInfo, NewCDQUtilClient())
 			if (err != nil) != (tt.wantErr != "") {
 				t.Errorf("got unexpected error %v", err)
 			} else if err == nil {
@@ -392,19 +392,19 @@ metadata:
 func TestGetDevfileAndDockerFilePaths(t *testing.T) {
 	tests := []struct {
 		testCase           string
-		cdqInfo            CDQInfoClient
+		cdqInfo            CDQInfo
 		wantDevfilePath    string
 		wantDockerfilePath string
 	}{
 		{
 			testCase:           "Unset dockerfilepath and devfilepath",
-			cdqInfo:            CDQInfoClient{},
+			cdqInfo:            CDQInfo{},
 			wantDevfilePath:    "",
 			wantDockerfilePath: "",
 		},
 		{
 			testCase:           "Set dockerfilepath and devfilepath",
-			cdqInfo:            CDQInfoClient{dockerfilePath: "/dockerfile", devfilePath: "devfile.yml"},
+			cdqInfo:            CDQInfo{dockerfilePath: "/dockerfile", devfilePath: "devfile.yml"},
 			wantDevfilePath:    "devfile.yml",
 			wantDockerfilePath: "/dockerfile",
 		},

--- a/cdq-analysis/pkg/detect_test.go
+++ b/cdq-analysis/pkg/detect_test.go
@@ -253,7 +253,7 @@ components:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			devfileBytes := []byte(tt.devfileString)
-			dockerfileImage, err := SearchForDockerfile(devfileBytes, "")
+			dockerfileImage, err := SearchForDockerfile(devfileBytes)
 			if !tt.wantErr && err != nil {
 				t.Errorf("Unexpected err: %+v", err)
 			} else if tt.wantErr && err == nil {

--- a/cdq-analysis/pkg/devfile_test.go
+++ b/cdq-analysis/pkg/devfile_test.go
@@ -286,11 +286,11 @@ func TestScanRepo(t *testing.T) {
 			if err != nil {
 				t.Errorf("got unexpected error %v", err)
 			} else {
-				devfileInfo := CDQInfoClient{
+				devfileInfo := CDQInfo{
 					DevfileRegistryURL: DevfileStageRegistryEndpoint,
 					GitURL:             GitURL{RepoURL: URL},
 				}
-				devfileMap, devfileURLMap, dockerfileMap, portsMap, err := ScanRepo(logger, alizerClient, tt.clonePath, "", devfileInfo)
+				devfileMap, devfileURLMap, dockerfileMap, portsMap, err := ScanRepo(logger, alizerClient, tt.clonePath, "", devfileInfo, NewCDQUtilClient())
 				if tt.wantErr && (err == nil) {
 					t.Error("wanted error but got nil")
 				} else if !tt.wantErr && err != nil {
@@ -430,7 +430,8 @@ func TestValidateDevfile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			shouldIgnoreDevfile, devfileBytes, err := ValidateDevfile(logger, tt.url, "")
+			cdqUtil := NewCDQUtilClient()
+			shouldIgnoreDevfile, devfileBytes, err := cdqUtil.ValidateDevfile(logger, tt.url, "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("TestValidateDevfile() unexpected error: %v", err)
 			}

--- a/cdq-analysis/pkg/mock.go
+++ b/cdq-analysis/pkg/mock.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pkg
+
+import "github.com/go-logr/logr"
+
+type CDQUtilMockClient struct {
+}
+
+func NewCDQUtilMockClient() CDQUtilMockClient {
+	return CDQUtilMockClient{}
+}
+
+func (cdqUtilMockClient CDQUtilMockClient) Clone(k K8sInfoClient, cdqInfo *CDQInfo, namespace, name, context string) error {
+
+	if cdqInfo == nil {
+		return nil
+	}
+
+	if cdqInfo.GitURL.Token == "valid-mock-token" {
+		// This is a private repository case
+		// Since we are not actually testing with a valid token,
+		// mock the clone by calling a valid public repository instead.
+		// This way, we can plug into the existing code where
+		// CDQ can search for a devfile or a Dockerfile and
+		// possibly use Alizer. By doing this check,
+		// CDQ now assumes its a public repository path
+		// by working around it and we can proceed
+		// with the private repository test
+
+		cdqInfo.GitURL.Token = ""
+	}
+
+	return clone(k, cdqInfo, namespace, name, context)
+}
+
+func (cdqUtilMockClient CDQUtilMockClient) ValidateDevfile(log logr.Logger, devfileLocation string, token string) (shouldIgnoreDevfile bool, devfileBytes []byte, err error) {
+
+	if token == "valid-mock-token" {
+		// This is a private repository case
+		// Since we are not actually testing with a valid token,
+		// mock the clone by calling a valid public repository instead.
+		// This way, we can plug into the existing code where
+		// CDQ can search for a devfile or a Dockerfile and
+		// possibly use Alizer. By doing this check,
+		// CDQ now assumes its a public repository path
+		// by working around it and we can proceed
+		// with the private repository test
+
+		token = ""
+	}
+
+	return validateDevfile(log, devfileLocation, token)
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,7 +5,8 @@ ignore:
   - "controllers/start_test_env.go" # setup of a test environment for unit and Pact tests
   - "controllers/application_pact_test_state_handlers.go" # state handlers for the Pact tests
   - "controllers/application_pact_test_utils.go" # utils file for the Pact tests
-  - "cdq-analysis/pkg/detect_mock.go" # mock file for testing
+  - "cdq-analysis/pkg/detect_mock.go" # mock file for testing CDQ detection logic
+  - "cdq-analysis/pkg/mock.go" # mock file for CDQUtil interface methods
   - "cdq-analysis/main.go" # entry point for cdq-analysis docker image
   - "pkg/github/mock.go" # mock file for testing
   - "pkg/github/token_mock.go" # mock file for testing

--- a/controllers/start_test_env.go
+++ b/controllers/start_test_env.go
@@ -132,6 +132,7 @@ func SetupTestEnv() (client.Client, *envtest.Environment, context.Context, conte
 		Config:             cfg,
 		RunKubernetesJob:   true,
 		CdqAnalysisImage:   cdqAnalysisImage,
+		CDQUtil:            cdqanalysis.NewCDQUtilMockClient(),
 	}).SetupWithManager(ctx, k8sManager)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 

--- a/controllers/update.go
+++ b/controllers/update.go
@@ -309,7 +309,7 @@ func (r *ApplicationReconciler) getAndAddComponentApplicationsToModel(log logr.L
 	return nil
 }
 
-func (r *ComponentDetectionQueryReconciler) updateComponentStub(req ctrl.Request, ctx context.Context, componentDetectionQuery *appstudiov1alpha1.ComponentDetectionQuery, devfilesMap map[string][]byte, devfilesURLMap map[string]string, dockerfileContextMap map[string]string, componentPortsMap map[string][]int, token string) error {
+func (r *ComponentDetectionQueryReconciler) updateComponentStub(req ctrl.Request, ctx context.Context, componentDetectionQuery *appstudiov1alpha1.ComponentDetectionQuery, devfilesMap map[string][]byte, devfilesURLMap map[string]string, dockerfileContextMap map[string]string, componentPortsMap map[string][]int) error {
 
 	if componentDetectionQuery == nil {
 		return fmt.Errorf("componentDetectionQuery is nil")
@@ -326,7 +326,7 @@ func (r *ComponentDetectionQueryReconciler) updateComponentStub(req ctrl.Request
 	for context, devfileBytes := range devfilesMap {
 		log.Info(fmt.Sprintf("Currently reading the devfile for context %v", context))
 		// Parse the Component Devfile
-		compDevfileData, err := cdqanalysis.ParseDevfileWithParserArgs(&parser.ParserArgs{Data: devfileBytes, Token: token})
+		compDevfileData, err := cdqanalysis.ParseDevfileWithParserArgs(&parser.ParserArgs{Data: devfileBytes})
 		if err != nil {
 			return err
 		}

--- a/controllers/update_test.go
+++ b/controllers/update_test.go
@@ -1763,9 +1763,9 @@ func TestUpdateComponentStub(t *testing.T) {
 			}
 			var err error
 			if tt.isNil {
-				err = r.updateComponentStub(ctrl.Request{}, ctx, nil, devfilesMap, nil, nil, nil, "")
+				err = r.updateComponentStub(ctrl.Request{}, ctx, nil, devfilesMap, nil, nil, nil)
 			} else {
-				err = r.updateComponentStub(ctrl.Request{}, ctx, &componentDetectionQuery, devfilesMap, tt.devfilesURLMap, tt.dockerfileURLMap, tt.componentPortsMap, "")
+				err = r.updateComponentStub(ctrl.Request{}, ctx, &componentDetectionQuery, devfilesMap, tt.devfilesURLMap, tt.dockerfileURLMap, tt.componentPortsMap)
 			}
 
 			if tt.wantErr && (err == nil) {

--- a/main.go
+++ b/main.go
@@ -218,6 +218,7 @@ func main() {
 		CdqAnalysisImage:   cdqAnalysisImage,
 		RunKubernetesJob:   RunKubernetesJob,
 		Config:             config,
+		CDQUtil:            cdqanalysis.NewCDQUtilClient(),
 	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ComponentDetectionQuery")
 		os.Exit(1)


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
- Introduces CDQUtil interface to abstract out CDQ logic which utilizes a git token, so that we can mock valid cases for tests with a private repo
- Remove unnecessary token usage when invoking devfile/library because we dont need a token to read byte strings
- Adds controller tests out lined in https://issues.redhat.com/browse/DEVHAS-490

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
https://issues.redhat.com/browse/DEVHAS-490

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
Run the tests `make test`