### PR TITLE
[DEVHAS-549]remove clonepath after cdq is done

### DIFF
--- a/cdq-analysis/pkg/componentdetectionquery.go
+++ b/cdq-analysis/pkg/componentdetectionquery.go
@@ -239,12 +239,13 @@ func (k K8sInfoClient) SendBackDetectionResult(devfilesMap map[string][]byte, de
 	log := k.Log
 	if !k.CreateK8sJob {
 		log.Info("Skip creating the job...")
-		// remove the clone path after cdq is done
+		// remove the clone path after cdq
 		if isExist, _ := IsExisting(Fs, clonePath); isExist {
 			if err := Fs.RemoveAll(clonePath); err != nil {
 				log.Error(err, fmt.Sprintf("Unable to remove the clonepath %s %v", clonePath, namespace))
 			}
 		}
+		return
 	}
 	log.Info(fmt.Sprintf("Sending back result, devfilesMap %v,devfilesURLMap %v, dockerfileContextMap %v, componentPortsMap %v, error %v ... %v", devfilesMap, devfilesURLMap, dockerfileContextMap, componentPortsMap, completeError, namespace))
 

--- a/cdq-analysis/pkg/componentdetectionquery_test.go
+++ b/cdq-analysis/pkg/componentdetectionquery_test.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -274,6 +275,7 @@ func TestSendBackDetectionResult(t *testing.T) {
 	ctx := context.TODO()
 	clientset := fake.NewSimpleClientset()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{})))
+	Fs := afero.Afero{}
 	log := ctrl.Log.WithName("TestSendBackDetectionResult")
 
 	k8sClient := K8sInfoClient{
@@ -374,7 +376,7 @@ metadata:
 	}
 	for _, tt := range tests {
 		t.Run(tt.testCase, func(t *testing.T) {
-			k8sClient.SendBackDetectionResult(tt.devfilesMap, tt.devfilesURLMap, tt.dockerfileContextMap, tt.componentPortsMap, revision, compName, namespaceName, tt.err)
+			k8sClient.SendBackDetectionResult(tt.devfilesMap, tt.devfilesURLMap, tt.dockerfileContextMap, tt.componentPortsMap, revision, compName, namespaceName, "", Fs, tt.err)
 			configMap, err := clientset.CoreV1().ConfigMaps(namespaceName).Get(k8sClient.Ctx, compName, metav1.GetOptions{})
 			if err != nil {
 				t.Errorf("got unexpected error %v", err)


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
This PR move the logic of removing clonepath to beginning of `SendBackDetectionResult`, ensure the clonepath is cleaned if execute with go module when CDQ is done, regardless of error or success case. 

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
https://issues.redhat.com/browse/DEVHAS-549

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
