### PR TITLE
[KFLUXBUGS-1105]: Retrieve Component before updating status for build-nudged-by

### DIFF
--- a/controllers/webhooks/component_webhook.go
+++ b/controllers/webhooks/component_webhook.go
@@ -88,7 +88,7 @@ func (r *ComponentWebhook) UpdateNudgedComponentStatus(ctx context.Context, obj 
 		if !util.StrInList(compName, nudgedComp.Status.BuildNudgedBy) {
 
 			// Update the Component's status - retry on conflict
-			retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				currentNudgedComp := &appstudiov1alpha1.Component{}
 				err := r.client.Get(ctx, types.NamespacedName{Namespace: comp.Namespace, Name: nudgedCompName}, currentNudgedComp)
 				if err != nil {
@@ -98,6 +98,9 @@ func (r *ComponentWebhook) UpdateNudgedComponentStatus(ctx context.Context, obj 
 				err = r.client.Status().Update(ctx, currentNudgedComp)
 				return err
 			})
+			if err != nil {
+				componentlog.Error(err, "error setting build-nudged-by in status")
+			}
 
 		}
 

--- a/controllers/webhooks/component_webhook.go
+++ b/controllers/webhooks/component_webhook.go
@@ -86,13 +86,19 @@ func (r *ComponentWebhook) UpdateNudgedComponentStatus(ctx context.Context, obj 
 
 		// Add the component to the status if it's not already present
 		if !util.StrInList(compName, nudgedComp.Status.BuildNudgedBy) {
-			nudgedComp.Status.BuildNudgedBy = append(nudgedComp.Status.BuildNudgedBy, compName)
 
 			// Update the Component's status - retry on conflict
-			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				err = r.client.Status().Update(ctx, nudgedComp)
+			retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				currentNudgedComp := &appstudiov1alpha1.Component{}
+				err := r.client.Get(ctx, types.NamespacedName{Namespace: comp.Namespace, Name: nudgedCompName}, currentNudgedComp)
+				if err != nil {
+					return err
+				}
+				currentNudgedComp.Status.BuildNudgedBy = append(currentNudgedComp.Status.BuildNudgedBy, compName)
+				err = r.client.Status().Update(ctx, currentNudgedComp)
 				return err
 			})
+
 		}
 
 	}


### PR DESCRIPTION
### What does this PR do?:
This PR ensures that we retrieve the most recent version of the Component before updating its status.build-nudged-by field. The should prevent an issue where the nudging component isn't referenced in that field.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/projects/KFLUXBUGS/issues/KFLUXBUGS-1105

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
