### PR TITLE
Return error for non supported development platform urls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ kustomize: ## Download kustomize locally if necessary.
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@395cfc7486e652d19fe1b544a436f9852ba26e4f)
 
 DLV = $(shell pwd)/bin/dlv
 dlv:

--- a/cdq-analysis/pkg/util.go
+++ b/cdq-analysis/pkg/util.go
@@ -170,11 +170,8 @@ func ConvertGitHubURL(URL string, revision string, context string) (string, erro
 	if err != nil {
 		return "", &InvalidURL{URL: URL, Err: err}
 	}
-	if !strings.Contains(url.Host, "github") {
-		return "", &InvalidURL{URL: URL, Err: fmt.Errorf("url %v is not from github.com", URL)}
-	}
 
-	if !strings.Contains(url.Host, "raw") {
+	if strings.Contains(url.Host, "github") && !strings.Contains(url.Host, "raw") {
 		// Convert path part of the URL
 		URLSlice := strings.Split(URL, "/")
 		if len(URLSlice) > 2 && URLSlice[len(URLSlice)-2] == "tree" {

--- a/cdq-analysis/pkg/util.go
+++ b/cdq-analysis/pkg/util.go
@@ -171,7 +171,7 @@ func ConvertGitHubURL(URL string, revision string, context string) (string, erro
 		return "", &InvalidURL{URL: URL, Err: err}
 	}
 	if !strings.Contains(url.Host, "github") {
-		return "", &InvalidURL{URL: URL, Err: fmt.Errorf("url %v not from github.com")}
+		return "", &InvalidURL{URL: URL, Err: fmt.Errorf("url %v is not from github.com", URL)}
 	}
 
 	if !strings.Contains(url.Host, "raw") {

--- a/cdq-analysis/pkg/util.go
+++ b/cdq-analysis/pkg/util.go
@@ -170,8 +170,11 @@ func ConvertGitHubURL(URL string, revision string, context string) (string, erro
 	if err != nil {
 		return "", &InvalidURL{URL: URL, Err: err}
 	}
+	if !strings.Contains(url.Host, "github") {
+		return "", &InvalidURL{URL: URL, Err: fmt.Errorf("url %v not from github.com")}
+	}
 
-	if strings.Contains(url.Host, "github") && !strings.Contains(url.Host, "raw") {
+	if !strings.Contains(url.Host, "raw") {
 		// Convert path part of the URL
 		URLSlice := strings.Split(URL, "/")
 		if len(URLSlice) > 2 && URLSlice[len(URLSlice)-2] == "tree" {

--- a/cdq-analysis/pkg/util.go
+++ b/cdq-analysis/pkg/util.go
@@ -279,3 +279,17 @@ func UpdateGitLink(repo, revision, context string) (string, error) {
 	}
 	return rawGitURL, nil
 }
+
+// ValidateGithubURL checks if the given url includes github in hostname
+// In case of invalid url (not able to parse / not github) returns an error.
+func ValidateGithubURL(URL string) error {
+	parsedURL, err := url.Parse(URL)
+	if err != nil {
+		return err
+	}
+
+	if strings.Contains(parsedURL.Host, "github") {
+		return nil
+	}
+	return fmt.Errorf("source git url %v is not from github", URL)
+}

--- a/cdq-analysis/pkg/util_test.go
+++ b/cdq-analysis/pkg/util_test.go
@@ -320,7 +320,7 @@ func TestConvertGitHubURL(t *testing.T) {
 		{
 			name:    "A non github url",
 			url:     "https://gitlab.com/",
-			wantUrl: "https://gitlab.com/",
+			wantUrl: "https://gitlab.com",
 		},
 		{
 			name:    "A non url",

--- a/cdq-analysis/pkg/util_test.go
+++ b/cdq-analysis/pkg/util_test.go
@@ -640,3 +640,36 @@ func TestUpdateGitLink(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateGithubURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		sourceGitURL string
+		wantErr      bool
+	}{
+		{
+			name:         "Valid github url",
+			sourceGitURL: "https://github.com/devfile-samples",
+			wantErr:      false,
+		},
+		{
+			name:         "Invalid url",
+			sourceGitURL: "afgae devfile",
+			wantErr:      true,
+		},
+		{
+			name:         "Not github url",
+			sourceGitURL: "https://gitlab.com/devfile-samples",
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateGithubURL(tt.sourceGitURL)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TestValidateGithubURL() unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/cdq-analysis/pkg/util_test.go
+++ b/cdq-analysis/pkg/util_test.go
@@ -318,6 +318,11 @@ func TestConvertGitHubURL(t *testing.T) {
 			wantUrl: "https://raw.githubusercontent.com/devfile/api/2.1.x",
 		},
 		{
+			name:    "A non github url",
+			url:     "https://gitlab.com/",
+			wantErr: true,
+		},
+		{
 			name:    "A non url",
 			url:     "\000x",
 			wantErr: true,

--- a/cdq-analysis/pkg/util_test.go
+++ b/cdq-analysis/pkg/util_test.go
@@ -320,7 +320,7 @@ func TestConvertGitHubURL(t *testing.T) {
 		{
 			name:    "A non github url",
 			url:     "https://gitlab.com/",
-			wantErr: true,
+			wantUrl: "https://gitlab.com/",
 		},
 		{
 			name:    "A non url",

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -894,14 +894,14 @@ func checkForCreateReconcile(component appstudiov1alpha1.Component) (bool, strin
 
 // isGithubURL checks if the given url includes github in hostname
 // In case of invalid url (not able to parse) returns false.
-func validateGithubURL(URL string) (bool, error) {
+func validateGithubURL(URL string) error {
 	parsedURL, err := url.Parse(URL)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	if strings.Contains(parsedURL.Host, "github") {
-		return true, nil
+		return nil
 	}
-	return false, fmt.Errorf("source git url %v is not from github", URL)
+	return fmt.Errorf("source git url %v is not from github", URL)
 }

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -301,7 +301,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if source.GitSource != nil && source.GitSource.URL != "" {
 			if !isGithubURL(source.GitSource.URL) {
 				// User error - the git url provided is not from github
-				log.Info("source git url %v is not from github", source.GitSource.URL)
+				log.Info(fmt.Sprintf("source git url %v is not from github", source.GitSource.URL))
 				metrics.IncrementComponentCreationSucceeded(prevErrCondition, err.Error())
 				return ctrl.Result{}, nil
 			}

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -302,7 +302,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			if !isGithubURL(source.GitSource.URL) {
 				// User error - the git url provided is not from github
 				log.Info(fmt.Sprintf("source git url %v is not from github", source.GitSource.URL))
-				metrics.IncrementComponentCreationSucceeded(prevErrCondition, err.Error())
+				metrics.IncrementComponentCreationSucceeded("", "")
 				return ctrl.Result{}, nil
 			}
 			context := source.GitSource.Context

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -303,6 +303,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				// User error - the git url provided is not from github
 				log.Error(err, "unable to validate github url")
 				metrics.IncrementComponentCreationSucceeded("", "")
+				_ = r.SetCreateConditionAndUpdateCR(ctx, req, &component, err)
 				return ctrl.Result{}, err
 			}
 			context := source.GitSource.Context

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -19,13 +19,14 @@ package controllers
 import (
 	"context"
 	"fmt"
-	corev1 "k8s.io/api/core/v1"
 	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/prometheus/client_golang/prometheus"
 	cdqanalysis "github.com/redhat-appstudio/application-service/cdq-analysis/pkg"

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/redhat-appstudio/application-service/cdq-analysis/pkg"
 	cdqanalysis "github.com/redhat-appstudio/application-service/cdq-analysis/pkg"
 	"github.com/redhat-appstudio/application-service/pkg/metrics"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -299,7 +298,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		var devfileBytes []byte
 
 		if source.GitSource != nil && source.GitSource.URL != "" {
-			if err := pkg.ValidateGithubURL(source.GitSource.URL); err != nil {
+			if err := cdqanalysis.ValidateGithubURL(source.GitSource.URL); err != nil {
 				// User error - the git url provided is not from github
 				log.Error(err, "unable to validate github url")
 				metrics.IncrementComponentCreationSucceeded("", "")

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -1105,11 +1105,7 @@ var _ = Describe("Component controller", func() {
 				return len(createdHasComp.Status.Conditions) > 0
 			}, timeout, interval).Should(BeTrue())
 
-			// Make sure the devfile model was properly set in Component
-			errCondition := createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1]
-			Expect(errCondition.Status).Should(Equal(metav1.ConditionFalse))
-			Expect(errCondition.Message).Should(ContainSubstring("Component create failed: unable to get default branch of Github Repo"))
-
+			// Confirm user error hasn't increase the failure metrics
 			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
 
 			Expect(testutil.ToFloat64(metrics.GetComponentCreationTotalReqs()) > beforeCreateTotalReqs).To(BeTrue())
@@ -2966,8 +2962,8 @@ var _ = Describe("Component controller", func() {
 
 			ctx := context.Background()
 
-			applicationName := HASAppName + "28"
-			componentName := HASCompName + "28"
+			applicationName := HASAppName + "30"
+			componentName := HASCompName + "30"
 
 			createAndFetchSimpleApp(applicationName, HASAppNamespace, DisplayName, Description)
 

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -2959,7 +2959,7 @@ var _ = Describe("Component controller", func() {
 		})
 	})
 	Context("Create component having git source from gitlab", func() {
-		It("Should return a user error for invalid url", func() {
+		It("Should not increase the component failure metrics", func() {
 			beforeCreateTotalReqs := testutil.ToFloat64(metrics.GetComponentCreationTotalReqs())
 			beforeCreateSucceedReqs := testutil.ToFloat64(metrics.GetComponentCreationSucceeded())
 			beforeCreateFailedReqs := testutil.ToFloat64(metrics.GetComponentCreationFailed())
@@ -3002,10 +3002,6 @@ var _ = Describe("Component controller", func() {
 				k8sClient.Get(ctx, hasCompLookupKey, createdHasComp)
 				return len(createdHasComp.Status.Conditions) > 0
 			}, timeout, interval).Should(BeTrue())
-
-			// Make sure the err was set
-			Expect(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Reason).Should(Equal("Error"))
-			Expect(strings.ToLower(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message)).Should(ContainSubstring("invalid url"))
 
 			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
 

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -52,14 +52,15 @@ var _ = Describe("Component controller", func() {
 
 	// Define utility constants for object names and testing timeouts/durations and intervals.
 	const (
-		HASAppName      = "test-application"
-		HASCompName     = "test-component"
-		HASAppNamespace = "default"
-		DisplayName     = "petclinic"
-		Description     = "Simple petclinic app"
-		ComponentName   = "backend"
-		SampleRepoLink  = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
-		gitToken        = "" //empty for public repo test
+		HASAppName           = "test-application"
+		HASCompName          = "test-component"
+		HASAppNamespace      = "default"
+		DisplayName          = "petclinic"
+		Description          = "Simple petclinic app"
+		ComponentName        = "backend"
+		SampleRepoLink       = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
+		SampleGitlabRepoLink = "https://gitlab.com/devfile-samples/devfile-sample-java-springboot-basic"
+		gitToken             = "" //empty for public repo test
 	)
 
 	prometheus.MustRegister(metrics.GetComponentCreationTotalReqs(), metrics.GetComponentCreationFailed(), metrics.GetComponentCreationSucceeded())
@@ -2943,6 +2944,68 @@ var _ = Describe("Component controller", func() {
 			Expect(createdHasComp.Status.Devfile).Should(Equal(""))
 			Expect(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Reason).Should(Equal("Error"))
 			Expect(strings.ToLower(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message)).Should(ContainSubstring("error unmarshaling"))
+
+			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
+
+			Expect(testutil.ToFloat64(metrics.GetComponentCreationTotalReqs()) > beforeCreateTotalReqs).To(BeTrue())
+			Expect(testutil.ToFloat64(metrics.GetComponentCreationSucceeded()) > beforeCreateSucceedReqs).To(BeTrue())
+			Expect(testutil.ToFloat64(metrics.GetComponentCreationFailed()) == beforeCreateFailedReqs).To(BeTrue())
+
+			// Delete the specified HASComp resource
+			deleteHASCompCR(hasCompLookupKey)
+
+			// Delete the specified HASApp resource
+			deleteHASAppCR(hasAppLookupKey)
+		})
+	})
+	Context("Create component having git source from gitlab", func() {
+		It("Should return a user error for invalid url", func() {
+			beforeCreateTotalReqs := testutil.ToFloat64(metrics.GetComponentCreationTotalReqs())
+			beforeCreateSucceedReqs := testutil.ToFloat64(metrics.GetComponentCreationSucceeded())
+			beforeCreateFailedReqs := testutil.ToFloat64(metrics.GetComponentCreationFailed())
+
+			ctx := context.Background()
+
+			applicationName := HASAppName + "28"
+			componentName := HASCompName + "28"
+
+			createAndFetchSimpleApp(applicationName, HASAppNamespace, DisplayName, Description)
+
+			hasComp := &appstudiov1alpha1.Component{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "Component",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      componentName,
+					Namespace: HASAppNamespace,
+				},
+				Spec: appstudiov1alpha1.ComponentSpec{
+					ComponentName: ComponentName,
+					Application:   applicationName,
+					Source: appstudiov1alpha1.ComponentSource{
+						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
+							GitSource: &appstudiov1alpha1.GitSource{
+								URL: SampleGitlabRepoLink,
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, hasComp)).Should(Succeed())
+
+			// Look up the has app resource that was created.
+			// num(conditions) may still be < 1 on the first try, so retry until at least _some_ condition is set
+			hasCompLookupKey := types.NamespacedName{Name: componentName, Namespace: HASAppNamespace}
+			createdHasComp := &appstudiov1alpha1.Component{}
+			Eventually(func() bool {
+				k8sClient.Get(ctx, hasCompLookupKey, createdHasComp)
+				return len(createdHasComp.Status.Conditions) > 0
+			}, timeout, interval).Should(BeTrue())
+
+			// Make sure the err was set
+			Expect(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Reason).Should(Equal("Error"))
+			Expect(strings.ToLower(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message)).Should(ContainSubstring("invalid URL"))
 
 			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
 

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -1105,6 +1105,10 @@ var _ = Describe("Component controller", func() {
 				return len(createdHasComp.Status.Conditions) > 0
 			}, timeout, interval).Should(BeTrue())
 
+			// Make sure the err was set
+			Expect(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Reason).Should(Equal("Error"))
+			Expect(strings.ToLower(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message)).Should(ContainSubstring("is not from github"))
+
 			// Confirm user error hasn't increase the failure metrics
 			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
 
@@ -2999,6 +3003,9 @@ var _ = Describe("Component controller", func() {
 				return len(createdHasComp.Status.Conditions) > 0
 			}, timeout, interval).Should(BeTrue())
 
+			// Make sure the err was set
+			Expect(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Reason).Should(Equal("Error"))
+			Expect(strings.ToLower(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message)).Should(ContainSubstring("is not from github"))
 			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
 
 			Expect(testutil.ToFloat64(metrics.GetComponentCreationTotalReqs()) > beforeCreateTotalReqs).To(BeTrue())

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -3005,7 +3005,7 @@ var _ = Describe("Component controller", func() {
 
 			// Make sure the err was set
 			Expect(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Reason).Should(Equal("Error"))
-			Expect(strings.ToLower(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message)).Should(ContainSubstring("invalid URL"))
+			Expect(strings.ToLower(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message)).Should(ContainSubstring("invalid url"))
 
 			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
 

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -1107,7 +1107,7 @@ var _ = Describe("Component controller", func() {
 
 			// Make sure the err was set
 			Expect(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Reason).Should(Equal("Error"))
-			Expect(strings.ToLower(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message)).Should(ContainSubstring("is not from github"))
+			Expect(strings.ToLower(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message)).Should(ContainSubstring("component create failed:"))
 
 			// Confirm user error hasn't increase the failure metrics
 			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}

--- a/controllers/component_controller_unit_test.go
+++ b/controllers/component_controller_unit_test.go
@@ -677,3 +677,36 @@ func TestCheckForCreateReconcile(t *testing.T) {
 	}
 
 }
+
+func TestValidateGithubURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		sourceGitURL string
+		wantErr      bool
+	}{
+		{
+			name:         "Valid github url",
+			sourceGitURL: "https://github.com/devfile-samples",
+			wantErr:      false,
+		},
+		{
+			name:         "Invalid url",
+			sourceGitURL: "afgae devfile",
+			wantErr:      true,
+		},
+		{
+			name:         "Not github url",
+			sourceGitURL: "https://gitlab.com/devfile-samples",
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateGithubURL(tt.sourceGitURL)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TestValidateGithubURL() unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/controllers/component_controller_unit_test.go
+++ b/controllers/component_controller_unit_test.go
@@ -677,36 +677,3 @@ func TestCheckForCreateReconcile(t *testing.T) {
 	}
 
 }
-
-func TestValidateGithubURL(t *testing.T) {
-	tests := []struct {
-		name         string
-		sourceGitURL string
-		wantErr      bool
-	}{
-		{
-			name:         "Valid github url",
-			sourceGitURL: "https://github.com/devfile-samples",
-			wantErr:      false,
-		},
-		{
-			name:         "Invalid url",
-			sourceGitURL: "afgae devfile",
-			wantErr:      true,
-		},
-		{
-			name:         "Not github url",
-			sourceGitURL: "https://gitlab.com/devfile-samples",
-			wantErr:      true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateGithubURL(tt.sourceGitURL)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("TestValidateGithubURL() unexpected error: %v", err)
-			}
-		})
-	}
-}

--- a/controllers/componentdetectionquery_controller.go
+++ b/controllers/componentdetectionquery_controller.go
@@ -29,7 +29,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/prometheus/client_golang/prometheus"
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
-	"github.com/redhat-appstudio/application-service/cdq-analysis/pkg"
 	cdqanalysis "github.com/redhat-appstudio/application-service/cdq-analysis/pkg"
 	"github.com/redhat-appstudio/application-service/pkg/github"
 	logutil "github.com/redhat-appstudio/application-service/pkg/log"
@@ -172,7 +171,7 @@ func (r *ComponentDetectionQueryReconciler) Reconcile(ctx context.Context, req c
 		}
 
 		// check if the given url is from github
-		if err := pkg.ValidateGithubURL(sourceURL); err != nil {
+		if err := cdqanalysis.ValidateGithubURL(sourceURL); err != nil {
 			// User error - the git url provided is not from github
 			log.Error(err, "unable to validate github url")
 			r.SetCompleteConditionAndUpdateCR(ctx, req, &componentDetectionQuery, copiedCDQ, err)

--- a/controllers/componentdetectionquery_controller_test.go
+++ b/controllers/componentdetectionquery_controller_test.go
@@ -3337,6 +3337,50 @@ metadata:
 		})
 
 	})
+	Context("Create Component Detection Query with non Github URL", func() {
+		It("Should err out", func() {
+			ctx := context.Background()
+
+			queryName := HASCompDetQuery + "21"
+
+			hasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "ComponentDetectionQuery",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      queryName,
+					Namespace: HASNamespace,
+					Annotations: map[string]string{
+						"runCDQAnalysisLocal": "true",
+					},
+				},
+				Spec: appstudiov1alpha1.ComponentDetectionQuerySpec{
+					GitSource: appstudiov1alpha1.GitSource{
+						URL:      "https://gitlab.com/redhat-appstudio-appdata/sample",
+						Revision: "main",
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, hasCompDetectionQuery)).Should(Succeed())
+
+			// Look up the has app resource that was created.
+			// num(conditions) may still be < 1 on the first try, so retry until at least _some_ condition is set
+			hasCompDetQueryLookupKey := types.NamespacedName{Name: queryName, Namespace: HASNamespace}
+			createdHasCompDetectionQuery := &appstudiov1alpha1.ComponentDetectionQuery{}
+			Eventually(func() bool {
+				k8sClient.Get(context.Background(), hasCompDetQueryLookupKey, createdHasCompDetectionQuery)
+				return len(createdHasCompDetectionQuery.Status.Conditions) > 1
+			}, timeout, interval).Should(BeTrue())
+
+			// Make sure the right err is set
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Message).Should(ContainSubstring("parse \"https://github.com/redhat-appstudio-appdata/!@#$%U%I$F    DFDN##\": invalid URL escape \"%U%\""))
+
+			// Delete the specified Detection Query resource
+			deleteCompDetQueryCR(hasCompDetQueryLookupKey)
+		})
+	})
 
 })
 

--- a/controllers/componentdetectionquery_controller_test.go
+++ b/controllers/componentdetectionquery_controller_test.go
@@ -3375,7 +3375,7 @@ metadata:
 			}, timeout, interval).Should(BeTrue())
 
 			// Make sure the right err is set
-			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Message).Should(ContainSubstring("parse \"https://github.com/redhat-appstudio-appdata/!@#$%U%I$F    DFDN##\": invalid URL escape \"%U%\""))
+			Expect(createdHasCompDetectionQuery.Status.Conditions[1].Message).Should(ContainSubstring("is not from github"))
 
 			// Delete the specified Detection Query resource
 			deleteCompDetQueryCR(hasCompDetQueryLookupKey)


### PR DESCRIPTION
### What does this PR do?:

The PR updates the `component_controller` to return a user error in case the `given` URL is not from a supported development platform (right now only github).

The necessary test cases have been added.

### Which issue(s)/story(ies) does this PR fixes:

https://issues.redhat.com/browse/DEVHAS-628

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
