### PR TITLE
Handle finalizer removal

### DIFF
--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -32,11 +32,13 @@ import (
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -48,6 +50,8 @@ import (
 	devfile "github.com/redhat-appstudio/application-service/pkg/devfile"
 	logutil "github.com/redhat-appstudio/application-service/pkg/log"
 )
+
+const appFinalizerName = "application.appstudio.redhat.com/finalizer"
 
 // ApplicationReconciler reconciles a Application object
 type ApplicationReconciler struct {
@@ -86,6 +90,26 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return reconcile.Result{}, err
 	}
 
+	if !application.ObjectMeta.DeletionTimestamp.IsZero() {
+		if containsString(application.GetFinalizers(), appFinalizerName) {
+			// remove the finalizer from the list and update it.
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				var currentApplication appstudiov1alpha1.Application
+				err := r.Get(ctx, req.NamespacedName, &currentApplication)
+				if err != nil {
+					return err
+				}
+
+				controllerutil.RemoveFinalizer(&currentApplication, appFinalizerName)
+
+				err = r.Update(ctx, &currentApplication)
+				return err
+			})
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	}
 	log.Info(fmt.Sprintf("Starting reconcile loop for %v", req.NamespacedName))
 	// If devfile hasn't been generated yet, generate it
 	// If the devfile hasn't been generated, the CR was just created.
@@ -231,4 +255,14 @@ func (r *ApplicationReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 			},
 		})).
 		Complete(r)
+}
+
+// Helper functions to check and remove string from a slice of strings.
+func containsString(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
 }

--- a/controllers/application_controller_test.go
+++ b/controllers/application_controller_test.go
@@ -145,6 +145,39 @@ var _ = Describe("Application controller", func() {
 		})
 	})
 
+	Context("Application CR with finalizer", func() {
+		It("Should delete successfully", func() {
+			ctx := context.Background()
+
+			applicationName := HASAppName + "5"
+
+			hasApp := &appstudiov1alpha1.Application{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "Application",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       applicationName,
+					Namespace:  HASAppNamespace,
+					Finalizers: []string{appFinalizerName},
+				},
+				Spec: appstudiov1alpha1.ApplicationSpec{
+					DisplayName: DisplayName,
+					Description: Description,
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, hasApp)).Should(Succeed())
+
+			// Look up the has app resource that was created.
+			// num(conditions) may still be < 1 on the first try, so retry until at least _some_ condition is set
+			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
+
+			// Delete the specified resource
+			deleteHASAppCR(hasAppLookupKey)
+		})
+	})
+
 })
 
 // deleteHASAppCR deletes the specified hasApp resource and verifies it was properly deleted

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -117,7 +117,7 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				return err
 			}
 
-			controllerutil.RemoveFinalizer(&currentComponent, appFinalizerName)
+			controllerutil.RemoveFinalizer(&currentComponent, compFinalizerName)
 
 			err = r.Update(ctx, &currentComponent)
 			return err

--- a/controllers/component_controller.go
+++ b/controllers/component_controller.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -57,6 +58,8 @@ import (
 	"github.com/redhat-appstudio/application-service/pkg/util"
 	"github.com/spf13/afero"
 )
+
+const compFinalizerName = "component.appstudio.redhat.com/finalizer"
 
 // ComponentReconciler reconciles a Component object
 type ComponentReconciler struct {
@@ -102,6 +105,29 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 		// Error reading the object - requeue the request.
 		return ctrl.Result{}, err
+	}
+
+	// If a resource is under deletion and still has the finalizer attached from it,
+	// just remove it before deletion to prevent it from being blocked
+	if !component.ObjectMeta.DeletionTimestamp.IsZero() {
+		if containsString(component.GetFinalizers(), appFinalizerName) {
+			// remove the finalizer from the list and update it.
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				var currentComponent appstudiov1alpha1.Component
+				err := r.Get(ctx, req.NamespacedName, &currentComponent)
+				if err != nil {
+					return err
+				}
+
+				controllerutil.RemoveFinalizer(&currentComponent, appFinalizerName)
+
+				err = r.Update(ctx, &currentComponent)
+				return err
+			})
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+		}
 	}
 
 	_, prevErrCondition := checkForCreateReconcile(component)

--- a/controllers/component_controller_test.go
+++ b/controllers/component_controller_test.go
@@ -1997,6 +1997,50 @@ var _ = Describe("Component controller", func() {
 			deleteHASAppCR(hasAppLookupKey)
 		})
 	})
+
+	Context("Component CR with finalizer", func() {
+		It("Should delete successfully", func() {
+			ctx := context.Background()
+
+			applicationName := HASAppName + "31"
+			componentName := HASCompName + "31"
+
+			createAndFetchSimpleApp(applicationName, HASAppNamespace, DisplayName, Description)
+
+			hasComp := &appstudiov1alpha1.Component{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "Component",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       componentName,
+					Namespace:  HASAppNamespace,
+					Finalizers: []string{compFinalizerName},
+				},
+				Spec: appstudiov1alpha1.ComponentSpec{
+					ComponentName: ComponentName,
+					Application:   applicationName,
+					Source: appstudiov1alpha1.ComponentSource{
+						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
+							GitSource: &appstudiov1alpha1.GitSource{
+								URL: SampleGitlabRepoLink,
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, hasComp)).Should(Succeed())
+
+			hasCompLookupKey := types.NamespacedName{Name: componentName, Namespace: HASAppNamespace}
+			hasAppLookupKey := types.NamespacedName{Name: applicationName, Namespace: HASAppNamespace}
+
+			// Delete the specified HASComp resource
+			deleteHASCompCR(hasCompLookupKey)
+
+			// Delete the specified HASApp resource
+			deleteHASAppCR(hasAppLookupKey)
+		})
+	})
 })
 
 type updateChecklist struct {


### PR DESCRIPTION
### What does this PR do?:
Updates the Application and Component controllers to add back the finalizer removal code. Upon each reconcile of a resource, the controllers will check if the resource still has the finalizer present, and if so, removes it before completing reconciliation. This will also ensure that no resources have finalizers left when HAS is deprecated.

### Which issue(s)/story(ies) does this PR fixes:
N/A, but relates to https://issues.redhat.com/browse/DEVHAS-648

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
