### PR TITLE
Rework replica logic

### DIFF
--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -1494,7 +1494,7 @@ var _ = Describe("Component controller", func() {
 			Expect(createdHasComp.Spec.Replicas).Should(BeNil())
 
 			//Update replica
-			updatedHasComp.Spec.Replicas = &numReplica
+			updatedHasComp.Spec.Replicas = &oneReplica
 			Expect(k8sClient.Update(ctx, updatedHasComp)).Should(Succeed())
 			newUpdatedHasComp := &appstudiov1alpha1.Component{}
 			Eventually(func() bool {
@@ -1505,7 +1505,7 @@ var _ = Describe("Component controller", func() {
 			Expect(newUpdatedHasComp.Status.Conditions[len(newUpdatedHasComp.Status.Conditions)-1].Status).Should(Equal(metav1.ConditionTrue))
 			//replica should not be nil and should have a value
 			Expect(newUpdatedHasComp.Spec.Replicas).Should(Not(BeNil()))
-			Expect(*newUpdatedHasComp.Spec.Replicas).Should(Equal(numReplica))
+			Expect(*newUpdatedHasComp.Spec.Replicas).Should(Equal(oneReplica))
 
 			// Delete the specified HASComp resource
 			deleteHASCompCR(hasCompLookupKey)

--- a/controllers/update.go
+++ b/controllers/update.go
@@ -70,24 +70,75 @@ func (r *ComponentReconciler) updateComponentDevfileModel(req ctrl.Request, hasC
 	for _, kubernetesComponent := range kubernetesComponents {
 		compUpdateRequired := false
 		// Update for Replica
-		currentReplica := 0
+		currentReplica := 1 // default value is 1
+		keyFound := true
+
 		if len(kubernetesComponent.Attributes) == 0 {
 			kubernetesComponent.Attributes = attributes.Attributes{}
+			keyFound = false
 		} else {
 			var err error
 			currentReplica = int(kubernetesComponent.Attributes.GetNumber(devfile.ReplicaKey, &err))
 			if err != nil {
 				if _, ok := err.(*attributes.KeyNotFoundError); !ok {
 					return err
+				} else {
+					keyFound = false
+					currentReplica = 1 //if an error is raised, it'll set currentReplica to 0 so we need to reset back to the default
 				}
 			}
 		}
 
-		numReplicas := util.GetIntValue(component.Spec.Replicas)
-		if currentReplica != numReplicas {
-			log.Info(fmt.Sprintf("setting devfile component %s attribute component.Spec.Replicas to %v", kubernetesComponent.Name, numReplicas))
-			kubernetesComponent.Attributes = kubernetesComponent.Attributes.PutInteger(devfile.ReplicaKey, numReplicas)
-			compUpdateRequired = true
+		numReplicas := 1 //default value
+		if component.Spec.Replicas != nil {
+			numReplicas = util.GetIntValue(component.Spec.Replicas)
+			// Component.Spec.Replicas will override any other settings.
+			// We will write the attribute if it doesn't exist for the initial creation case when comp.spec.replica is 1
+			if currentReplica != numReplicas || !keyFound {
+				log.Info(fmt.Sprintf("setting devfile component %s attribute component.Spec.Replicas to %v", kubernetesComponent.Name, numReplicas))
+				kubernetesComponent.Attributes = kubernetesComponent.Attributes.PutInteger(devfile.ReplicaKey, numReplicas)
+				compUpdateRequired = true
+			}
+		} else {
+			//check to see if we have an inlined deployment
+			isDeployReplicaSet := false
+			inlined := kubernetesComponent.Kubernetes.Inlined
+			if inlined != "" {
+				log.Info(fmt.Sprintf("reading the kubernetes inline from component %s", component.Name))
+				src := parser.YamlSrc{
+					Data: []byte(inlined),
+				}
+
+				values, err := parser.ReadKubernetesYaml(src, nil, nil)
+				if err != nil {
+					return err
+				}
+
+				resources, err := parser.ParseKubernetesYaml(values)
+				if err != nil {
+					return err
+				}
+
+				if len(resources.Deployments) > 0 {
+					replica := resources.Deployments[0].Spec.Replicas
+					if replica != nil {
+						isDeployReplicaSet = true
+						//remove the deployment/replicas attribute which can be left behind if we go from a set value to an unset value
+						if kubernetesComponent.Attributes.Exists(devfile.ReplicaKey) {
+							num := int(kubernetesComponent.Attributes.GetNumber(devfile.ReplicaKey, nil))
+							log.Info(fmt.Sprintf("deleting %s attribute with value %v", devfile.ReplicaKey, num))
+							delete(kubernetesComponent.Attributes, devfile.ReplicaKey)
+						}
+					}
+				}
+			}
+
+			//set the default if replicas is unset in the component and deployment spec.
+			if !isDeployReplicaSet {
+				log.Info(fmt.Sprintf("setting devfile component %s attribute component.Spec.Replicas to %v", kubernetesComponent.Name, 1))
+				kubernetesComponent.Attributes = kubernetesComponent.Attributes.PutInteger(devfile.ReplicaKey, 1)
+				compUpdateRequired = true
+			}
 		}
 
 		// Update for Port

--- a/controllers/update_test.go
+++ b/controllers/update_test.go
@@ -44,7 +44,60 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-var numReplica = 1
+var (
+	oneReplica    = 1
+	zeroReplica   = 0
+	threeReplicas = 3
+)
+
+var k8sInlined = ` 
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        creationTimestamp: null
+        labels:
+          maysun: test
+        name: deploy-sample
+      spec:
+        replicas: 3
+        selector: {}
+        strategy: {}
+        template:
+          metadata:
+            creationTimestamp: null
+            labels:
+              app.kubernetes.io/instance: component-sample
+          spec:
+            containers:
+            - env:
+              - name: FOO
+                value: foo1
+              - name: BARBAR
+                value: bar1
+              image: quay.io/redhat-appstudio/user-workload:application-service-system-component-sample
+              imagePullPolicy: Always
+              livenessProbe:
+                httpGet:
+                  path: /
+                  port: 1111
+                initialDelaySeconds: 10
+                periodSeconds: 10
+              name: container-image
+              ports:
+              - containerPort: 1111
+              readinessProbe:
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                tcpSocket:
+                  port: 1111
+              resources:
+                limits:
+                  cpu: "2"
+                  memory: 500Mi
+                requests:
+                  cpu: 700m
+                  memory: 400Mi
+      status: {}`
 
 func TestUpdateApplicationDevfileModel(t *testing.T) {
 	tests := []struct {
@@ -617,6 +670,7 @@ func TestUpdateComponentDevfileModel(t *testing.T) {
 	}
 
 	envAttributes := attributes.Attributes{}.FromMap(map[string]interface{}{devfilePkg.ContainerENVKey: []corev1.EnvVar{{Name: "FOO", Value: "foo"}}}, &err)
+	emptyAttributes := attributes.Attributes{}
 	if err != nil {
 		t.Error(err)
 	}
@@ -638,6 +692,7 @@ func TestUpdateComponentDevfileModel(t *testing.T) {
 		component      appstudiov1alpha1.Component
 		updateExpected bool
 		wantErr        bool
+		wantReplica    *int
 	}{
 		{
 			name: "No kubernetes component",
@@ -678,13 +733,248 @@ func TestUpdateComponentDevfileModel(t *testing.T) {
 						},
 					},
 					Route:      "route1",
-					Replicas:   &numReplica,
+					Replicas:   &oneReplica,
 					TargetPort: 1111,
 					Env:        env,
 					Resources:  originalResources,
 				},
 			},
 			updateExpected: true,
+			wantReplica:    &oneReplica,
+		},
+		{
+			// This is the default test case where replicas is unset everywhere
+			name: "replica test: no attributes, comp.Spec.Replicas is nil, and no deployment spec.  Replica should be 1",
+			components: []devfileAPIV1.Component{
+				{
+					Name: "component1",
+					ComponentUnion: devfileAPIV1.ComponentUnion{
+						Kubernetes: &devfileAPIV1.KubernetesComponent{},
+					},
+				},
+			},
+			component: appstudiov1alpha1.Component{
+				Spec: appstudiov1alpha1.ComponentSpec{
+					ComponentName: "componentName",
+					Application:   "applicationName",
+					Source: appstudiov1alpha1.ComponentSource{
+						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
+							GitSource: &appstudiov1alpha1.GitSource{
+								URL: "url",
+							},
+						},
+					},
+					Route:      "route1",
+					TargetPort: 1111,
+					Env:        env,
+					Resources:  originalResources,
+				},
+			},
+			updateExpected: true,
+			wantReplica:    &oneReplica,
+		},
+		{
+			name: "replica test: comp.Spec.Replicas is 3, no deployment spec.  Replicas should be 3",
+			components: []devfileAPIV1.Component{
+				{
+					Name: "component1",
+					ComponentUnion: devfileAPIV1.ComponentUnion{
+						Kubernetes: &devfileAPIV1.KubernetesComponent{},
+					},
+				},
+			},
+			component: appstudiov1alpha1.Component{
+				Spec: appstudiov1alpha1.ComponentSpec{
+					ComponentName: "componentName",
+					Application:   "applicationName",
+					Replicas:      &threeReplicas,
+					Source: appstudiov1alpha1.ComponentSource{
+						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
+							GitSource: &appstudiov1alpha1.GitSource{
+								URL: "url",
+							},
+						},
+					},
+					Route:      "route1",
+					TargetPort: 1111,
+					Env:        env,
+					Resources:  originalResources,
+				},
+			},
+			updateExpected: true,
+			wantReplica:    &threeReplicas,
+		},
+		{
+			// Initial creation case, where the attribute does not exist so an update is expected
+			name: "replica test: comp.Spec.Replicas is 1, no deployment spec.  Replicas should be 1",
+			components: []devfileAPIV1.Component{
+				{
+					Name: "component1",
+					ComponentUnion: devfileAPIV1.ComponentUnion{
+						Kubernetes: &devfileAPIV1.KubernetesComponent{},
+					},
+				},
+			},
+			component: appstudiov1alpha1.Component{
+				Spec: appstudiov1alpha1.ComponentSpec{
+					ComponentName: "componentName",
+					Application:   "applicationName",
+					Replicas:      &oneReplica,
+					Source: appstudiov1alpha1.ComponentSource{
+						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
+							GitSource: &appstudiov1alpha1.GitSource{
+								URL: "url",
+							},
+						},
+					},
+					Route:      "route1",
+					TargetPort: 1111,
+					Env:        env,
+					Resources:  originalResources,
+				},
+			},
+			updateExpected: true,
+			wantReplica:    &oneReplica,
+		},
+		{
+			// similar to the initial creation case above, this time attribute list is present but key not found
+			name: "replica test: comp.Spec.Replicas is 1, no deployment spec.  Replicas should be 1",
+			components: []devfileAPIV1.Component{
+				{
+					Name:       "component1",
+					Attributes: emptyAttributes.PutInteger(devfilePkg.ContainerImagePortKey, 1001),
+					ComponentUnion: devfileAPIV1.ComponentUnion{
+						Kubernetes: &devfileAPIV1.KubernetesComponent{},
+					},
+				},
+			},
+			component: appstudiov1alpha1.Component{
+				Spec: appstudiov1alpha1.ComponentSpec{
+					ComponentName: "componentName",
+					Application:   "applicationName",
+
+					Replicas: &oneReplica,
+					Source: appstudiov1alpha1.ComponentSource{
+						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
+							GitSource: &appstudiov1alpha1.GitSource{
+								URL: "url",
+							},
+						},
+					},
+					Route:      "route1",
+					TargetPort: 1111,
+					Env:        env,
+					Resources:  originalResources,
+				},
+			},
+			updateExpected: true,
+			wantReplica:    &oneReplica,
+		},
+		{
+			// component.Spec.Replicas is explicitly set as 0, so it should override the deployment replica
+			name: "replica test: comp.Spec.Replicas is 0, Deployment spec is 3.  Replicas should be 0",
+			components: []devfileAPIV1.Component{
+				{
+					Name: "component1",
+					ComponentUnion: devfileAPIV1.ComponentUnion{
+						Kubernetes: &devfileAPIV1.KubernetesComponent{
+							K8sLikeComponent: devfileAPIV1.K8sLikeComponent{
+								K8sLikeComponentLocation: devfileAPIV1.K8sLikeComponentLocation{
+									Inlined: k8sInlined,
+								},
+							},
+						},
+					},
+				},
+			},
+			component: appstudiov1alpha1.Component{
+				Spec: appstudiov1alpha1.ComponentSpec{
+					ComponentName: "componentName",
+					Application:   "applicationName",
+					Replicas:      &zeroReplica,
+					Source: appstudiov1alpha1.ComponentSource{
+						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
+							GitSource: &appstudiov1alpha1.GitSource{
+								URL: "url",
+							},
+						},
+					},
+					Route:      "route1",
+					TargetPort: 1111,
+					Env:        env,
+					Resources:  originalResources,
+				},
+			},
+			updateExpected: true,
+			wantReplica:    &zeroReplica,
+		},
+		{
+			// No update to the component model because deployment replica will be used
+			name: "replica test: comp.Spec.Replicas is nil, deployment spec replica is 3. No update",
+			components: []devfileAPIV1.Component{
+				{
+					Name: "component1",
+					ComponentUnion: devfileAPIV1.ComponentUnion{
+						Kubernetes: &devfileAPIV1.KubernetesComponent{
+							K8sLikeComponent: devfileAPIV1.K8sLikeComponent{
+								K8sLikeComponentLocation: devfileAPIV1.K8sLikeComponentLocation{
+									Inlined: k8sInlined,
+								},
+							},
+						},
+					},
+				},
+			},
+			component: appstudiov1alpha1.Component{
+				Spec: appstudiov1alpha1.ComponentSpec{
+					ComponentName: "componentName",
+					Application:   "applicationName",
+					Source: appstudiov1alpha1.ComponentSource{
+						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
+							GitSource: &appstudiov1alpha1.GitSource{
+								URL: "url",
+							},
+						},
+					},
+					Route:      "route1",
+					TargetPort: 1111,
+					Env:        env,
+					Resources:  originalResources,
+				},
+			},
+			updateExpected: false,
+		},
+		{
+			// no update to the component model because replica value has not changed
+			name: "replica test: comp.Spec.Replicas is 1, attribute deploy/replicas: 1.  Replicas should be 1, no update",
+			components: []devfileAPIV1.Component{
+				{
+					Name:       "component1",
+					Attributes: envAttributes.PutInteger(devfilePkg.ReplicaKey, 1),
+					ComponentUnion: devfileAPIV1.ComponentUnion{
+						Kubernetes: &devfileAPIV1.KubernetesComponent{},
+					},
+				},
+			},
+			component: appstudiov1alpha1.Component{
+				Spec: appstudiov1alpha1.ComponentSpec{
+					ComponentName: "componentName",
+					Application:   "applicationName",
+					Replicas:      &oneReplica,
+					Source: appstudiov1alpha1.ComponentSource{
+						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
+							GitSource: &appstudiov1alpha1.GitSource{
+								URL: "url",
+							},
+						},
+					},
+					Route:      "route1",
+					TargetPort: 1111,
+					Env:        env,
+					Resources:  originalResources,
+				},
+			},
+			updateExpected: false,
 		},
 		{
 			name: "two kubernetes components",
@@ -716,13 +1006,14 @@ func TestUpdateComponentDevfileModel(t *testing.T) {
 						},
 					},
 					Route:      "route1",
-					Replicas:   &numReplica,
+					Replicas:   &oneReplica,
 					TargetPort: 1111,
 					Env:        env,
 					Resources:  originalResources,
 				},
 			},
 			updateExpected: true,
