### PR TITLE
Add availability metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ import (
 	cdqanalysis "github.com/redhat-appstudio/application-service/cdq-analysis/pkg"
 	"github.com/redhat-appstudio/application-service/controllers"
 	"github.com/redhat-appstudio/application-service/controllers/webhooks"
+	"github.com/redhat-appstudio/application-service/pkg/availability"
 	"github.com/redhat-appstudio/application-service/pkg/github"
 	"github.com/redhat-appstudio/application-service/pkg/spi"
 	"github.com/redhat-appstudio/application-service/pkg/util/ioutils"
@@ -248,6 +249,12 @@ func main() {
 	}
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
+		os.Exit(1)
+	}
+
+	availabilityChecker := &availability.AvailabilityWatchdog{GitHubTokenClient: ghTokenClient}
+	if err := mgr.Add(availabilityChecker); err != nil {
+		setupLog.Error(err, "unable to set up availability checks")
 		os.Exit(1)
 	}
 

--- a/pkg/availability/git.go
+++ b/pkg/availability/git.go
@@ -1,0 +1,71 @@
+//
+// Copyright 2024 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package availability
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/redhat-appstudio/application-service/pkg/github"
+	"github.com/redhat-appstudio/application-service/pkg/metrics"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// Inspired from https://github.com/konflux-ci/remote-secret/blob/main/pkg/availability/storage_watchdog.go
+
+type AvailabilityWatchdog struct {
+	GitHubTokenClient github.GitHubToken
+}
+
+func (r *AvailabilityWatchdog) Start(ctx context.Context) error {
+	// Check every 20 minutes
+	ticker := time.NewTicker(20 * time.Minute)
+	go func() {
+		for {
+			// make call immediately to avoid waiting for the first tick
+			r.checkAvailability(ctx)
+			select {
+			case <-ticker.C:
+				continue
+			case <-ctx.Done():
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+func (r *AvailabilityWatchdog) checkAvailability(ctx context.Context) {
+	log := ctrl.LoggerFrom(ctx)
+	checkGitLabel := prometheus.Labels{"check": "github"}
+
+	ghClient, err := r.GitHubTokenClient.GetNewGitHubClient("")
+	if err != nil {
+		log.Error(err, "Unable to create Go-GitHub client due to error, marking HAS availability as down")
+		metrics.HASAvailabilityGauge.With(checkGitLabel).Set(0)
+	}
+
+	isGitAvailable, err := ghClient.GetGitStatus(ctx)
+	if !isGitAvailable {
+		log.Error(err, "Unable to create Go-GitHub client due to error, marking HAS availability as down")
+		metrics.HASAvailabilityGauge.With(checkGitLabel).Set(0)
+	} else {
+		log.Info("HAS is marked as available, Git check has passed...")
+		metrics.HASAvailabilityGauge.With(checkGitLabel).Set(1)
+	}
+}

--- a/pkg/availability/git_test.go
+++ b/pkg/availability/git_test.go
@@ -1,0 +1,41 @@
+//
+// Copyright 2024 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package availability
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/redhat-appstudio/application-service/pkg/github"
+	"github.com/redhat-appstudio/application-service/pkg/metrics"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckAvailability(t *testing.T) {
+
+	t.Run("check availability", func(t *testing.T) {
+		checkGitLabel := prometheus.Labels{"check": "github"}
+		r := AvailabilityWatchdog{
+			GitHubTokenClient: github.MockGitHubTokenClient{},
+		}
+
+		r.checkAvailability(context.TODO())
+
+		assert.Equal(t, 1.0, testutil.ToFloat64(metrics.HASAvailabilityGauge.With(checkGitLabel)))
+	})
+}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -124,6 +124,15 @@ func GetRepoAndOrgFromURL(repoURL string) (string, string, error) {
 	return repoName, orgName, nil
 }
 
+// GetGitStatus returns the status of the Git API with a simple noop call
+func (g *GitHubClient) GetGitStatus(ctx context.Context) (bool, error) {
+	quote, response, err := g.Client.Zen(ctx)
+	if err == nil && response != nil && response.StatusCode >= 200 && response.StatusCode <= 299 && quote != "" {
+		return true, nil
+	}
+	return false, err
+}
+
 // GetDefaultBranchFromURL returns the default branch of a given repoURL
 func (g *GitHubClient) GetDefaultBranchFromURL(repoURL string, ctx context.Context) (string, error) {
 	repoName, orgName, err := GetRepoAndOrgFromURL(repoURL)

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -377,6 +377,41 @@ func TestGetRepoAndOrgFromURL(t *testing.T) {
 	}
 }
 
+func TestGetGitStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		repoName      string
+		orgName       string
+		wantAvailable bool
+		wantErr       bool
+	}{
+		{
+			name:          "Simple repo name",
+			repoName:      "test-repo-1",
+			orgName:       "redhat-appstudio-appdata",
+			wantAvailable: true,
+			wantErr:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		mockedClient := GitHubClient{
+			Client: GetMockedClient(),
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			isGitAvailable, err := mockedClient.GetGitStatus(context.Background())
+
+			if tt.wantErr != (err != nil) {
+				t.Errorf("TestGetGitStatus() unexpected error value: %v", err)
+			}
+			if !tt.wantErr && isGitAvailable != tt.wantAvailable {
+				t.Errorf("TestGetGitStatus() error: expected %v got %v", tt.wantAvailable, isGitAvailable)
+			}
+		})
+	}
+}
+
 func TestGetLatestCommitSHAFromRepository(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/github/mock.go
+++ b/pkg/github/mock.go
@@ -115,6 +115,13 @@ func GetMockedClient() *github.Client {
 			}),
 		),
 		mock.WithRequestMatchHandler(
+			mock.GetZen,
+			http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				/* #nosec G104 -- test code */
+				w.Write([]byte("peace"))
+			}),
+		),
+		mock.WithRequestMatchHandler(
 			mock.GetReposByOwnerByRepo,
 			http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				if strings.Contains(req.RequestURI, "test-error-response") {

--- a/pkg/metrics/git.go
+++ b/pkg/metrics/git.go
@@ -72,4 +72,13 @@ var (
 			Help: "Number of successful import from git repository requests",
 		},
 	)
+
+	HASAvailabilityGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "has_availability",
+			Help: "Availability of the Konflux application service component",
+		},
+		// check - can have the values of "github" or whatever availability is being checked
+		[]string{"check"},
+	)
 )

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -24,7 +24,7 @@ import (
 func init() {
 	// Register custom metrics with the global prometheus registry
 	metrics.Registry.MustRegister(GitOpsRepoCreationTotalReqs, GitOpsRepoCreationFailed, GitOpsRepoCreationSucceeded, ControllerGitRequest,
-		SecondaryRateLimitCounter, PrimaryRateLimitCounter, TokenPoolGauge,
+		SecondaryRateLimitCounter, PrimaryRateLimitCounter, TokenPoolGauge, HASAvailabilityGauge,
 		ApplicationDeletionTotalReqs, ApplicationDeletionSucceeded, ApplicationDeletionFailed,
 		ApplicationCreationSucceeded, ApplicationCreationFailed, ApplicationCreationTotalReqs,
 		componentCreationTotalReqs, componentCreationSucceeded, componentCreationFailed,


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
- Adds in the Availability metrics as per https://github.com/redhat-appstudio/o11y/tree/main/exporters/dsexporter 
- Inspired from https://github.com/konflux-ci/remote-secret/pull/338 
- Metric format specification at https://docs.google.com/document/d/193FO8DYP8zCzzued53DiIT84xmyTm51v_OqiWzQi8Bg/edit
- Makes a simple noop Git API call every 20 minutes (see screenshot below)

### Which issue(s)/story(ies) does this PR fixes:
<!-- _Link to issue(s)/story(ies)_ -->
https://issues.redhat.com/browse/DEVHAS-597

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
The HAS pod will print the statements about availability:

<img width="1126" alt="Screenshot 2024-03-18 at 4 17 01 PM" src="https://github.com/redhat-appstudio/application-service/assets/31771087/3f516d42-6fc5-4fc3-9af4-84bbfabfe183">
