### PR TITLE
Add container port to manager container (addresses kube-linter error)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,6 +38,10 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        ports:
+        - containerPort: 8081
+          name: health
+          protocol: TCP
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
Adds in the container port to the manager container because the kube linter from stackrox was complaining about it:
```
Error: found 2 lint errors
/home/runner/work/application-service/application-service/.kube-linter/manifests.yaml: (object: application-service-system/application-service-controller-manager apps/v1, Kind=Deployment) container "manager" does not expose port 8081 for the HTTPGet (check: liveness-port, remediation: Check which ports you've exposed and ensure they match what you have specified in the liveness probe.)

/home/runner/work/application-service/application-service/.kube-linter/manifests.yaml: (object: application-service-system/application-service-controller-manager apps/v1, Kind=Deployment) container "manager" does not expose port 8081 for the HTTPGet (check: readiness-port, remediation: Check which ports you've exposed and ensure they match what you have specified in the readiness probe.)
```

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
N/A

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
- tests should pass
- manually deployed HAS on my cluster and created application,components to confirm HAS pod runs fine
```
$ oc get po -n application-service-system
NAME                                                      READY   STATUS    RESTARTS   AGE
application-service-controller-manager-78f45864f7-p277v   2/2     Running   0          11m
```