### PR TITLE
Avoid application deletion race conditions

### DIFF
--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -117,7 +117,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			var components appstudiov1alpha1.ComponentList
 			err = r.List(ctx, &components)
 			if err != nil {
-				log.Error(err, "failed to check if any application component is under deletion")
+				log.Error(err, "failed to check if any Component is under deletion, proceeding with Application delete")
 			}
 			if err := util.VerifyNoApplicationComponentUnderDeletion(components, application.Name); err != nil {
 				// requeue in case any of the application components are under deletion

--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -121,7 +121,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			}
 			if err := util.VerifyNoApplicationComponentUnderDeletion(components, application.Name); err != nil {
 				// requeue in case any of the application components are under deletion
-				log.Error(err, "Error an application component is under deletion. Deletion requeued")
+				log.Error(err, "Component is under deletion, Application deletion requeued")
 				return reconcile.Result{}, err
 			}
 			metrics.ApplicationDeletionTotalReqs.Inc()

--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -115,7 +115,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	} else {
 		if containsString(application.GetFinalizers(), appFinalizerName) {
 			var components appstudiov1alpha1.ComponentList
-			err = r.List(context.Background(), &components)
+			err = r.List(ctx, &components)
 			if err != nil {
 				log.Error(err, "failed to check if any application component is under deletion")
 			}

--- a/controllers/application_controller_test.go
+++ b/controllers/application_controller_test.go
@@ -388,9 +388,6 @@ var _ = Describe("Application controller", func() {
 				Spec: appstudiov1alpha1.ApplicationSpec{
 					DisplayName: DisplayName,
 					Description: Description,
-					AppModelRepository: appstudiov1alpha1.ApplicationGitRepository{
-						URL: "https://github.com/testorg/petclinic-app",
-					},
 				},
 			}
 

--- a/controllers/application_controller_test.go
+++ b/controllers/application_controller_test.go
@@ -406,17 +406,18 @@ var _ = Describe("Application controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			// Create application component
+			hasComponentName := "test-component"
 			hasComp := &appstudiov1alpha1.Component{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "appstudio.redhat.com/v1alpha1",
 					Kind:       "Component",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      componentName,
+					Name:      hasComponentName,
 					Namespace: HASAppNamespace,
 				},
 				Spec: appstudiov1alpha1.ComponentSpec{
-					ComponentName: "test-component",
+					ComponentName: hasComponentName,
 					Application:   applicationName,
 					Source: appstudiov1alpha1.ComponentSource{
 						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
@@ -431,7 +432,7 @@ var _ = Describe("Application controller", func() {
 
 			// Look up the has app resource that was created.
 			// num(conditions) may still be < 1 on the first try, so retry until at least _some_ condition is set
-			hasCompLookupKey := types.NamespacedName{Name: componentName, Namespace: HASAppNamespace}
+			hasCompLookupKey := types.NamespacedName{Name: hasComponentName, Namespace: HASAppNamespace}
 			fetchedHasComp := &appstudiov1alpha1.Component{}
 			Eventually(func() bool {
 				k8sClient.Get(context.Background(), hasCompLookupKey, fetchedHasComp)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -223,3 +223,13 @@ func RemoveStrFromList(str string, strList []string) []string {
 	}
 	return strList
 }
+
+// VerifyNoApplicationComponentUnderDeletion checks if any of the application components is under deletion
+func VerifyNoApplicationComponentUnderDeletion(components appstudiov1alpha1.ComponentList, applicationName string) error {
+	for _, component := range components.Items {
+		if component.Spec.Application == applicationName && !component.ObjectMeta.DeletionTimestamp.IsZero() {
+			return fmt.Errorf("application's %v component %v is under deletion", applicationName, component.Name)
+		}
+	}
+	return nil
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -740,7 +740,7 @@ func TestVerifyNoApplicationComponentUnderDeletion(t *testing.T) {
 				Items: []appstudiov1alpha1.Component{
 					{
 						Spec:       appstudiov1alpha1.ComponentSpec{Application: "application-one"},
-						ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &metav1.Time{testTime}},
+						ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &metav1.Time{Time: testTime}},
 					},
 				},
 			},


### PR DESCRIPTION
### What does this PR do?:
This PR tries to implement the same logic followed to the `component_controller` (introduced here: https://github.com/redhat-appstudio/application-service/pull/451) on the `application_controller` too. This way we avoid race conditions upon `application` & `component` deletion.

More detailed, we are ensuring that before the `application` deletion (after we have confirmed the presence of a finalizer), that the application has no components under deletion. If it does we are requeueing the deletion.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/DEVHAS-627

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