+			wantReplica:    &oneReplica,
 		},
 		{
 			name: "Component with envFrom component - should error out as it's not supported right now",
@@ -825,13 +1116,14 @@ func TestUpdateComponentDevfileModel(t *testing.T) {
 						},
 					},
 					Route:      "route1",
-					Replicas:   &numReplica,
+					Replicas:   &oneReplica,
 					TargetPort: 1111,
 					Env:        env,
 					Resources:  originalResources,
 				},
 			},
 			updateExpected: true,
+			wantReplica:    &oneReplica,
 		},
 		{
 			name: "devfile with invalid components, error out when trying to update devfile's Dockerfile uri",
@@ -875,7 +1167,7 @@ func TestUpdateComponentDevfileModel(t *testing.T) {
 						},
 					},
 					Route:      "route1",
-					Replicas:   &numReplica,
+					Replicas:   &oneReplica,
 					TargetPort: 1111,
 					Env:        env,
 					Resources:  originalResources,
@@ -913,7 +1205,7 @@ func TestUpdateComponentDevfileModel(t *testing.T) {
 					// it has been updated
 					checklist := updateChecklist{
 						route:     tt.component.Spec.Route,
-						replica:   *tt.component.Spec.Replicas,
+						replica:   *tt.wantReplica,
 						port:      tt.component.Spec.TargetPort,
 						env:       tt.component.Spec.Env,
 						resources: tt.component.Spec.Resources,

--- a/pkg/devfile/devfile_test.go
+++ b/pkg/devfile/devfile_test.go
@@ -1210,6 +1210,7 @@ components:
     deployment/container-port: 1111
     deployment/storageLimit: 401Mi
     deployment/storageRequest: 201Mi
+    deployment/replicas: 1
   kubernetes:
     deployByDefault: false
     endpoints:
@@ -1307,6 +1308,7 @@ components:
     deployment/container-port: 1111
     deployment/storageLimit: 401Mi
     deployment/storageRequest: 201Mi
+    deployment/replicas: 5
   kubernetes:
     deployByDefault: false
     endpoints:
@@ -1436,7 +1438,7 @@ components:
         name: deploy-sample
       spec:
         revisionHistoryLimit: 5
-        replicas: 1
+        replicas: 5
         selector:
           matchLabels:
             app.kubernetes.io/instance: component-sample
@@ -1530,6 +1532,7 @@ components:
 - attributes:
     api.devfile.io/k8sLikeComponent-originalURI: deploy.yaml
     deployment/container-port: 5566
+    deployment/replicas: 5
   kubernetes:
     deployByDefault: false
     endpoints:
@@ -2524,7 +2527,7 @@ schemaVersion: 2.2.0`
 				},
 				Spec: appsv1.DeploymentSpec{
 					RevisionHistoryLimit: &revHistoryLimit,
-					Replicas:             &replicaUpdated,
+					Replicas:             &replica, // value from component attribute deployment/replicas
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"app.kubernetes.io/instance": "component-sample",
@@ -2714,7 +2717,7 @@ schemaVersion: 2.2.0`
 				},
 				Spec: appsv1.DeploymentSpec{
 					RevisionHistoryLimit: &setRevHistoryLimit,
-					Replicas:             &replicaUpdated,
+					Replicas:             &replica, // replica value from deployment spec
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"app.kubernetes.io/instance": "component-sample",
@@ -3397,7 +3400,7 @@ schemaVersion: 2.2.0`
 				},
 				Spec: appsv1.DeploymentSpec{
 					RevisionHistoryLimit: &revHistoryLimit,
-					Replicas:             &replicaUpdated,
+					Replicas:             &replica, //replica from component attribute
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"app.kubernetes.io/instance": "component-sample",


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
- Updates the logic so deployment replicas are set to 1 by default if implied (i.e. unset in the component spec, devfile and inline deployment).  Order of precedence is comp.spec.replicas > devfile replicas > deployment replicas
- The component attribute `deployment/replicas: 1` will be written for the default case and will trigger an update to the component model.  
- If the replicas are only specified in the deployment, no component attribute will be generated (it'll be removed if previously set).  We will rely on the value that's already specified (by parsing) rather than the one set in the attribute  
- Fixed some bugs
- Updated test cases so there's a greater coverage.  Mixed up some numbers so we're not always testing with replica 1

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
https://issues.redhat.com/browse/RHTAPBUGS-12

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
1.  Built the HAS image and deployed on a local cluster.  Created a token with read and write permissions to write into a test org
2. Deployed the sample [Application](https://github.com/redhat-appstudio/application-service/blob/main/config/samples/application/app.yaml) and [Component](https://github.com/redhat-appstudio/application-service/blob/main/config/samples/component/component-basic.yaml).  Verified the [replica was set to 1](https://github.com/has-test-org/application-sample-N6juw-last-relax/commit/1813a6f244b7f8af739ee082320cfe1d276e2bab) in the generated deployment
3. Updated the Component CR to set replicas to 0.  Verified the [replica was set to 0](https://github.com/has-test-org/application-sample-N6juw-last-relax/commit/fa7406d220a967aae20c968e1c1e2945d0a977c9) in the generated deployment
4. Updated the Component CR to remove the replica field.  Verified the [replica was set to 1 (value from the deployment)](https://github.com/has-test-org/application-sample-N6juw-last-relax/commit/eea0bc9198f3355dcda3935f220ee6724ec58324)
5. Created a new Component CR with the QE test and verified the [replica was 1](https://github.com/has-test-org/application-sample-N6juw-last-relax/blob/main/components/component-sample-2/base/deployment.yaml#L13) (and not 0 as it was set in the failing runs)