### PR TITLE
Avoid race coditions from component deletion for applications already marked to be deleted

### DIFF
--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -188,8 +188,8 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			log.Info(fmt.Sprintf("added the finalizer %v", req.NamespacedName))
 		}
 	} else {
-		if hasApplication.Status.Devfile != "" && (forceGenerateGitopsResource || len(component.Status.Conditions) > 0 && component.Status.Conditions[len(component.Status.Conditions)-1].Status == metav1.ConditionTrue && containsString(component.GetFinalizers(), compFinalizerName)) {
-			// only attempt to finalize and update the gitops repo if an Application is present & the previous Component status is good
+		if hasApplication.Status.Devfile != "" && hasApplication.ObjectMeta.DeletionTimestamp.IsZero() && (forceGenerateGitopsResource || len(component.Status.Conditions) > 0 && component.Status.Conditions[len(component.Status.Conditions)-1].Status == metav1.ConditionTrue && containsString(component.GetFinalizers(), compFinalizerName)) {
+			// only attempt to finalize and update the gitops repo if an Application is present & not under deletion & the previous Component status is good
 			// A finalizer is present for the Component CR, so make sure we do the necessary cleanup steps
 			metrics.ComponentDeletionTotalReqs.Inc()
 			if err := r.Finalize(ctx, &component, &hasApplication, ghClient, gitToken); err != nil {

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -192,7 +192,8 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			// only attempt to finalize and update the gitops repo if an Application is present & not under deletion & the previous Component status is good
 			// A finalizer is present for the Component CR, so make sure we do the necessary cleanup steps
 			if !hasApplication.ObjectMeta.DeletionTimestamp.IsZero() {
-				return ctrl.Result{}, fmt.Errorf("application %v is under deletion. Skipping deletion for component %v", hasApplication.Name, component.Name)
+				log.Info("application %v is under deletion. Skipping deletion for component %v", hasApplication.Name, component.Name)
+				return ctrl.Result{}, nil
 			}
 
 			metrics.ComponentDeletionTotalReqs.Inc()

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -188,9 +188,13 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			log.Info(fmt.Sprintf("added the finalizer %v", req.NamespacedName))
 		}
 	} else {
-		if hasApplication.Status.Devfile != "" && hasApplication.ObjectMeta.DeletionTimestamp.IsZero() && (forceGenerateGitopsResource || len(component.Status.Conditions) > 0 && component.Status.Conditions[len(component.Status.Conditions)-1].Status == metav1.ConditionTrue && containsString(component.GetFinalizers(), compFinalizerName)) {
+		if hasApplication.Status.Devfile != "" && (forceGenerateGitopsResource || len(component.Status.Conditions) > 0 && component.Status.Conditions[len(component.Status.Conditions)-1].Status == metav1.ConditionTrue && containsString(component.GetFinalizers(), compFinalizerName)) {
 			// only attempt to finalize and update the gitops repo if an Application is present & not under deletion & the previous Component status is good
 			// A finalizer is present for the Component CR, so make sure we do the necessary cleanup steps
+			if !hasApplication.ObjectMeta.DeletionTimestamp.IsZero() {
+				return ctrl.Result{}, fmt.Errorf("application %v is under deletion. Skipping deletion for component %v", hasApplication.Name, component.Name)
+			}
+
 			metrics.ComponentDeletionTotalReqs.Inc()
 			if err := r.Finalize(ctx, &component, &hasApplication, ghClient, gitToken); err != nil {
 				if errors.IsConflict(err) {

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -39,6 +39,7 @@ import (
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	devfilePkg "github.com/redhat-appstudio/application-service/pkg/devfile"
 
+	spiapi "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -3016,7 +3016,7 @@ var _ = Describe("Component controller", func() {
 
 			Expect(k8sClient.Update(ctx, createdHasComp)).Should(Succeed())
 
-			// Set deletion timestamp for application
+			// Set deletion timestamp for application.
 			gracePeriodSeconds := int64(5)
 			opts := &client.DeleteOptions{GracePeriodSeconds: &gracePeriodSeconds}
 

--- a/pkg/metrics/component.go
+++ b/pkg/metrics/component.go
@@ -81,6 +81,10 @@ func GetComponentCreationFailed() prometheus.Counter {
 	return componentCreationFailed
 }
 
+func GetComponentDeletionFailed() prometheus.Counter {
+	return ComponentDeletionFailed
+}
+
 // IncrementComponentCreationSucceeded increments the component creation succeeded metric.
 func IncrementComponentCreationSucceeded(oldError, newError string) {
 	if oldError == "" || newError == "" || !strings.Contains(oldError, newError) {
@@ -98,6 +102,14 @@ func GetComponentCreationSucceeded() prometheus.Counter {
 	return componentCreationSucceeded
 }
 
+func GetComponentDeletionSucceeded() prometheus.Counter {
+	return ComponentDeletionSucceeded
+}
+
 func GetComponentCreationTotalReqs() prometheus.Counter {
 	return componentCreationTotalReqs
+}
+
+func GetComponentDeletionTotalReqs() prometheus.Counter {
+	return ComponentDeletionTotalReqs
 }


### PR DESCRIPTION
### What does this PR do?:

This PR adds an extra condition upon component deletion. More detailed in https://github.com/redhat-appstudio/application-service/blob/main/controllers/component_controller.go#L191 we now check if the component's application has a deletion timestamp set. If yes we don't delete the component to avoid race conditions between the component & the application deletion.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-627

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
