### PR TITLE
[Devtools Week] Fix book of appstudio link

### DIFF
--- a/docs/serviceability.md
+++ b/docs/serviceability.md
@@ -47,7 +47,7 @@ For more information, on how to debug on RHTAP Staging or how to set up a debugg
 ## FAQs
 Q. Where can I view the application-service API types?
 
-A. The application-service API types and their corresponding webhooks are defined in the [redhat-appstudio/application-api](https://github.com/redhat-appstudio/application-api) repository. You can also find the API reference information in the [Book of AppStudio](https://redhat-appstudio.github.io/book/ref/index.html) website. 
+A. The application-service API types and their corresponding webhooks are defined in the [redhat-appstudio/application-api](https://github.com/redhat-appstudio/application-api) repository. You can also find the API reference information in the [Book of AppStudio](https://redhat-appstudio.github.io/architecture/ref/index.html ) website.
 
 Q. Where are the application-service controller logic located?
 

--- a/docs/serviceability.md
+++ b/docs/serviceability.md
@@ -47,7 +47,7 @@ For more information, on how to debug on RHTAP Staging or how to set up a debugg
 ## FAQs
 Q. Where can I view the application-service API types?
 
-A. The application-service API types and their corresponding webhooks are defined in the [redhat-appstudio/application-api](https://github.com/redhat-appstudio/application-api) repository. You can also find the API reference information in the [Book of AppStudio](https://redhat-appstudio.github.io/architecture/ref/index.html ) website.
+A. The application-service API types and their corresponding webhooks are defined in the [redhat-appstudio/application-api](https://github.com/redhat-appstudio/application-api) repository. You can also find the API reference information in the [Book of AppStudio](https://redhat-appstudio.github.io/architecture/ref/index.html) website.
 
 Q. Where are the application-service controller logic located?
 


### PR DESCRIPTION
### What does this PR do?:
Simply fixes a broken link to book of appstudio (currently gives 404) with a working one (https://redhat-appstudio.github.io/architecture/ref/index.html)

### Which issue(s)/story(ies) does this PR fixes:
N/A - Part of devtools week

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
