### PR TITLE
RHTAP-1134: Remove the check for valid SCM vendor

### DIFF
--- a/controllers/webhooks/component_webhook.go
+++ b/controllers/webhooks/component_webhook.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"strings"
 
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/application-service/pkg/util"
@@ -100,9 +99,6 @@ func (r *ComponentWebhook) UpdateNudgedComponentStatus(ctx context.Context, obj 
 	return nil
 }
 
-// Github is the only supported vendor right now
-const SupportedGitRepo = "github.com"
-
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // +kubebuilder:webhook:path=/validate-appstudio-redhat-com-v1alpha1-component,mutating=false,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=components,verbs=create;update,versions=v1alpha1,name=vcomponent.kb.io,admissionReviewVersions=v1
 
@@ -119,12 +115,9 @@ func (r *ComponentWebhook) ValidateCreate(ctx context.Context, obj runtime.Objec
 	sourceSpecified := false
 
 	if comp.Spec.Source.GitSource != nil && comp.Spec.Source.GitSource.URL != "" {
-		if gitsourceURL, err := url.ParseRequestURI(comp.Spec.Source.GitSource.URL); err != nil {
+		if _, err := url.ParseRequestURI(comp.Spec.Source.GitSource.URL); err != nil {
 			return fmt.Errorf(err.Error() + appstudiov1alpha1.InvalidSchemeGitSourceURL)
-		} else if SupportedGitRepo != strings.ToLower(gitsourceURL.Host) {
-			return fmt.Errorf(appstudiov1alpha1.InvalidGithubVendorURL, gitsourceURL, SupportedGitRepo)
 		}
-
 		sourceSpecified = true
 	} else if comp.Spec.ContainerImage != "" {
 		sourceSpecified = true

--- a/controllers/webhooks/component_webhook_test.go
+++ b/controllers/webhooks/component_webhook_test.go
@@ -94,12 +94,6 @@ var _ = Describe("Application validation webhook", func() {
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring(errors.New("invalid URI for request" + appstudiov1alpha1.InvalidSchemeGitSourceURL).Error()))
 
-			//Bad URL with unsupported vendor
-			hasComp.Spec.Source.GitSource.URL = "http://url"
-			err = k8sClient.Create(ctx, hasComp)
-			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring(fmt.Errorf(appstudiov1alpha1.InvalidGithubVendorURL, "http://url", SupportedGitRepo).Error()))
-
 			// Good URL
 			hasComp.Spec.Source.GitSource.URL = SampleRepoLink
 			err = k8sClient.Create(ctx, hasComp)

--- a/controllers/webhooks/component_webhook_unit_test.go
+++ b/controllers/webhooks/component_webhook_unit_test.go
@@ -100,27 +100,6 @@ func TestComponentCreateValidatingWebhook(t *testing.T) {
 			},
 		},
 		{
-			name:   "valid component with invalid git vendor src",
-			client: fakeClient,
-			err:    fmt.Errorf(appstudiov1alpha1.InvalidGithubVendorURL, "http://url", SupportedGitRepo).Error(),
-			newComp: appstudiov1alpha1.Component{
-				ObjectMeta: v1.ObjectMeta{
-					Name: "test-component",
-				},
-				Spec: appstudiov1alpha1.ComponentSpec{
-					ComponentName: "component1",
-					Application:   "application1",
-					Source: appstudiov1alpha1.ComponentSource{
-						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
-							GitSource: &appstudiov1alpha1.GitSource{
-								URL: "http://url",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
 			name:   "valid component with invalid git scheme src",
 			client: fakeClient,
 			err:    "invalid URI for request" + appstudiov1alpha1.InvalidSchemeGitSourceURL,


### PR DESCRIPTION
- Required for supporting components with source in Gitlab.
- The current check was over simplified and assumed the structure of the SCM's hostname, which can be anything (we can only require for it to be a url).

