### PR TITLE
Fix deployment spec when replica set to 0

### DIFF
--- a/pkg/devfile/devfile.go
+++ b/pkg/devfile/devfile.go
@@ -166,9 +166,7 @@ func GetResourceFromDevfile(log logr.Logger, devfileData data.DevfileData, deplo
 						resources.Deployments[0].Spec.Template.ObjectMeta.Labels = matchLabels
 					}
 
-					if currentReplica > 0 {
-						resources.Deployments[0].Spec.Replicas = &currentReplica
-					}
+					resources.Deployments[0].Spec.Replicas = &currentReplica
 
 					if len(resources.Deployments[0].Spec.Template.Spec.Containers) > 0 {
 						if image != "" {

--- a/pkg/devfile/devfile_test.go
+++ b/pkg/devfile/devfile_test.go
@@ -1210,6 +1210,7 @@ components:
     deployment/container-port: 1111
     deployment/storageLimit: 401Mi
     deployment/storageRequest: 201Mi
+    deployment/replicas: 1
   kubernetes:
     deployByDefault: false
     endpoints:
@@ -1307,6 +1308,7 @@ components:
     deployment/container-port: 1111
     deployment/storageLimit: 401Mi
     deployment/storageRequest: 201Mi
+    deployment/replicas: 1
   kubernetes:
     deployByDefault: false
     endpoints:
@@ -1421,6 +1423,7 @@ components:
     deployment/container-port: 1111
     deployment/storageLimit: 401Mi
     deployment/storageRequest: 201Mi
+    deployment/replicas: 1
   kubernetes:
     deployByDefault: false
     endpoints:
@@ -1530,6 +1533,7 @@ components:
 - attributes:
     api.devfile.io/k8sLikeComponent-originalURI: deploy.yaml
     deployment/container-port: 5566
+    deployment/replicas: 1
   kubernetes:
     deployByDefault: false
     endpoints:


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

Removes the if statement that was used to set the replica field in the deployment spec since it should always be set to a value.   If field is unset, it should have a default value of 0.  

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
https://issues.redhat.com/browse/RHTAPBUGS-12

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [X ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->
Updated the unit tests to include the expected component attributes values for `deployment/replicas`

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:

Manually tested:
1.  Built the HAS image and deployed on a local cluster.  Created a token with read and write permissions to write into a test org
2. Deployed the sample [Application](https://github.com/redhat-appstudio/application-service/blob/main/config/samples/application/app.yaml) and [Component](https://github.com/redhat-appstudio/application-service/blob/main/config/samples/component/component-basic.yaml).  Verified the [replica was set to 1](https://github.com/has-test-org/application-sample-N6juw-plan-cope/commit/c18d9b31b12bebecc9bcbc3091a172189844840c) in the generated deployment
3. Updated the Component CR to set replicas to 0.  Verified the [replica was set to 0](https://github.com/has-test-org/application-sample-N6juw-plan-cope/commit/d363cd3f08b9c042a39018b4093d223319827272) in the generated deployment
4. Updated the Component CR to remove the replica field.  This did not trigger an update since existing deployment was equivalent.   Internally, the deployed CR instance had the replica field removed but the   `deployment/replicas: 0` attribute remained
