### PR TITLE
Update codecov ignore list - ignore token mock and contract test files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,3 +9,4 @@ ignore:
   - "cdq-analysis/main.go" # entry point for cdq-analysis docker image
   - "pkg/github/mock.go" # mock file for testing
   - "pkg/github/token_moke.go" # mock file for testing
+  - "contracts/" # contract testing files

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,5 +8,5 @@ ignore:
   - "cdq-analysis/pkg/detect_mock.go" # mock file for testing
   - "cdq-analysis/main.go" # entry point for cdq-analysis docker image
   - "pkg/github/mock.go" # mock file for testing
-  - "pkg/github/token_moke.go" # mock file for testing
+  - "pkg/github/token_mock.go" # mock file for testing
   - "contracts/" # contract testing files


### PR DESCRIPTION
Those files are test only, and shouldn't be included in coverage calculations

