### PR TITLE
Get application in retry blocks

### DIFF
--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -154,7 +154,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 					return err
 				}
 
-				controllerutil.RemoveFinalizer(&application, appFinalizerName)
+				controllerutil.RemoveFinalizer(&currentApplication, appFinalizerName)
 
 				err = r.Update(ctx, &application)
 				return err

--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -156,7 +156,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 				controllerutil.RemoveFinalizer(&currentApplication, appFinalizerName)
 
-				err = r.Update(ctx, &application)
+				err = r.Update(ctx, &currentApplication)
 				return err
 			})
 			if err != nil {


### PR DESCRIPTION
### What does this PR do?:
Retry blocks need to include a "get" in them, so this PR updates the retry blocks added in https://github.com/redhat-appstudio/application-service/pull/417 to include Get API calls.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-547

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
