### PR TITLE
chore: move to supported kube-rbac-proxy image

### DIFF
--- a/bundle/manifests/application-service.clusterserviceversion.yaml
+++ b/bundle/manifests/application-service.clusterserviceversion.yaml
@@ -276,7 +276,7 @@ spec:
                 - --logtostderr=true
                 - --v=10
                 - --http2-disable=true
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.18
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.18
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
gcr.io is being decommissioned.

