### PR TITLE
fix(KONFLUX-8822): disable leader election

### DIFF
--- a/bundle/manifests/application-service.clusterserviceversion.yaml
+++ b/bundle/manifests/application-service.clusterserviceversion.yaml
@@ -286,7 +286,7 @@ spec:
               - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
-                - --leader-elect
+                - --leader-elect=false
                 command:
                 - /manager
                 env:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -35,4 +35,4 @@ spec:
         args:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
-        - "--leader-elect"
+        - "--leader-elect=false"


### PR DESCRIPTION
* The etcd defragmentation is causing the leader election to fail frequently, crashing the service

Signed-off-by: dirgim <kpavic@redhat.com>

### What does this PR do?:
Disable leader election in controller manager

### Which issue(s)/story(ies) does this PR fixes:
[KONFLUX-8822](https://issues.redhat.com//browse/KONFLUX-8822)

### PR acceptance criteria:

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
