### PR TITLE
[KFLUXBUGS-1290] Handle ownerrefs in webhook

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -101,7 +101,7 @@ jobs:
         uses: codecov/codecov-action@v2.1.0
       - name: Run Gosec Security Scanner
         run: |
-          go install github.com/securego/gosec/v2/cmd/gosec@latest
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.19.0
           make gosec
           if [[ $? != 0 ]]
           then

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ vet: ## Run go vet against code.
 .PHONY: gosec
 gosec:
 	# Run this command to install gosec, if not installed:
-	# go install github.com/securego/gosec/v2/cmd/gosec@latest
+	# go install github.com/securego/gosec/v2/cmd/gosec@v2.19.0
 	gosec -no-fail -fmt=sarif -out=gosec.sarif  ./...
 	
 lint:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -44,25 +44,6 @@ webhooks:
     - UPDATE
     resources:
     - components
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /mutate-appstudio-redhat-com-v1alpha1-component
-  failurePolicy: Fail
-  name: mcomponent.kb.io
-  rules:
-  - apiGroups:
-    - appstudio.redhat.com
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
     - components/status
   sideEffects: None
 ---

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -45,6 +45,26 @@ webhooks:
     resources:
     - components
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-appstudio-redhat-com-v1alpha1-component
+  failurePolicy: Fail
+  name: mcomponent.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - components/status
+  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/controllers/webhooks/component_webhook.go
+++ b/controllers/webhooks/component_webhook.go
@@ -55,8 +55,7 @@ func (w *ComponentWebhook) Register(mgr ctrl.Manager, log *logr.Logger) error {
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-appstudio-redhat-com-v1alpha1-component,mutating=true,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=components,verbs=create;update,versions=v1alpha1,name=mcomponent.kb.io,admissionReviewVersions=v1
-// +kubebuilder:webhook:path=/mutate-appstudio-redhat-com-v1alpha1-component,mutating=true,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=components/status,verbs=create;update,versions=v1alpha1,name=mcomponent.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-appstudio-redhat-com-v1alpha1-component,mutating=true,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=components;components/status,verbs=create;update,versions=v1alpha1,name=mcomponent.kb.io,admissionReviewVersions=v1
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *ComponentWebhook) Default(ctx context.Context, obj runtime.Object) error {
@@ -72,14 +71,16 @@ func (r *ComponentWebhook) Default(ctx context.Context, obj runtime.Object) erro
 			// Don't block if the Application doesn't exist yet - this will retrigger whenever the resource is modified
 			err = fmt.Errorf("unable to get the Application %s for Component %s, ignoring for now", component.Spec.Application, compName)
 			componentlog.Error(err, "skip setting owner reference on component")
+		} else {
+			ownerReference := metav1.OwnerReference{
+				APIVersion: hasApplication.APIVersion,
+				Kind:       hasApplication.Kind,
+				Name:       hasApplication.Name,
+				UID:        hasApplication.UID,
+			}
+			component.SetOwnerReferences(append(component.GetOwnerReferences(), ownerReference))
 		}
-		ownerReference := metav1.OwnerReference{
-			APIVersion: hasApplication.APIVersion,
-			Kind:       hasApplication.Kind,
-			Name:       hasApplication.Name,
-			UID:        hasApplication.UID,
-		}
-		component.SetOwnerReferences(append(component.GetOwnerReferences(), ownerReference))
+
 	}
 
 	return nil

--- a/controllers/webhooks/component_webhook.go
+++ b/controllers/webhooks/component_webhook.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/go-logr/logr"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -55,9 +56,32 @@ func (w *ComponentWebhook) Register(mgr ctrl.Manager, log *logr.Logger) error {
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
 // +kubebuilder:webhook:path=/mutate-appstudio-redhat-com-v1alpha1-component,mutating=true,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=components,verbs=create;update,versions=v1alpha1,name=mcomponent.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-appstudio-redhat-com-v1alpha1-component,mutating=true,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=components/status,verbs=create;update,versions=v1alpha1,name=mcomponent.kb.io,admissionReviewVersions=v1
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *ComponentWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	component := obj.(*appstudiov1alpha1.Component)
+	compName := component.Name
+	componentlog := r.log.WithValues("controllerKind", "Component").WithValues("name", compName).WithValues("namespace", component.Namespace)
+
+	if len(component.OwnerReferences) == 0 {
+		// Get the Application CR
+		hasApplication := appstudiov1alpha1.Application{}
+		err := r.client.Get(ctx, types.NamespacedName{Name: component.Spec.Application, Namespace: component.Namespace}, &hasApplication)
+		if err != nil {
+			// Don't block if the Application doesn't exist yet - this will retrigger whenever the resource is modified
+			err = fmt.Errorf("unable to get the Application %s for Component %s, ignoring for now", component.Spec.Application, compName)
+			componentlog.Error(err, "skip setting owner reference on component")
+		}
+		ownerReference := metav1.OwnerReference{
+			APIVersion: hasApplication.APIVersion,
+			Kind:       hasApplication.Kind,
+			Name:       hasApplication.Name,
+			UID:        hasApplication.UID,
+		}
+		component.SetOwnerReferences(append(component.GetOwnerReferences(), ownerReference))
+	}
+
 	return nil
 }
 

