### PR TITLE
Fix error log format

### DIFF
--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -196,7 +196,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				}
 				// if fail to delete the external dependency here, log the error, but don't return error
 				// Don't want to get stuck in a cycle of repeatedly trying to update the repository and failing
-				log.Error(err, "Unable to update GitOps repository for component %v in namespace %v", component.GetName(), component.GetNamespace())
+				log.Error(err, fmt.Sprintf("Unable to update GitOps repository for component %v in namespace %v", component.GetName(), component.GetNamespace()))
 
 				// Increment the Component deletion failed metric as the component delete did not fully succeed
 				metrics.ComponentDeletionFailed.Inc()


### PR DESCRIPTION
### What does this PR do?:

Simple fix for the error log of the gitops repo update failure. The code didn't include the `fmt.Sprintf()` function and as a result inside the log we would only see the `%v` variables as they are and not their content. After adding `fmt.Sprintf()` this is fixed.

### Which issue(s)/story(ies) does this PR fixes:

fixes https://issues.redhat.com/browse/RHTAPBUGS-1016

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [x] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [x] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
