### PR TITLE
[KFLUXBUGS-1299] Use HAS kubeconfig to set ownerref

### DIFF
--- a/controllers/webhooks/component_webhook.go
+++ b/controllers/webhooks/component_webhook.go
@@ -75,6 +75,7 @@ func (r *ComponentWebhook) Default(ctx context.Context, obj runtime.Object) erro
 			// Update the Component's owner ref's - retry on conflict
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				var curComp appstudiov1alpha1.Component
+				// Get the Component to update using the operator's kubeconfig so that there aren't any permissions issues setting the owner reference
 				err := r.client.Get(context.Background(), types.NamespacedName{Name: compName, Namespace: component.Namespace}, &curComp)
 				if err != nil {
 					componentlog.Error(err, "unable to get current component, so skip setting owner reference")

--- a/controllers/webhooks/component_webhook.go
+++ b/controllers/webhooks/component_webhook.go
@@ -66,21 +66,36 @@ func (r *ComponentWebhook) Default(ctx context.Context, obj runtime.Object) erro
 	if len(component.OwnerReferences) == 0 && component.DeletionTimestamp.IsZero() {
 		// Get the Application CR
 		hasApplication := appstudiov1alpha1.Application{}
-		err := r.client.Get(ctx, types.NamespacedName{Name: component.Spec.Application, Namespace: component.Namespace}, &hasApplication)
+		err := r.client.Get(context.Background(), types.NamespacedName{Name: component.Spec.Application, Namespace: component.Namespace}, &hasApplication)
 		if err != nil {
 			// Don't block if the Application doesn't exist yet - this will retrigger whenever the resource is modified
 			err = fmt.Errorf("unable to get the Application %s for Component %s, ignoring for now", component.Spec.Application, compName)
 			componentlog.Error(err, "skip setting owner reference on component")
 		} else {
-			ownerReference := metav1.OwnerReference{
-				APIVersion: hasApplication.APIVersion,
-				Kind:       hasApplication.Kind,
-				Name:       hasApplication.Name,
-				UID:        hasApplication.UID,
-			}
-			component.SetOwnerReferences(append(component.GetOwnerReferences(), ownerReference))
-		}
+			// Update the Component's owner ref's - retry on conflict
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				var curComp appstudiov1alpha1.Component
+				err := r.client.Get(context.Background(), types.NamespacedName{Name: compName, Namespace: component.Namespace}, &curComp)
+				if err != nil {
+					componentlog.Error(err, "unable to get current component, so skip setting owner reference")
+					return nil
+				}
 
+				ownerReference := metav1.OwnerReference{
+					APIVersion: hasApplication.APIVersion,
+					Kind:       hasApplication.Kind,
+					Name:       hasApplication.Name,
+					UID:        hasApplication.UID,
+				}
+				curComp.SetOwnerReferences(append(curComp.GetOwnerReferences(), ownerReference))
+				err = r.client.Update(ctx, &curComp)
+				return err
+			})
+			if err != nil {
+				componentlog.Error(err, "error setting owner-references")
+			}
+
+		}
 	}
 
 	return nil

--- a/controllers/webhooks/component_webhook.go
+++ b/controllers/webhooks/component_webhook.go
@@ -65,6 +65,7 @@ func (r *ComponentWebhook) Default(ctx context.Context, obj runtime.Object) erro
 
 	if len(component.OwnerReferences) == 0 && component.DeletionTimestamp.IsZero() {
 		// Get the Application CR
+		// Use the background context to ensure the operator's kubeconfig is used
 		hasApplication := appstudiov1alpha1.Application{}
 		err := r.client.Get(context.Background(), types.NamespacedName{Name: component.Spec.Application, Namespace: component.Namespace}, &hasApplication)
 		if err != nil {
@@ -76,6 +77,7 @@ func (r *ComponentWebhook) Default(ctx context.Context, obj runtime.Object) erro
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				var curComp appstudiov1alpha1.Component
 				// Get the Component to update using the operator's kubeconfig so that there aren't any permissions issues setting the owner reference
+				// Use the background context to ensure the operator's kubeconfig is used
 				err := r.client.Get(context.Background(), types.NamespacedName{Name: compName, Namespace: component.Namespace}, &curComp)
 				if err != nil {
 					componentlog.Error(err, "unable to get current component, so skip setting owner reference")


### PR DESCRIPTION
### What does this PR do?:
Updates the Component webhook to use the HAS kubeconfig and kube client to update the owner ref, rather than the one provided by the defaulting webhook, which averts the issue seen in https://issues.redhat.com/browse/KFLUXBUGS-1299

### Which issue(s)/story(ies) does this PR fixes:
https://issues.redhat.com/browse/KFLUXBUGS-1299

### PR acceptance criteria:
<!--Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed
-->

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
