### PR TITLE
Add arch support for local go build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ APPLICATION_API_CRD = https://raw.githubusercontent.com/redhat-appstudio/applica
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.22
 
+# Get the local platform
+OS=$(shell go env GOOS)
+ARCH=$(shell go env GOARCH)
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -87,6 +91,9 @@ help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##@ Development
+
+platform_info:
+	$(info OS is $(OS) and ARCH is $(ARCH))
 
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..."
@@ -164,7 +171,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 ##@ Build
 
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
+	GOOS=${OS} GOARCH=${ARCH} go build -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
@@ -249,7 +256,6 @@ ifeq (,$(shell which opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
 	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.15.1/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}


### PR DESCRIPTION
### What does this PR do?:
Add arch support for go build binary in Makefile. Not needed in Dockerfile, since we are building inside the image.

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
```
MacBook-Pro:application-service maysun$ make platform_info
OS is darwin and ARCH is amd64
make: `platform_info' is up to date.

MacBook-Pro:application-service maysun$ make build
/Users/maysun/dev/appstudio/application-service/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
find . -not -path '*/\.*' -not -name '*zz_generated*.go' -name '*.go' -exec goimports -w {} \;
go vet ./...
GOOS=darwin GOARCH=amd64 go build -o bin/manager main.go

MacBook-Pro:application-service maysun$ echo $?
0

MacBook-Pro:application-service maysun$ ls -la bin/manager 
-rwxr-xr-x  1 maysun  staff  77239792 26 Feb 15:11 bin/manager
```