### PR TITLE
Enable cross-Application nudging

### DIFF
--- a/controllers/webhooks/component_webhook_test.go
+++ b/controllers/webhooks/component_webhook_test.go
@@ -208,32 +208,6 @@ var _ = Describe("Application validation webhook", func() {
 			err := k8sClient.Create(ctx, nudgedComp)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			// comp in a different app
-			differentAppComp := &appstudiov1alpha1.Component{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "appstudio.redhat.com/v1alpha1",
-					Kind:       "Component",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: HASAppNamespace,
-					Name:      uniqueHASCompName + "-new-app",
-				},
-				Spec: appstudiov1alpha1.ComponentSpec{
-					ComponentName: uniqueHASCompName + "-new-app",
-					Application:   "test-application2",
-					Source: appstudiov1alpha1.ComponentSource{
-						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
-							GitSource: &appstudiov1alpha1.GitSource{
-								URL: SampleRepoLink,
-							},
-						},
-					},
-				},
-			}
-
-			err = k8sClient.Create(ctx, differentAppComp)
-			Expect(err).Should(Not(HaveOccurred()))
-
 			// nudgingComp
 			nudgingComp := &appstudiov1alpha1.Component{
 				TypeMeta: metav1.TypeMeta{
@@ -285,12 +259,6 @@ var _ = Describe("Application validation webhook", func() {
 			buildNudgedByList := nudgedComp.Status.BuildNudgedBy
 			Expect(len(buildNudgedByList)).To(Equal(1))
 			Expect(buildNudgedByList[0] == uniqueHASCompName)
-
-			// Now attempt to update the build-nudges-ref field to an invalid component (different app)
-			createdHasComp.Spec.BuildNudgesRef = []string{uniqueHASCompName + "-new-app"}
-			err = k8sClient.Update(ctx, createdHasComp)
-			Expect(err).Should((HaveOccurred()))
-			Expect(err.Error()).Should(ContainSubstring("belongs to a different application"))
 
 			// Delete the specified HASComp resource
 			deleteHASCompCR(hasCompLookupKey)

--- a/controllers/webhooks/component_webhook_unit_test.go
+++ b/controllers/webhooks/component_webhook_unit_test.go
@@ -494,7 +494,6 @@ func TestValidateBuildNudgesRefGraph(t *testing.T) {
 			name:     "nudged component belongs to different app",
 			compName: "component-invalid-app",
 			webhook:  compWebhook,
-			errStr:   "component component4 cannot be added to spec.build-nudges-ref as it belongs to a different application",
 		},
 		{
 			name:     "complex component relationship - some valid, some not valid (self referential)",
@@ -514,7 +513,7 @@ func TestValidateBuildNudgesRefGraph(t *testing.T) {
 			component := &appstudiov1alpha1.Component{}
 			fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: test.compName}, component)
 
-			err := test.webhook.validateBuildNudgesRefGraph(context.Background(), component.Spec.BuildNudgesRef, "default", test.compName, component.Spec.Application)
+			err := test.webhook.validateBuildNudgesRefGraph(context.Background(), component.Spec.BuildNudgesRef, "default", test.compName)
 			var errStr string
 			if err != nil {
 				errStr = err.Error()


### PR DESCRIPTION
### What does this PR do?:
In order to enable improved organization of Components and Applications, we want to loosen the requirement that all nudging happens within the same Application. Therefore we no longer need to run webhook validation to adhere to this constraint.

### Which issue(s)/story(ies) does this PR fixes:
issues.redhat.com/browse/DEVHAS-593

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