--- a/controllers/webhooks/component_webhook.go
+++ b/controllers/webhooks/component_webhook.go
@@ -64,7 +64,7 @@ func (r *ComponentWebhook) Default(ctx context.Context, obj runtime.Object) erro
 	compName := component.Name
 	componentlog := r.log.WithValues("controllerKind", "Component").WithValues("name", compName).WithValues("namespace", component.Namespace)
 
-	if len(component.OwnerReferences) == 0 {
+	if len(component.OwnerReferences) == 0 && component.DeletionTimestamp.IsZero() {
 		// Get the Application CR
 		hasApplication := appstudiov1alpha1.Application{}
 		err := r.client.Get(ctx, types.NamespacedName{Name: component.Spec.Application, Namespace: component.Namespace}, &hasApplication)

--- a/controllers/webhooks/component_webhook_unit_test.go
+++ b/controllers/webhooks/component_webhook_unit_test.go
@@ -35,6 +35,87 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
+func TestComponentDefaultingWebhook(t *testing.T) {
+
+	fakeClient := setUpComponents(t)
+
+	app := appstudiov1alpha1.Application{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "application1",
+			Namespace: "default",
+		},
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "appstudio.redhat.com/v1alpha1",
+			Kind:       "Component",
+		},
+		Spec: appstudiov1alpha1.ApplicationSpec{
+			DisplayName: "app",
+			Description: "Description",
+		},
+	}
+	err := fakeClient.Create(context.Background(), &app)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name   string
+		client client.Client
+		comp   appstudiov1alpha1.Component
+	}{
+		{
+			name:   "component has owner ref set",
+			client: fakeClient,
+			comp: appstudiov1alpha1.Component{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "1-test-component",
+					Namespace: "default",
+				},
+				Spec: appstudiov1alpha1.ComponentSpec{
+					ComponentName: "component1",
+					Application:   "application1",
+				},
+			},
+		},
+		{
+			name:   "application not found",
+			client: fakeClient,
+			comp: appstudiov1alpha1.Component{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "1-test-component",
+					Namespace: "default",
+				},
+				Spec: appstudiov1alpha1.ComponentSpec{
+					ComponentName: "component1",
+					Application:   "application-not-found",
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			compWebhook := ComponentWebhook{
+				client: test.client,
+				log: zap.New(zap.UseFlagOptions(&zap.Options{
+					Development: true,
+					TimeEncoder: zapcore.ISO8601TimeEncoder,
+				})),
+			}
+			err := compWebhook.Default(context.Background(), &test.comp)
+
+			// Defaulting webhook should not return an error
+			assert.Nil(t, err)
+
+			// Ensure that the component had its owner reference set correctly
+			if len(test.comp.OwnerReferences) != 1 && test.name != "application not found" {
+				t.Error("expected component to have owner reference set")
+			} else if test.name != "application not found" {
+				if test.comp.OwnerReferences[0].Name != "application1" {
+					t.Errorf("expected component to have owner reference set to application %s, got %s", "application1", test.comp.OwnerReferences[0].Name)
+				}
+			}
+		})
+	}
+}
+
 func TestComponentCreateValidatingWebhook(t *testing.T) {
 
 	fakeClient := setUpComponents(t)


### PR DESCRIPTION
### What does this PR do?:
Updates the Component webhooks to add in logic to set the owner references. The defaulting webhook will check to see if the Component has the owner reference set every time the resource is created/updated, and if not set, it will update the resource to have it set.

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/KFLUXBUGS-1290

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
