### PR TITLE
Fix metrics for component creation and gitlab url

### DIFF
--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -295,6 +295,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if component.Status.Devfile == "" {
 
 		source := component.Spec.Source
+		gitSourceFromGitlab := false
 
 		var compDevfileData data.DevfileData
 		var devfileLocation string
@@ -304,9 +305,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			if err := util.ValidateGithubURL(source.GitSource.URL); err != nil {
 				// User error - the git url provided is not from github
 				log.Error(err, "unable to validate github url")
-				metrics.IncrementComponentCreationSucceeded("", "")
-				_ = r.SetCreateConditionAndUpdateCR(ctx, req, &component, err)
-				return ctrl.Result{}, nil
+				gitSourceFromGitlab = true
 			}
 			context := source.GitSource.Context
 			// If a Git secret was passed in, retrieve it for use in our Git operations
@@ -330,7 +329,8 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 					_, err := ghClient.GetBranchFromURL(sourceURL, ctx, "main")
 					if err != nil {
 						metrics.HandleRateLimitMetrics(err, metricsLabel)
-						if _, ok := err.(*github.GitHubUserErr); ok {
+						_, ok := err.(*github.GitHubUserErr)
+						if ok || gitSourceFromGitlab {
 							// User error, so increment the "success" metric since we're tracking only system errors
 							metrics.IncrementComponentCreationSucceeded(prevErrCondition, err.Error())
 						} else {
@@ -380,7 +380,9 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 					devfileBytes, devfileLocation, err = spi.DownloadDevfileUsingSPI(r.SPIClient, ctx, component, gitURL, source.GitSource.Revision, context)
 					if err != nil {
 						// Increment the import git repo and component create failed metric on non-user errors
-						if _, ok := err.(*cdqanalysis.NoDevfileFound); !ok {
+						// Exclude errors from gitlab urls
+						_, ok := err.(*cdqanalysis.NoDevfileFound)
+						if !ok && !gitSourceFromGitlab {
 							metrics.ImportGitRepoFailed.Inc()
 							metrics.IncrementComponentCreationFailed(prevErrCondition, err.Error())
 						} else {

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -301,6 +301,13 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		var devfileBytes []byte
 
 		if source.GitSource != nil && source.GitSource.URL != "" {
+			if err := util.ValidateGithubURL(source.GitSource.URL); err != nil {
+				// User error - the git url provided is not from github
+				log.Error(err, "unable to validate github url")
+				metrics.IncrementComponentCreationSucceeded("", "")
+				_ = r.SetCreateConditionAndUpdateCR(ctx, req, &component, err)
+				return ctrl.Result{}, nil
+			}
 			context := source.GitSource.Context
 			// If a Git secret was passed in, retrieve it for use in our Git operations
 			// The secret needs to be in the same namespace as the Component

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -1108,7 +1108,7 @@ var _ = Describe("Component controller", func() {
 			// Make sure the devfile model was properly set in Component
 			errCondition := createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1]
 			Expect(errCondition.Status).Should(Equal(metav1.ConditionFalse))
-			Expect(strings.ToLower(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message)).Should(ContainSubstring("Component create failed: unable to get default branch of Github Repo"))
+			Expect(errCondition.Message).Should(ContainSubstring("Component create failed: unable to get default branch of Github Repo"))
 
 			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
 

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -1108,7 +1108,7 @@ var _ = Describe("Component controller", func() {
 			// Make sure the devfile model was properly set in Component
 			errCondition := createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1]
 			Expect(errCondition.Status).Should(Equal(metav1.ConditionFalse))
-			Expect(errCondition.Message).Should(ContainSubstring("Component create failed: unable to get default branch of Github Repo"))
+			Expect(errCondition.Message).Should(ContainSubstring("Component create failed: parse"))
 
 			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
 

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -3037,66 +3037,66 @@ var _ = Describe("Component controller", func() {
 			Expect(testutil.ToFloat64(metrics.GetComponentDeletionSucceeded()) == beforeDeleteSucceedReqs).To(BeTrue())
 			Expect(testutil.ToFloat64(metrics.GetComponentDeletionTotalReqs()) == beforeDeleteTotalReqs).To(BeTrue())
 		})
-		Context("Create component having git source from gitlab", func() {
-			It("Should not increase the component failure metrics", func() {
-				beforeCreateTotalReqs := testutil.ToFloat64(metrics.GetComponentCreationTotalReqs())
-				beforeCreateSucceedReqs := testutil.ToFloat64(metrics.GetComponentCreationSucceeded())
-				beforeCreateFailedReqs := testutil.ToFloat64(metrics.GetComponentCreationFailed())
+	})
+	Context("Create component having git source from gitlab", func() {
+		It("Should not increase the component failure metrics", func() {
+			beforeCreateTotalReqs := testutil.ToFloat64(metrics.GetComponentCreationTotalReqs())
+			beforeCreateSucceedReqs := testutil.ToFloat64(metrics.GetComponentCreationSucceeded())
+			beforeCreateFailedReqs := testutil.ToFloat64(metrics.GetComponentCreationFailed())
 
-				ctx := context.Background()
+			ctx := context.Background()
 
-				applicationName := HASAppName + "30"
-				componentName := HASCompName + "30"
+			applicationName := HASAppName + "30"
+			componentName := HASCompName + "30"
 
-				createAndFetchSimpleApp(applicationName, HASAppNamespace, DisplayName, Description)
+			createAndFetchSimpleApp(applicationName, HASAppNamespace, DisplayName, Description)
 
-				hasComp := &appstudiov1alpha1.Component{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "appstudio.redhat.com/v1alpha1",
-						Kind:       "Component",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      componentName,
-						Namespace: HASAppNamespace,
-					},
-					Spec: appstudiov1alpha1.ComponentSpec{
-						ComponentName: ComponentName,
-						Application:   applicationName,
-						Source: appstudiov1alpha1.ComponentSource{
-							ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
-								GitSource: &appstudiov1alpha1.GitSource{
-									URL: SampleGitlabRepoLink,
-								},
+			hasComp := &appstudiov1alpha1.Component{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "Component",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      componentName,
+					Namespace: HASAppNamespace,
+				},
+				Spec: appstudiov1alpha1.ComponentSpec{
+					ComponentName: ComponentName,
+					Application:   applicationName,
+					Source: appstudiov1alpha1.ComponentSource{
+						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
+							GitSource: &appstudiov1alpha1.GitSource{
+								URL: SampleGitlabRepoLink,
 							},
 						},
 					},
-				}
-				Expect(k8sClient.Create(ctx, hasComp)).Should(Succeed())
+				},
+			}
+			Expect(k8sClient.Create(ctx, hasComp)).Should(Succeed())
 
-				// Look up the has app resource that was created.
-				// num(conditions) may still be < 1 on the first try, so retry until at least _some_ condition is set
-				hasCompLookupKey := types.NamespacedName{Name: componentName, Namespace: HASAppNamespace}
-				createdHasComp := &appstudiov1alpha1.Component{}
-				Eventually(func() bool {
-					k8sClient.Get(ctx, hasCompLookupKey, createdHasComp)
-					return len(createdHasComp.Status.Conditions) > 0
-				}, timeout, interval).Should(BeTrue())
+			// Look up the has app resource that was created.
+			// num(conditions) may still be < 1 on the first try, so retry until at least _some_ condition is set
+			hasCompLookupKey := types.NamespacedName{Name: componentName, Namespace: HASAppNamespace}
+			createdHasComp := &appstudiov1alpha1.Component{}
+			Eventually(func() bool {
+				k8sClient.Get(ctx, hasCompLookupKey, createdHasComp)
+				return len(createdHasComp.Status.Conditions) > 0
+			}, timeout, interval).Should(BeTrue())
 
-				// Make sure the err was set
-				Expect(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Reason).Should(Equal("Error"))
-				Expect(strings.ToLower(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message)).Should(ContainSubstring("Component create failed: unable to get default branch of Github Repo"))
-				hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
+			// Make sure the err was set
+			Expect(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Reason).Should(Equal("Error"))
+			Expect(strings.ToLower(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message)).Should(ContainSubstring("Component create failed: unable to"))
+			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
 
-				Expect(testutil.ToFloat64(metrics.GetComponentCreationTotalReqs()) > beforeCreateTotalReqs).To(BeTrue())
-				Expect(testutil.ToFloat64(metrics.GetComponentCreationSucceeded()) > beforeCreateSucceedReqs).To(BeTrue())
-				Expect(testutil.ToFloat64(metrics.GetComponentCreationFailed()) == beforeCreateFailedReqs).To(BeTrue())
+			Expect(testutil.ToFloat64(metrics.GetComponentCreationTotalReqs()) > beforeCreateTotalReqs).To(BeTrue())
+			Expect(testutil.ToFloat64(metrics.GetComponentCreationSucceeded()) > beforeCreateSucceedReqs).To(BeTrue())
+			Expect(testutil.ToFloat64(metrics.GetComponentCreationFailed()) == beforeCreateFailedReqs).To(BeTrue())
 
-				// Delete the specified HASComp resource
-				deleteHASCompCR(hasCompLookupKey)
+			// Delete the specified HASComp resource
+			deleteHASCompCR(hasCompLookupKey)
 
-				// Delete the specified HASApp resource
-				deleteHASAppCR(hasAppLookupKey)
-			})
+			// Delete the specified HASApp resource
+			deleteHASAppCR(hasAppLookupKey)
 		})
 	})
 })

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -52,14 +52,15 @@ var _ = Describe("Component controller", func() {
 
 	// Define utility constants for object names and testing timeouts/durations and intervals.
 	const (
-		HASAppName      = "test-application"
-		HASCompName     = "test-component"
-		HASAppNamespace = "default"
-		DisplayName     = "petclinic"
-		Description     = "Simple petclinic app"
-		ComponentName   = "backend"
-		SampleRepoLink  = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
-		gitToken        = "" //empty for public repo test
+		HASAppName           = "test-application"
+		HASCompName          = "test-component"
+		HASAppNamespace      = "default"
+		DisplayName          = "petclinic"
+		Description          = "Simple petclinic app"
+		ComponentName        = "backend"
+		SampleRepoLink       = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
+		SampleGitlabRepoLink = "https://gitlab.com/devfile-samples/devfile-sample-java-springboot-basic"
+		gitToken             = "" //empty for public repo test
 	)
 
 	prometheus.MustRegister(metrics.GetComponentCreationTotalReqs(), metrics.GetComponentCreationFailed(), metrics.GetComponentCreationSucceeded())
@@ -3035,6 +3036,67 @@ var _ = Describe("Component controller", func() {
 			Expect(testutil.ToFloat64(metrics.GetComponentDeletionFailed()) == beforeDeleteFailedReqs).To(BeTrue())
 			Expect(testutil.ToFloat64(metrics.GetComponentDeletionSucceeded()) == beforeDeleteSucceedReqs).To(BeTrue())
 			Expect(testutil.ToFloat64(metrics.GetComponentDeletionTotalReqs()) == beforeDeleteTotalReqs).To(BeTrue())
+		})
+		Context("Create component having git source from gitlab", func() {
+			It("Should not increase the component failure metrics", func() {
+				beforeCreateTotalReqs := testutil.ToFloat64(metrics.GetComponentCreationTotalReqs())
+				beforeCreateSucceedReqs := testutil.ToFloat64(metrics.GetComponentCreationSucceeded())
+				beforeCreateFailedReqs := testutil.ToFloat64(metrics.GetComponentCreationFailed())
+
+				ctx := context.Background()
+
+				applicationName := HASAppName + "30"
+				componentName := HASCompName + "30"
+
+				createAndFetchSimpleApp(applicationName, HASAppNamespace, DisplayName, Description)
+
+				hasComp := &appstudiov1alpha1.Component{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "appstudio.redhat.com/v1alpha1",
+						Kind:       "Component",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      componentName,
+						Namespace: HASAppNamespace,
+					},
+					Spec: appstudiov1alpha1.ComponentSpec{
+						ComponentName: ComponentName,
+						Application:   applicationName,
+						Source: appstudiov1alpha1.ComponentSource{
+							ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
+								GitSource: &appstudiov1alpha1.GitSource{
+									URL: SampleGitlabRepoLink,
+								},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, hasComp)).Should(Succeed())
+
+				// Look up the has app resource that was created.
+				// num(conditions) may still be < 1 on the first try, so retry until at least _some_ condition is set
+				hasCompLookupKey := types.NamespacedName{Name: componentName, Namespace: HASAppNamespace}
+				createdHasComp := &appstudiov1alpha1.Component{}
+				Eventually(func() bool {
+					k8sClient.Get(ctx, hasCompLookupKey, createdHasComp)
+					return len(createdHasComp.Status.Conditions) > 0
+				}, timeout, interval).Should(BeTrue())
+
+				// Make sure the err was set
+				Expect(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Reason).Should(Equal("Error"))
+				Expect(strings.ToLower(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message)).Should(ContainSubstring("is not from github"))
+				hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
+
+				Expect(testutil.ToFloat64(metrics.GetComponentCreationTotalReqs()) > beforeCreateTotalReqs).To(BeTrue())
+				Expect(testutil.ToFloat64(metrics.GetComponentCreationSucceeded()) > beforeCreateSucceedReqs).To(BeTrue())
+				Expect(testutil.ToFloat64(metrics.GetComponentCreationFailed()) == beforeCreateFailedReqs).To(BeTrue())
+
+				// Delete the specified HASComp resource
+				deleteHASCompCR(hasCompLookupKey)
+
+				// Delete the specified HASApp resource
+				deleteHASAppCR(hasAppLookupKey)
+			})
 		})
 	})
 })

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -1108,7 +1108,7 @@ var _ = Describe("Component controller", func() {
 			// Make sure the devfile model was properly set in Component
 			errCondition := createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1]
 			Expect(errCondition.Status).Should(Equal(metav1.ConditionFalse))
-			Expect(errCondition.Message).Should(ContainSubstring("Component create failed: parse"))
+			Expect(strings.ToLower(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message)).Should(ContainSubstring("Component create failed: unable to get default branch of Github Repo"))
 
 			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
 
@@ -3084,7 +3084,7 @@ var _ = Describe("Component controller", func() {
 
 				// Make sure the err was set
 				Expect(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Reason).Should(Equal("Error"))
-				Expect(strings.ToLower(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message)).Should(ContainSubstring("is not from github"))
+				Expect(strings.ToLower(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message)).Should(ContainSubstring("Component create failed: unable to get default branch of Github Repo"))
 				hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
 
 				Expect(testutil.ToFloat64(metrics.GetComponentCreationTotalReqs()) > beforeCreateTotalReqs).To(BeTrue())

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -3085,7 +3085,7 @@ var _ = Describe("Component controller", func() {
 
 			// Make sure the err was set
 			Expect(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Reason).Should(Equal("Error"))
-			Expect(strings.ToLower(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message)).Should(ContainSubstring("Component create failed: unable to"))
+			Expect(strings.ToLower(createdHasComp.Status.Conditions[len(createdHasComp.Status.Conditions)-1].Message)).Should(ContainSubstring("component create failed: unable to"))
 			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
 
 			Expect(testutil.ToFloat64(metrics.GetComponentCreationTotalReqs()) > beforeCreateTotalReqs).To(BeTrue())

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -223,3 +223,17 @@ func RemoveStrFromList(str string, strList []string) []string {
 	}
 	return strList
 }
+
+// ValidateGithubURL checks if the given url includes github in hostname
+// In case of invalid url (not able to parse / not github) returns an error.
+func ValidateGithubURL(URL string) error {
+	parsedURL, err := url.Parse(URL)
+	if err != nil {
+		return err
+	}
+
+	if strings.Contains(parsedURL.Host, "github") {
+		return nil
+	}
+	return fmt.Errorf("source git url %v is not from github", URL)
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -724,3 +724,36 @@ func TestGenerateRandomRouteName(t *testing.T) {
 
 	}
 }
+
+func TestValidateGithubURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		sourceGitURL string
+		wantErr      bool
+	}{
+		{
+			name:         "Valid github url",
+			sourceGitURL: "https://github.com/devfile-samples",
+			wantErr:      false,
+		},
+		{
+			name:         "Invalid url",
+			sourceGitURL: "afgae devfile",
+			wantErr:      true,
+		},
+		{
+			name:         "Not github url",
+			sourceGitURL: "https://gitlab.com/devfile-samples",
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateGithubURL(tt.sourceGitURL)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TestValidateGithubURL() unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?:

This PR tries to fix the metrics for component creation for cases of gitlab URLs by returning a user error on the `component_controller.go`

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-628

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
